### PR TITLE
ci: Validate PR title

### DIFF
--- a/.github/workflows/validate_pr_title.yaml
+++ b/.github/workflows/validate_pr_title.yaml
@@ -20,5 +20,7 @@ jobs:
           pipx install commitizen
 
       - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          cz check --message "${{ github.event.pull_request.title }}"
+          cz check --message "$PR_TITLE"


### PR DESCRIPTION
CI workflow that

- validates that PR title conforms to [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- runs on PRs into main and develop branches
- re-runs if PR changes (e.g., title is modified) 