### PR TITLE
ci(dependabot): Group uv updates into a single PR per dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,14 +22,8 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      production:
-        dependency-type: "production"
-        patterns:
-          - "*"
-      development:
-        dependency-type: "development"
-        patterns:
-          - "*"
+      monorepo-dependencies:
+        group-by: dependency-name
     cooldown:
       default-days: 10
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

## What is the new behavior (if this is a feature change)?

Updates dependabot configuration to group all uv updates into a single pull request. 

Adjusted based on [docs](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-updates-across-directories-in-a-monorepo).

Disclaimer: A PR per dependency name is expected. Combining multiple dependencies across multiple directories is currently not supported.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
