### PR TITLE
feat: add spps rules

### DIFF
--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -7,6 +7,7 @@
 
 """Compute the N-1 AC/DC power flow for the pandapower network."""
 
+import json
 import math
 import uuid
 from copy import deepcopy
@@ -52,6 +53,7 @@ from toop_engine_contingency_analysis.pandapower.spps import SppsPowerFlowError,
 from toop_engine_grid_helpers.pandapower.bus_lookup import create_bus_lookup_simple
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
 from toop_engine_grid_helpers.pandapower.slack_allocation import assign_slack_per_island
+from toop_engine_interfaces.interface_helpers import get_empty_dataframe_from_model
 from toop_engine_interfaces.loadflow_result_helpers import (
     concatenate_loadflow_results,
     convert_pandas_loadflow_results_to_polars,
@@ -64,6 +66,7 @@ from toop_engine_interfaces.loadflow_results import (
     ConvergenceStatus,
     LoadflowResults,
     NodeResultSchema,
+    SppsResultsSchema,
     SwitchResultsSchema,
     VADiffResultSchema,
 )
@@ -111,6 +114,7 @@ def run_single_outage(
     opened_cb_indices = open_outaged_circuit_breakers(net, outaged_elements)
 
     were_in_service = set_outaged_elements_out_of_service(net, outaged_elements)
+    spps_results = get_empty_dataframe_from_model(SppsResultsSchema)
     if not any(were_in_service):
         status = ConvergenceStatus.NO_CALCULATION
     else:
@@ -129,6 +133,18 @@ def run_single_outage(
                     max_iterations=ctx.spps_rules_max_iterations,
                     on_power_flow_error=ctx.on_power_flow_error,
                 )
+                spps_rows = [
+                    {
+                        "timestep": ctx.timestep,
+                        "contingency": contingency.unique_id,
+                        "iterations": spps_result.iterations,
+                        "activated_schemes_per_iter": json.dumps(spps_result.activated_schemes_per_iter),
+                        "max_iterations_reached": spps_result.max_iterations_reached,
+                        "power_flow_failed": spps_result.power_flow_failed,
+                    }
+                    for contingency in grouped_contingency.contingencies
+                ]
+                spps_results = SppsResultsSchema.validate(pd.DataFrame(spps_rows).set_index(["timestep", "contingency"]))
                 if spps_result.power_flow_failed or spps_result.max_iterations_reached:
                     status = ConvergenceStatus.FAILED
                 else:
@@ -206,6 +222,7 @@ def run_single_outage(
         va_diff_results=va_diff_results,
         switch_results=switch_df,
         warnings=[],
+        spps_results=spps_results,
     )
 
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -48,7 +48,7 @@ from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas impo
     SequentialContingencyAnalysisContext,
     SingleOutageContext,
 )
-from toop_engine_contingency_analysis.pandapower.spps import run_spps
+from toop_engine_contingency_analysis.pandapower.spps import SppsPowerFlowError, run_spps
 from toop_engine_grid_helpers.pandapower.bus_lookup import create_bus_lookup_simple
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
 from toop_engine_grid_helpers.pandapower.slack_allocation import assign_slack_per_island
@@ -117,7 +117,7 @@ def run_single_outage(
         runpp_kwargs = ctx.runpp_kwargs or {}
         try:
             if not ctx.spps_conditions.empty:
-                run_spps(
+                spps_result = run_spps(
                     net=net,
                     conditions=ctx.spps_conditions,
                     actions=ctx.spps_actions,
@@ -127,11 +127,16 @@ def run_single_outage(
                     },
                     runpp_kwargs=runpp_kwargs,
                     max_iterations=ctx.spps_rules_max_iterations,
+                    on_power_flow_error=ctx.on_power_flow_error,
                 )
+                if spps_result.power_flow_failed or spps_result.max_iterations_reached:
+                    status = ConvergenceStatus.FAILED
+                else:
+                    status = ConvergenceStatus.CONVERGED
             else:
                 pp.rundcpp(net, **runpp_kwargs) if ctx.method == "dc" else pp.runpp(net, **runpp_kwargs)
-            status = ConvergenceStatus.CONVERGED
-        except pp.LoadflowNotConverged:
+                status = ConvergenceStatus.CONVERGED
+        except (pp.LoadflowNotConverged, SppsPowerFlowError):
             status = ConvergenceStatus.FAILED
 
     convergence_df = pd.concat(
@@ -434,6 +439,7 @@ def run_contingency_analysis_sequential(
         spps_conditions=ctx.spps_conditions,
         spps_actions=ctx.spps_actions,
         spps_rules_max_iterations=ctx.spps_rules_max_iterations,
+        on_power_flow_error=ctx.on_power_flow_error,
     )
 
     for grouped_contingency in n_minus_1_definition.grouped_contingencies:
@@ -499,6 +505,7 @@ def run_contingency_analysis_parallel(
         spps_conditions=ctx.spps_conditions,
         spps_actions=ctx.spps_actions,
         spps_rules_max_iterations=ctx.spps_rules_max_iterations,
+        on_power_flow_error=ctx.on_power_flow_error,
     )
 
     for batch in work:
@@ -690,6 +697,7 @@ def run_contingency_analysis_pandapower(
                 spps_conditions=pp_n1_definition.spps_conditions,
                 spps_actions=pp_n1_definition.spps_actions,
                 spps_rules_max_iterations=cfg.spps_rules_max_iterations,
+                on_power_flow_error=cfg.on_power_flow_error,
             ),
         )
     else:
@@ -707,6 +715,7 @@ def run_contingency_analysis_pandapower(
                 method=cfg.method,
                 runpp_kwargs=cfg.runpp_kwargs,
                 spps_rules_max_iterations=cfg.spps_rules_max_iterations,
+                on_power_flow_error=cfg.on_power_flow_error,
                 parallel=cfg.parallel,
             ),
         )

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pandera as pa
 import pandera.typing as pat
 import ray
-from beartype.typing import Literal, Optional, Union
+from beartype.typing import Optional, Union
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers import (
     PandapowerContingency,
     PandapowerContingencyGroup,
@@ -42,8 +42,15 @@ from toop_engine_contingency_analysis.pandapower.pandapower_helpers.results.swit
     get_failed_switch_results,
     get_switch_mapped_elements,
 )
-from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import ContingencyAnalysisConfig
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
+    ContingencyAnalysisConfig,
+    ParallelContingencyAnalysisContext,
+    SequentialContingencyAnalysisContext,
+    SingleOutageContext,
+)
+from toop_engine_contingency_analysis.pandapower.spps import run_spps
 from toop_engine_grid_helpers.pandapower.bus_lookup import create_bus_lookup_simple
+from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
 from toop_engine_grid_helpers.pandapower.slack_allocation import assign_slack_per_island
 from toop_engine_interfaces.loadflow_result_helpers import (
     concatenate_loadflow_results,
@@ -96,59 +103,33 @@ def _apply_contingency_to_index(df: pd.DataFrame, contingency: PandapowerConting
 def run_single_outage(
     net: pp.pandapowerNet,
     grouped_contingency: PandapowerContingencyGroup,
-    monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
-    timestep: int,
-    job_id: str,
-    basecase_voltage: pat.Series[float],
-    method: Literal["ac", "dc"],
-    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema],
-    runpp_kwargs: Optional[dict] = None,
+    ctx: SingleOutageContext,
 ) -> LoadflowResults:
-    """Compute a single outage for the given network
-
-    Parameters
-    ----------
-    net : pp.pandapowerNet
-        The network to compute the outage for
-    grouped_contingency: PandapowerContingencyGroup,
-        The grouped contingency to compute the outage for
-    monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
-        The elements to monitor during the outage
-    timestep : int
-        The timestep of the results
-    job_id : str
-        The job id of the current job
-
-    basecase_voltage: pat.Series[float]
-        The voltage results from the basecase run.
-        Contains computed voltages if the basecase converged,
-        otherwise a series of NaN values.
-    method : Literal["ac", "dc"]
-        The method to use for the loadflow. Either "ac" or "dc"
-    switch_element_mapping : pat.DataFrame[SwitchElementMappingSchema]
-        Mapping between switches and connected elements, used to compute
-        switch-level results during each outage.
-    runpp_kwargs : Optional[dict], optional
-        Additional keyword arguments to pass to runpp/rundcpp functions, by default None
-
-
-    Returns
-    -------
-    LoadflowResults
-        The results of the ContingencyAnalysis computation
-    """
+    """Compute a single outage for the given network."""
     outaged_elements = grouped_contingency.elements
 
     opened_cb_indices = open_outaged_circuit_breakers(net, outaged_elements)
 
     were_in_service = set_outaged_elements_out_of_service(net, outaged_elements)
     if not any(were_in_service):
-        # If no elements were outaged, this is the base case and we should not run the loadflow
         status = ConvergenceStatus.NO_CALCULATION
     else:
-        runpp_kwargs = runpp_kwargs or {}
+        runpp_kwargs = ctx.runpp_kwargs or {}
         try:
-            pp.rundcpp(net, **runpp_kwargs) if method == "dc" else pp.runpp(net, **runpp_kwargs)
+            if not ctx.spps_conditions.empty:
+                run_spps(
+                    net=net,
+                    conditions=ctx.spps_conditions,
+                    actions=ctx.spps_actions,
+                    method=ctx.method,
+                    failed_elements={
+                        get_globally_unique_id(element.table_id, element.table) for element in outaged_elements
+                    },
+                    runpp_kwargs=runpp_kwargs,
+                    max_iterations=ctx.spps_rules_max_iterations,
+                )
+            else:
+                pp.rundcpp(net, **runpp_kwargs) if ctx.method == "dc" else pp.runpp(net, **runpp_kwargs)
             status = ConvergenceStatus.CONVERGED
         except pp.LoadflowNotConverged:
             status = ConvergenceStatus.FAILED
@@ -156,7 +137,7 @@ def run_single_outage(
     convergence_df = pd.concat(
         [
             get_convergence_df(
-                timestep=timestep,
+                timestep=ctx.timestep,
                 contingency=contingency,
                 status=status.value,
             )
@@ -169,12 +150,25 @@ def run_single_outage(
     va_diff_dfs = []
     regulating_elements_dfs = []
     switch_dfs = []
-    element_name_map = monitored_elements["name"].to_dict()
+
+    element_name_map = ctx.monitored_elements["name"].to_dict()
     first_contingency = grouped_contingency.contingencies[0]
+
     branch_results_df, node_results_df, va_diff_results, sw_results_df = get_element_results_df(
-        net, first_contingency, monitored_elements, timestep, status, basecase_voltage, switch_element_mapping
+        net,
+        first_contingency,
+        ctx.monitored_elements,
+        ctx.timestep,
+        status,
+        ctx.basecase_voltage,
+        ctx.switch_element_mapping,
     )
-    reg_element_result = get_regulating_element_results(timestep, monitored_elements, first_contingency)
+
+    reg_element_result = get_regulating_element_results(
+        ctx.timestep,
+        ctx.monitored_elements,
+        first_contingency,
+    )
 
     for contingency in grouped_contingency.contingencies:
         branch_dfs.append(_apply_contingency_to_index(branch_results_df, contingency))
@@ -198,8 +192,8 @@ def run_single_outage(
     restore_outaged_circuit_breakers(net, opened_cb_indices)
     restore_elements_to_service(net, outaged_elements, were_in_service)
 
-    lf_result = LoadflowResults(
-        job_id=job_id,
+    return LoadflowResults(
+        job_id=ctx.job_id,
         branch_results=branch_results_df,
         node_results=node_results_df,
         converged=convergence_df,
@@ -208,7 +202,6 @@ def run_single_outage(
         switch_results=switch_df,
         warnings=[],
     )
-    return lf_result
 
 
 def update_results_with_names(
@@ -425,72 +418,44 @@ def open_outaged_circuit_breakers(net: pp.pandapowerNet, outaged_elements: list[
 def run_contingency_analysis_sequential(
     net: pp.pandapowerNet,
     n_minus_1_definition: PandapowerNMinus1Definition,
-    job_id: str,
-    timestep: int,
-    basecase_voltage: pat.Series[float],
-    slack_allocation_config: SlackAllocationConfig,
-    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema],
-    method: Literal["ac", "dc"] = "dc",
-    runpp_kwargs: Optional[dict] = None,
+    ctx: SequentialContingencyAnalysisContext,
 ) -> list[LoadflowResults]:
-    """Compute a full N-1 analysis for the given network, but a single timestep
-
-    Parameters
-    ----------
-    net : pp.pandapowerNet
-        The network to compute the N-1 analysis for
-    n_minus_1_definition: PandapowerNMinus1Definition,
-        The N-1 definition to use for the analysis
-    job_id : str
-        The job id of the current job
-    timestep : int
-        The timestep of the results
-    slack_allocation_config : SlackAllocationConfig
-        Precomputed configuration for slack allocation per island.
-    switch_element_mapping : pat.DataFrame[SwitchElementMappingSchema]
-        Mapping between switches and connected elements, used to compute
-        switch-level results during each outage.
-    method : Literal["ac", "dc"], optional
-        The method to use for the loadflow, by default "dc"
-    runpp_kwargs : Optional[dict], optional
-        Additional keyword arguments to pass to runpp/rundcpp functions, by default None
-    basecase_voltage: pat.Series[float]
-        The voltage results from the basecase run.
-        Contains computed voltages if the basecase converged,
-        otherwise a series of NaN values.
-
-    Returns
-    -------
-    list[LoadflowResults]
-        A list of the results per contingency
-    """
+    """Compute a full N-1 analysis for the given network, but a single timestep."""
     results = []
+
+    single_outage_ctx = SingleOutageContext(
+        monitored_elements=n_minus_1_definition.monitored_elements,
+        timestep=ctx.timestep,
+        job_id=ctx.job_id,
+        method=ctx.method,
+        runpp_kwargs=ctx.runpp_kwargs,
+        basecase_voltage=ctx.basecase_voltage,
+        switch_element_mapping=ctx.switch_element_mapping,
+        spps_conditions=ctx.spps_conditions,
+        spps_actions=ctx.spps_actions,
+        spps_rules_max_iterations=ctx.spps_rules_max_iterations,
+    )
 
     for grouped_contingency in n_minus_1_definition.grouped_contingencies:
         copy_net = deepcopy(net)
         elements_ids = [element.unique_id for element in grouped_contingency.elements]
+
         removed_edges = assign_slack_per_island(
             net=copy_net,
-            net_graph=slack_allocation_config.net_graph,
-            bus_lookup=slack_allocation_config.bus_lookup,
+            net_graph=ctx.slack_allocation_config.net_graph,
+            bus_lookup=ctx.slack_allocation_config.bus_lookup,
             elements_ids=elements_ids,
-            min_island_size=slack_allocation_config.min_island_size,
+            min_island_size=ctx.slack_allocation_config.min_island_size,
         )
 
         single_res = run_single_outage(
             net=copy_net,
             grouped_contingency=grouped_contingency,
-            monitored_elements=n_minus_1_definition.monitored_elements,
-            timestep=timestep,
-            job_id=job_id,
-            method=method,
-            runpp_kwargs=runpp_kwargs,
-            basecase_voltage=basecase_voltage,
-            switch_element_mapping=switch_element_mapping,
+            ctx=single_outage_ctx,
         )
 
         results.append(single_res)
-        slack_allocation_config.net_graph.add_edges_from(removed_edges)
+        ctx.slack_allocation_config.net_graph.add_edges_from(removed_edges)
 
     return results
 
@@ -498,46 +463,15 @@ def run_contingency_analysis_sequential(
 def run_contingency_analysis_parallel(
     net: pp.pandapowerNet,
     n_minus_1_definition: PandapowerNMinus1Definition,
-    job_id: str,
-    timestep: int,
-    slack_allocation_config: SlackAllocationConfig,
-    basecase_voltage: pat.Series[float],
-    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema],
-    cfg: ContingencyAnalysisConfig,
+    ctx: ParallelContingencyAnalysisContext,
 ) -> list[LoadflowResults]:
-    """Compute the N-1 AC/DC power flow for the network.
-
-    Parameters
-    ----------
-    net: pp.pandapowerNet,
-        The pandapower network to compute the N-1 power flow for, with the topolgy already applied.
-        You can either pass the network directly or a ray.ObjectRef to the network (wrapped in a
-        list to avoid dereferencing the object).
-    n_minus_1_definition: PandapowerNMinus1Definition,
-        The N-1 definition to use for the analysis. Contains outages and monitored elements
-    job_id : str
-        The job id of the current job
-    timestep : int
-        The timestep of the results
-    slack_allocation_config : SlackAllocationConfig
-        Precomputed configuration for slack allocation per island.
-    cfg : ContingencyAnalysisConfig
-        Execution configuration (method, islanding/slack settings, parallelization, etc.).
-    basecase_voltage: pat.Series[float]
-        The basecase voltage results
-    switch_element_mapping : pat.DataFrame[SwitchElementMappingSchema]
-        Mapping between switches and connected elements, used to compute
-        switch-level results during each outage.
-
-    Returns
-    -------
-    list[LoadflowResults]
-        A list of the results per contingency
-    """
+    """Compute the N-1 AC/DC power flow for the network in parallel."""
     n_outages = len(n_minus_1_definition.grouped_contingencies)
-    batch_size = cfg.parallel.batch_size
+    batch_size = ctx.parallel.batch_size
+
     if batch_size is None:
-        batch_size = math.ceil(n_outages / cfg.parallel.n_processes)
+        batch_size = math.ceil(n_outages / ctx.parallel.n_processes)
+
     work = []
     for i in range(0, n_outages, batch_size):
         grouped_batch = n_minus_1_definition.grouped_contingencies[i : i + batch_size]
@@ -550,35 +484,39 @@ def run_contingency_analysis_parallel(
             )
         )
 
-    # Schedule work until the handle list is too long, then wait for the first result and continue
     handles = []
     result_lists = []
     _compute_remote = ray.remote(run_contingency_analysis_sequential)
+
+    sequential_ctx = SequentialContingencyAnalysisContext(
+        job_id=ctx.job_id,
+        timestep=ctx.timestep,
+        slack_allocation_config=ctx.slack_allocation_config,
+        method=ctx.method,
+        runpp_kwargs=ctx.runpp_kwargs,
+        basecase_voltage=ctx.basecase_voltage,
+        switch_element_mapping=ctx.switch_element_mapping,
+        spps_conditions=ctx.spps_conditions,
+        spps_actions=ctx.spps_actions,
+        spps_rules_max_iterations=ctx.spps_rules_max_iterations,
+    )
+
     for batch in work:
         handles.append(
             _compute_remote.remote(
                 net=net,
                 n_minus_1_definition=batch,
-                job_id=job_id,
-                timestep=timestep,
-                slack_allocation_config=slack_allocation_config,
-                method=cfg.method,
-                runpp_kwargs=cfg.runpp_kwargs,
-                basecase_voltage=basecase_voltage,
-                switch_element_mapping=switch_element_mapping,
+                ctx=sequential_ctx,
             )
         )
-        if len(handles) >= cfg.parallel.n_processes:
-            # Wait for the first result and continue
+
+        if len(handles) >= ctx.parallel.n_processes:
             finished, handles = ray.wait(handles, num_returns=1)
             result_lists.extend(ray.get(finished))
+
     result_lists.extend(ray.get(handles))
 
-    # Sort the result_lists back into the original order
-    del handles
-    # Flatten the result_lists
-    results = [result for result_list in result_lists for result in result_list]
-    return results
+    return [result for result_list in result_lists for result in result_list]
 
 
 def _run_base_case_loadflow(
@@ -741,24 +679,36 @@ def run_contingency_analysis_pandapower(
         results = run_contingency_analysis_sequential(
             net=net,
             n_minus_1_definition=pp_n1_definition,
-            job_id=job_id,
-            timestep=timestep,
-            slack_allocation_config=slack_allocation_config,
-            method=cfg.method,
-            runpp_kwargs=cfg.runpp_kwargs,
-            basecase_voltage=net.res_bus.vm_pu.copy(),
-            switch_element_mapping=switch_element_mapping,
+            ctx=SequentialContingencyAnalysisContext(
+                job_id=job_id,
+                timestep=timestep,
+                slack_allocation_config=slack_allocation_config,
+                method=cfg.method,
+                runpp_kwargs=cfg.runpp_kwargs,
+                basecase_voltage=net.res_bus.vm_pu.copy(),
+                switch_element_mapping=switch_element_mapping,
+                spps_conditions=pp_n1_definition.spps_conditions,
+                spps_actions=pp_n1_definition.spps_actions,
+                spps_rules_max_iterations=cfg.spps_rules_max_iterations,
+            ),
         )
     else:
         results = run_contingency_analysis_parallel(
             net=net,
             n_minus_1_definition=pp_n1_definition,
-            job_id=job_id,
-            timestep=timestep,
-            slack_allocation_config=slack_allocation_config,
-            cfg=cfg,
-            basecase_voltage=net.res_bus.vm_pu.copy(),
-            switch_element_mapping=switch_element_mapping,
+            ctx=ParallelContingencyAnalysisContext(
+                job_id=job_id,
+                timestep=timestep,
+                slack_allocation_config=slack_allocation_config,
+                basecase_voltage=net.res_bus.vm_pu.copy(),
+                switch_element_mapping=switch_element_mapping,
+                spps_conditions=pp_n1_definition.spps_conditions,
+                spps_actions=pp_n1_definition.spps_actions,
+                method=cfg.method,
+                runpp_kwargs=cfg.runpp_kwargs,
+                spps_rules_max_iterations=cfg.spps_rules_max_iterations,
+                parallel=cfg.parallel,
+            ),
         )
     lf_result = concatenate_loadflow_results(results)
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
@@ -7,6 +7,8 @@
 
 """Utilities for translating CGMES and globally unique IDs into pandapower tables, monitored elements."""
 
+from typing import Optional
+
 import numpy as np
 import pandapower
 import pandas as pd
@@ -264,8 +266,23 @@ def extract_contingencies_with_cgmes_id(
 def _resolve_unique_pandapower_element(net: pandapowerNet, unique_id: str) -> tuple[str, int]:
     """Resolve a pandapower globally unique id into a ``(table, table_id)`` pair.
 
-    Raises ``ValueError`` if the id cannot be parsed or the element is not
-    present in ``net``.
+    ``unique_id`` is parsed as ``"<table_id>%%<table>"``; the table is mapped to
+    the corresponding non-result DataFrame in ``net`` and ``table_id`` is
+    checked against that table's index. Raises ``ValueError`` if parsing fails
+    or the element is not present in ``net``.
+
+    Parameters
+    ----------
+    net : pandapowerNet
+        The network whose element tables are used to validate the resolved id.
+    unique_id : str
+        Pandapower globally unique id string (``"%%"``-separated id and type).
+
+    Returns
+    -------
+    tuple[str, int]
+        ``(table, table_id)`` where ``table`` is the pandapower element table
+        name and ``table_id`` the row index in that table.
     """
     pp_id, pp_type = parse_globally_unique_id(unique_id)
     table = get_element_table(pp_type, res_table=False)
@@ -278,7 +295,28 @@ def _build_spps_condition_rows(
     rule: SppsRule,
     resolved_conditions: list[tuple[Condition, str, int]],
 ) -> list[dict]:
-    """Build one DataFrame row per resolved condition, including ``scheme_name``."""
+    """Build one row dict per resolved condition for SpPS condition tables.
+
+    Each dict matches ``SppsConditionsPandapowerSchema`` column names, mixing
+    fields from the ``Condition`` with the resolved pandapower
+    ``(table, table_id)`` for the monitored element.
+
+    Parameters
+    ----------
+    rule : SppsRule
+        The rule; ``scheme_name`` is copied into every row.
+    resolved_conditions : list[tuple[Condition, str, int]]
+        For each condition, the ``Condition`` plus ``condition_element_table``
+        and ``condition_element_table_id`` after unique-id resolution.
+
+    Returns
+    -------
+    list[dict]
+        One mapping per condition, with keys including ``scheme_name``,
+        ``condition_type``, ``condition_check_type``, ``condition_side``,
+        ``condition_limit_value``, ``condition_element_table``, and
+        ``condition_element_table_id``.
+    """
     rows = []
     for condition, cond_table, cond_table_id in resolved_conditions:
         rows.append(
@@ -299,7 +337,27 @@ def _build_spps_action_rows(
     rule: SppsRule,
     resolved_actions: list[tuple[Action, str, int]],
 ) -> list[dict]:
-    """Build one DataFrame row per resolved action, including ``scheme_name``."""
+    """Build one row dict per resolved action for SpPS action tables.
+
+    Each dict matches ``SppsActionsPandapowerSchema`` column names, mixing
+    fields from the ``Action`` with the resolved pandapower ``(table, table_id)``
+    for the measure element.
+
+    Parameters
+    ----------
+    rule : SppsRule
+        The rule; ``scheme_name`` is copied into every row.
+    resolved_actions : list[tuple[Action, str, int]]
+        For each action, the ``Action`` plus ``measure_element_table`` and
+        ``measure_element_table_id`` after unique-id resolution.
+
+    Returns
+    -------
+    list[dict]
+        One mapping per action, with keys including ``scheme_name``,
+        ``measure_element_table``, ``measure_element_table_id``, ``measure_type``,
+        and ``measure_value``.
+    """
     rows = []
     for action, meas_table, meas_table_id in resolved_actions:
         rows.append(
@@ -317,7 +375,7 @@ def _build_spps_action_rows(
 @pa.check_types
 def extract_spps_rules_with_unique_pandapower_id(
     net: pandapowerNet,
-    rules: list[SppsRule],
+    rules: Optional[list[SppsRule]],
 ) -> tuple[
     pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
 ]:
@@ -328,14 +386,15 @@ def extract_spps_rules_with_unique_pandapower_id(
     (``"<table_id>%%<table>"``) and resolved into ``(table, table_id)`` pairs.
     Resolved pairs are validated against ``net``.
 
-    Rules whose conditions or actions reference ids not present in ``net`` are
-    dropped from the result and returned in ``missing_rules``.
+    Rules with no conditions or no actions, and rules whose conditions or
+    actions reference ids not present in ``net``, are dropped from the result
+    and returned in ``missing_rules``.
 
     Parameters
     ----------
     net : pandapowerNet
         The pandapower network used to validate resolved condition / action ids.
-    rules : list[SppsRule]
+    rules : Optional[list[SppsRule]]
         The list of SpPS rules to translate.
 
     Returns
@@ -345,8 +404,9 @@ def extract_spps_rules_with_unique_pandapower_id(
     pat.DataFrame[SppsActionsPandapowerSchema]
         One row per action, keyed by ``scheme_name``.
     list[SppsRule]
-        SpPS rules dropped because a condition or action id could not be
-        parsed or the referenced element was not found in ``net``.
+        SpPS rules dropped because the rule has no conditions or no actions, a
+        condition or action id could not be parsed, or the referenced element
+        was not found in ``net``.
     list[str]
         A list of ids that were not unique in the grid. This is only relevant
         for cgmes ids and is always empty in this mode.
@@ -360,6 +420,9 @@ def extract_spps_rules_with_unique_pandapower_id(
         return empty_conditions, empty_actions, missing_rules, []
 
     for rule in rules:
+        if not rule.conditions or not rule.actions:
+            missing_rules.append(rule)
+            continue
         try:
             resolved_conditions = [
                 (c, *_resolve_unique_pandapower_element(net, c.condition_element_unique_id)) for c in rule.conditions
@@ -386,10 +449,28 @@ def _resolve_cgmes_element(
 ) -> tuple[str, int]:
     """Resolve a CGMES GUID into a pandapower ``(table, table_id)`` pair.
 
-    Appends ``guid`` to ``seen_duplicated_ids`` when it was flagged as
-    non-unique during the ``cgmes_ids`` lookup build.
+    ``cgmes_ids`` is the mapping from ``get_cgmes_id_to_table_df`` (index =
+    origin id, columns include ``table_id`` and ``table``). If ``guid`` was
+    marked as duplicated when that mapping was built, it is recorded in
+    ``seen_duplicated_ids`` so callers can report non-unique ids. Raises
+    ``KeyError`` if ``guid`` is not in ``cgmes_ids.index``.
 
-    Raises ``KeyError`` if the GUID is not present in ``cgmes_ids``.
+    Parameters
+    ----------
+    cgmes_ids : pd.DataFrame
+        DataFrame mapping CGMES / ``origin_id`` values to ``table`` and
+        ``table_id``, indexed by origin id (from ``get_cgmes_id_to_table_df``).
+    duplicated_ids : list[str]
+        Ids that appeared more than once when ``cgmes_ids`` was built.
+    seen_duplicated_ids : list[str]
+        Mutable list; ``guid`` is appended when it is in ``duplicated_ids``.
+    guid : str
+        The condition or action element id to look up in ``cgmes_ids``.
+
+    Returns
+    -------
+    tuple[str, int]
+        ``(table, table_id)`` for the pandapower element row.
     """
     if guid in duplicated_ids:
         seen_duplicated_ids.append(guid)
@@ -400,7 +481,7 @@ def _resolve_cgmes_element(
 @pa.check_types
 def extract_spps_rules_with_cgmes_id(
     net: pandapowerNet,
-    rules: list[SppsRule],
+    rules: Optional[list[SppsRule]],
 ) -> tuple[
     pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
 ]:
@@ -411,16 +492,16 @@ def extract_spps_rules_with_cgmes_id(
     element. Both are resolved to pandapower ``(table, table_id)`` pairs via
     the network's ``origin_id`` columns.
 
-    Rules for which any condition or action GUID cannot be resolved to an
-    element in ``net`` are dropped from the result and returned in
-    ``missing_rules``.
+    Rules with no conditions or no actions, and rules for which any condition
+    or action GUID cannot be resolved to an element in ``net``, are dropped
+    from the result and returned in ``missing_rules``.
 
     Parameters
     ----------
     net : pandapowerNet
         The pandapower network used to resolve CGMES GUIDs into pandapower
         table names and row ids.
-    rules : list[SppsRule]
+    rules : Optional[list[SppsRule]]
         The list of SpPS rules to translate. Each condition's
         ``condition_element_unique_id`` and each action's
         ``measure_element_unique_id`` must contain the CGMES GUID of the
@@ -431,8 +512,9 @@ def extract_spps_rules_with_cgmes_id(
     pat.DataFrame[SppsConditionsPandapowerSchema]
     pat.DataFrame[SppsActionsPandapowerSchema]
     list[SppsRule]
-        The SpPS rules that were dropped because at least one of their
-        condition/action GUIDs could not be resolved in ``net``.
+        The SpPS rules that were dropped because the rule has no conditions or
+        no actions, or at least one condition/action GUID could not be resolved
+        in ``net``.
     list[str]
         A list of GUIDs that were not unique in the grid.
     """
@@ -449,6 +531,9 @@ def extract_spps_rules_with_cgmes_id(
         return empty_conditions, empty_actions, missing_rules, []
 
     for rule in rules:
+        if not rule.conditions or not rule.actions:
+            missing_rules.append(rule)
+            continue
         try:
             resolved_conditions = [
                 (c, *_resolve_cgmes_element(cgmes_ids, duplicated_ids, seen_duplicated_ids, c.condition_element_unique_id))

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
@@ -313,7 +313,7 @@ def _build_spps_condition_rows(
     -------
     list[dict]
         One mapping per condition, with keys including ``scheme_name``,
-        ``condition_type``, ``condition_check_type``, ``condition_side``,
+        ``condition_logic``, ``condition_type``, ``condition_check_type``, ``condition_side``,
         ``condition_limit_value``, ``condition_element_table``, and
         ``condition_element_table_id``.
     """
@@ -322,6 +322,7 @@ def _build_spps_condition_rows(
         rows.append(
             {
                 "scheme_name": rule.scheme_name,
+                "condition_logic": rule.condition_logic.value,
                 "condition_type": condition.condition_type,
                 "condition_check_type": condition.condition_check_type,
                 "condition_side": condition.condition_side,

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/extractors.py
@@ -17,6 +17,8 @@ from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas impo
     PandapowerContingency,
     PandapowerElements,
     PandapowerMonitoredElementSchema,
+    SppsActionsPandapowerSchema,
+    SppsConditionsPandapowerSchema,
 )
 from toop_engine_grid_helpers.pandapower.pandapower_helpers import get_element_table
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import (
@@ -24,8 +26,11 @@ from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import (
 )
 from toop_engine_interfaces.interface_helpers import get_empty_dataframe_from_model
 from toop_engine_interfaces.nminus1_definition import (
+    Action,
+    Condition,
     Contingency,
     GridElement,
+    SppsRule,
 )
 
 
@@ -254,3 +259,211 @@ def extract_contingencies_with_cgmes_id(
         if monitored_element.id in duplicated_ids
     ]
     return pp_contingencies, missing_contingencies, duplicated_ids
+
+
+def _resolve_unique_pandapower_element(net: pandapowerNet, unique_id: str) -> tuple[str, int]:
+    """Resolve a pandapower globally unique id into a ``(table, table_id)`` pair.
+
+    Raises ``ValueError`` if the id cannot be parsed or the element is not
+    present in ``net``.
+    """
+    pp_id, pp_type = parse_globally_unique_id(unique_id)
+    table = get_element_table(pp_type, res_table=False)
+    if pp_id not in net[table].index:
+        raise ValueError(f"Pandapower id {unique_id!r} not found in net")
+    return table, int(pp_id)
+
+
+def _build_spps_condition_rows(
+    rule: SppsRule,
+    resolved_conditions: list[tuple[Condition, str, int]],
+) -> list[dict]:
+    """Build one DataFrame row per resolved condition, including ``scheme_name``."""
+    rows = []
+    for condition, cond_table, cond_table_id in resolved_conditions:
+        rows.append(
+            {
+                "scheme_name": rule.scheme_name,
+                "condition_type": condition.condition_type,
+                "condition_check_type": condition.condition_check_type,
+                "condition_side": condition.condition_side,
+                "condition_limit_value": condition.condition_limit_value,
+                "condition_element_table": cond_table,
+                "condition_element_table_id": cond_table_id,
+            }
+        )
+    return rows
+
+
+def _build_spps_action_rows(
+    rule: SppsRule,
+    resolved_actions: list[tuple[Action, str, int]],
+) -> list[dict]:
+    """Build one DataFrame row per resolved action, including ``scheme_name``."""
+    rows = []
+    for action, meas_table, meas_table_id in resolved_actions:
+        rows.append(
+            {
+                "scheme_name": rule.scheme_name,
+                "measure_element_table": meas_table,
+                "measure_element_table_id": meas_table_id,
+                "measure_type": action.measure_type,
+                "measure_value": action.measure_value,
+            }
+        )
+    return rows
+
+
+@pa.check_types
+def extract_spps_rules_with_unique_pandapower_id(
+    net: pandapowerNet,
+    rules: list[SppsRule],
+) -> tuple[
+    pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
+]:
+    """Extract SpPS rules into pandapower condition and action tables using globally unique ids.
+
+    Each condition's ``condition_element_unique_id`` and each action's
+    ``measure_element_unique_id`` are parsed as pandapower globally unique ids
+    (``"<table_id>%%<table>"``) and resolved into ``(table, table_id)`` pairs.
+    Resolved pairs are validated against ``net``.
+
+    Rules whose conditions or actions reference ids not present in ``net`` are
+    dropped from the result and returned in ``missing_rules``.
+
+    Parameters
+    ----------
+    net : pandapowerNet
+        The pandapower network used to validate resolved condition / action ids.
+    rules : list[SppsRule]
+        The list of SpPS rules to translate.
+
+    Returns
+    -------
+    pat.DataFrame[SppsConditionsPandapowerSchema]
+        One row per condition, keyed by ``scheme_name``.
+    pat.DataFrame[SppsActionsPandapowerSchema]
+        One row per action, keyed by ``scheme_name``.
+    list[SppsRule]
+        SpPS rules dropped because a condition or action id could not be
+        parsed or the referenced element was not found in ``net``.
+    list[str]
+        A list of ids that were not unique in the grid. This is only relevant
+        for cgmes ids and is always empty in this mode.
+    """
+    empty_conditions = get_empty_dataframe_from_model(SppsConditionsPandapowerSchema)
+    empty_actions = get_empty_dataframe_from_model(SppsActionsPandapowerSchema)
+    cond_rows: list[dict] = []
+    act_rows: list[dict] = []
+    missing_rules: list[SppsRule] = []
+    if not rules:
+        return empty_conditions, empty_actions, missing_rules, []
+
+    for rule in rules:
+        try:
+            resolved_conditions = [
+                (c, *_resolve_unique_pandapower_element(net, c.condition_element_unique_id)) for c in rule.conditions
+            ]
+            resolved_actions = [
+                (a, *_resolve_unique_pandapower_element(net, a.measure_element_unique_id)) for a in rule.actions
+            ]
+        except ValueError:
+            missing_rules.append(rule)
+            continue
+        cond_rows.extend(_build_spps_condition_rows(rule, resolved_conditions))
+        act_rows.extend(_build_spps_action_rows(rule, resolved_actions))
+
+    spps_conditions = pd.concat([empty_conditions, pd.DataFrame(cond_rows)], ignore_index=True)
+    spps_actions = pd.concat([empty_actions, pd.DataFrame(act_rows)], ignore_index=True)
+    return spps_conditions, spps_actions, missing_rules, []
+
+
+def _resolve_cgmes_element(
+    cgmes_ids: pd.DataFrame,
+    duplicated_ids: list[str],
+    seen_duplicated_ids: list[str],
+    guid: str,
+) -> tuple[str, int]:
+    """Resolve a CGMES GUID into a pandapower ``(table, table_id)`` pair.
+
+    Appends ``guid`` to ``seen_duplicated_ids`` when it was flagged as
+    non-unique during the ``cgmes_ids`` lookup build.
+
+    Raises ``KeyError`` if the GUID is not present in ``cgmes_ids``.
+    """
+    if guid in duplicated_ids:
+        seen_duplicated_ids.append(guid)
+    table_id, table = cgmes_ids.loc[guid, ["table_id", "table"]].tolist()
+    return table, int(table_id)
+
+
+@pa.check_types
+def extract_spps_rules_with_cgmes_id(
+    net: pandapowerNet,
+    rules: list[SppsRule],
+) -> tuple[
+    pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
+]:
+    """Extract SpPS rules into pandapower condition and action tables, resolving CGMES GUIDs.
+
+    In CGMES mode each condition's ``condition_element_unique_id`` and each
+    action's ``measure_element_unique_id`` carry the CGMES GUID of the target
+    element. Both are resolved to pandapower ``(table, table_id)`` pairs via
+    the network's ``origin_id`` columns.
+
+    Rules for which any condition or action GUID cannot be resolved to an
+    element in ``net`` are dropped from the result and returned in
+    ``missing_rules``.
+
+    Parameters
+    ----------
+    net : pandapowerNet
+        The pandapower network used to resolve CGMES GUIDs into pandapower
+        table names and row ids.
+    rules : list[SppsRule]
+        The list of SpPS rules to translate. Each condition's
+        ``condition_element_unique_id`` and each action's
+        ``measure_element_unique_id`` must contain the CGMES GUID of the
+        target element.
+
+    Returns
+    -------
+    pat.DataFrame[SppsConditionsPandapowerSchema]
+    pat.DataFrame[SppsActionsPandapowerSchema]
+    list[SppsRule]
+        The SpPS rules that were dropped because at least one of their
+        condition/action GUIDs could not be resolved in ``net``.
+    list[str]
+        A list of GUIDs that were not unique in the grid.
+    """
+    empty_conditions = get_empty_dataframe_from_model(SppsConditionsPandapowerSchema)
+    empty_actions = get_empty_dataframe_from_model(SppsActionsPandapowerSchema)
+    cgmes_ids, duplicated_ids = get_cgmes_id_to_table_df(net)
+
+    cond_rows: list[dict] = []
+    act_rows: list[dict] = []
+    missing_rules: list[SppsRule] = []
+    seen_duplicated_ids: list[str] = []
+
+    if not rules:
+        return empty_conditions, empty_actions, missing_rules, []
+
+    for rule in rules:
+        try:
+            resolved_conditions = [
+                (c, *_resolve_cgmes_element(cgmes_ids, duplicated_ids, seen_duplicated_ids, c.condition_element_unique_id))
+                for c in rule.conditions
+            ]
+            resolved_actions = [
+                (a, *_resolve_cgmes_element(cgmes_ids, duplicated_ids, seen_duplicated_ids, a.measure_element_unique_id))
+                for a in rule.actions
+            ]
+        except KeyError:
+            missing_rules.append(rule)
+            continue
+        cond_rows.extend(_build_spps_condition_rows(rule, resolved_conditions))
+        act_rows.extend(_build_spps_action_rows(rule, resolved_actions))
+
+    spps_conditions = pd.concat([empty_conditions, pd.DataFrame(cond_rows)], ignore_index=True)
+    spps_actions = pd.concat([empty_actions, pd.DataFrame(act_rows)], ignore_index=True)
+    return spps_conditions, spps_actions, missing_rules, list(dict.fromkeys(seen_duplicated_ids))

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -9,12 +9,15 @@
 
 import dataclasses
 
+import pandas as pd
 import pandera as pa
 import pandera.typing as pat
 from beartype.typing import Any, Literal, Optional
 from networkx.classes import MultiGraph
 from pandera.typing import Index, Series
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+from toop_engine_interfaces.interface_helpers import get_empty_dataframe_from_model
+from toop_engine_interfaces.loadflow_results import SwitchElementMappingSchema
 from toop_engine_interfaces.nminus1_definition import (
     Contingency,
     GridElement,
@@ -128,6 +131,61 @@ class PandapowerContingencyGroup(BaseModel):
             group become unavailable together."""
 
 
+class SppsConditionsPandapowerSchema(pa.DataFrameModel):
+    """Pandera schema for resolved SpPS condition rows (one row per condition)."""
+
+    scheme_name: Series[str]
+    """Name of the rule scheme: conditions with the same name are evaluated as one logical group."""
+
+    condition_type: Series[str] = pa.Field(isin=["current", "active_power", "reactive_power", "voltage", "state"])
+    """What is being checked (e.g. current, power, voltage, or element state)."""
+
+    condition_check_type: Series[str] = pa.Field(isin=[">", "<", "=", "failed", "de_energized"])
+    """How the condition is evaluated (comparison or state check)."""
+
+    condition_side: Series[str] = pa.Field(isin=["primary", "secondary", "tertiary", "maximum_value"])
+    """Which side or value of the element is used for the check."""
+
+    condition_limit_value: Series[float] = pa.Field(
+        nullable=True,
+        coerce=True,
+    )
+    """Threshold value for the condition (empty for state-based checks)."""
+
+    condition_element_table: Series[str]
+    """Pandapower table containing the element to monitor."""
+
+    condition_element_table_id: Series[int] = pa.Field(coerce=True)
+    """Row id of the monitored element in the table."""
+
+
+class SppsActionsPandapowerSchema(pa.DataFrameModel):
+    """Pandera schema for resolved SpPS action rows (one row per action)."""
+
+    scheme_name: Series[str]
+    """Name of the rule scheme: actions in a scheme are applied when all its conditions pass."""
+
+    measure_type: Series[str] = pa.Field(isin=["active_power", "reactive_power", "voltage", "switching_state"])
+    """What is applied when the scheme activates."""
+
+    measure_value: Series[object]
+    """Target value (number or switch state like 'Open'/'Closed')."""
+
+    measure_element_table: Series[str]
+    """Pandapower table containing the element to control."""
+
+    measure_element_table_id: Series[int] = pa.Field(coerce=True)
+    """Row id of the controlled element in the table."""
+
+
+def _default_spps_conditions() -> "pat.DataFrame[SppsConditionsPandapowerSchema]":
+    return get_empty_dataframe_from_model(SppsConditionsPandapowerSchema)
+
+
+def _default_spps_actions() -> "pat.DataFrame[SppsActionsPandapowerSchema]":
+    return get_empty_dataframe_from_model(SppsActionsPandapowerSchema)
+
+
 class PandapowerNMinus1Definition(BaseModel):
     """A Pandapower N-1 definition.
 
@@ -135,7 +193,7 @@ class PandapowerNMinus1Definition(BaseModel):
     It contains only the necessary information to run an N-1 analysis in Pandapower.
     """
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     contingencies: list[PandapowerContingency]
     """The outages to be considered. Maps contingency id to outaged element ids."""
@@ -148,6 +206,11 @@ class PandapowerNMinus1Definition(BaseModel):
 
     monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema]
     """A dictionary mapping the element kind to a list of element ids that are monitored."""
+
+    spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema] = Field(default_factory=_default_spps_conditions)
+    """Resolved SpPS conditions (monitoring) keyed by ``scheme_name``."""
+    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema] = Field(default_factory=_default_spps_actions)
+    """Resolved SpPS actions (setpoints) keyed by ``scheme_name``."""
 
     missing_elements: list[GridElement]
     """A list of monitored elements that were not found in the network."""
@@ -180,6 +243,8 @@ class ContingencyAnalysisConfig(BaseModel):
     executed, how electrical islands are handled, whether outage grouping is
     applied, and how switch results are mapped and aggregated.
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     method: Literal["ac", "dc"] = "ac"
     """Load-flow method used for the base case and contingency calculations.
@@ -229,6 +294,203 @@ class ContingencyAnalysisConfig(BaseModel):
 
     The selected side determines which electrically connected buses and
     connected elements contribute to the computed switch results.
+    """
+
+    parallel: ParallelConfig = Field(default_factory=ParallelConfig)
+    """Parallel execution settings for contingency processing.
+
+    Controls the number of worker processes and optional batch sizing for
+    distributed execution.
+    """
+
+    spps_rules_max_iterations: int = Field(default=10, ge=1)
+    """Maximum number of iterations for the SpPS engine.
+
+    Limits how many times rules can be evaluated and applied during
+    a single outage calculation.
+    """
+
+
+class SingleOutageContext(BaseModel):
+    """Shared execution context for a single outage calculation.
+
+    This context bundles all parameters required to compute one contingency
+    (outage) scenario, including load-flow settings, monitored elements,
+    and optional SpPS rule execution.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema]
+    """Elements that should be monitored during the outage computation.
+
+    These elements define which results (branches, buses, switches, etc.)
+    are extracted and returned after the load-flow execution.
+    """
+
+    timestep: int
+    """Timestep associated with the computed results.
+
+    Used to label all output tables consistently across base case and
+    contingency calculations.
+    """
+
+    job_id: str
+    """Identifier of the current computation job.
+
+    This value is propagated into the resulting :class:`LoadflowResults`
+    object for traceability.
+    """
+
+    basecase_voltage: pd.Series
+    """Voltage results from the base-case load-flow.
+
+    Contains valid voltage magnitudes if the base case converged,
+    otherwise a series of NaN values. Used for voltage comparison
+    and delta calculations.
+    """
+
+    method: Literal["ac", "dc"] = "ac"
+    """Load-flow method used for the base case and contingency calculations.
+
+    - ``"ac"`` runs a full AC power flow using :func:`pandapower.runpp`
+    - ``"dc"`` runs a DC approximation using :func:`pandapower.rundcpp`
+    """
+
+    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema]
+    """Mapping between switches and connected elements.
+
+    Used to compute switch-level results based on the electrical
+    connectivity of monitored elements.
+    """
+
+    spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
+    """SpPS conditions for the outage (see ``spps_actions`` for matching actions)."""
+    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
+    """SpPS actions applied when a scheme's conditions are all satisfied.
+
+    If ``spps_conditions`` is empty, a standard load flow is executed.
+    """
+
+    spps_rules_max_iterations: int = Field(default=10, ge=1)
+    """Maximum number of iterations for the SpPS engine.
+
+    Limits how many times rules can be evaluated and applied during
+    a single outage calculation.
+    """
+
+    runpp_kwargs: dict[str, Any] | None = None
+    """Additional keyword arguments for pandapower load-flow execution.
+
+    Passed directly to :func:`pandapower.runpp` or
+    :func:`pandapower.rundcpp` depending on the selected method.
+    """
+
+
+class SequentialContingencyAnalysisContext(BaseModel):
+    """Shared context for sequential N-1 contingency analysis.
+
+    This context contains all parameters required to execute a full
+    contingency analysis sequentially (single process), including
+    load-flow configuration, SpPS settings, and slack allocation data.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    job_id: str
+    """Identifier of the current computation job.
+
+    Used to tag all resulting load-flow outputs.
+    """
+
+    timestep: int
+    """Timestep associated with the computed results."""
+
+    basecase_voltage: pd.Series
+    """Voltage results from the base-case load-flow.
+
+    Used for comparison with contingency results and for computing
+    voltage differences.
+    """
+
+    slack_allocation_config: SlackAllocationConfig
+    """Configuration for assigning slack buses per electrical island.
+
+    Contains the network graph, bus lookup, and minimum island size
+    used to determine slack allocation during outages.
+    """
+
+    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema]
+    """Mapping between switches and connected elements.
+
+    Used for computing switch-level results during each outage.
+    """
+
+    spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
+    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
+    """SpPS condition and action tables for each outage (see :class:`SingleOutageContext`)."""
+
+    spps_rules_max_iterations: int = Field(default=10, ge=1)
+    """Maximum number of iterations for the SpPS engine.
+
+    Limits how many times rules can be evaluated and applied during
+    a single outage calculation.
+    """
+
+    method: Literal["ac", "dc"] = "ac"
+    """Load-flow method used for the base case and contingency calculations.
+
+    - ``"ac"`` runs a full AC power flow using :func:`pandapower.runpp`
+    - ``"dc"`` runs a DC approximation using :func:`pandapower.rundcpp`
+    """
+
+    runpp_kwargs: dict[str, Any] | None = None
+    """Additional keyword arguments forwarded to pandapower load-flow execution."""
+
+
+class ParallelContingencyAnalysisContext(BaseModel):
+    """Shared context for parallel N-1 contingency analysis.
+
+    This context extends the sequential configuration with parameters
+    required for parallel execution, such as worker count and batching.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    job_id: str
+    """Identifier of the current computation job."""
+
+    timestep: int
+    """Timestep associated with the computed results."""
+
+    slack_allocation_config: SlackAllocationConfig
+    """Configuration for slack bus allocation per electrical island."""
+
+    basecase_voltage: pd.Series
+    """Voltage results from the base-case load-flow."""
+
+    switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema]
+    """Mapping between switches and connected elements."""
+
+    spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
+    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
+    """SpPS condition and action tables for each outage."""
+
+    method: Literal["ac", "dc"] = "ac"
+    """Load-flow method used for the base case and contingency calculations.
+
+    - ``"ac"`` runs a full AC power flow using :func:`pandapower.runpp`
+    - ``"dc"`` runs a DC approximation using :func:`pandapower.rundcpp`
+    """
+
+    runpp_kwargs: dict[str, Any] | None = None
+    """Additional keyword arguments for pandapower load-flow execution."""
+
+    spps_rules_max_iterations: int = Field(default=10, ge=1)
+    """Maximum number of iterations for the SpPS engine.
+
+    Limits how many times rules can be evaluated and applied during
+    a single outage calculation.
     """
 
     parallel: ParallelConfig = Field(default_factory=ParallelConfig)

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -22,6 +22,13 @@ from toop_engine_interfaces.nminus1_definition import (
     Contingency,
     GridElement,
 )
+from toop_engine_interfaces.spps_parameters import (
+    SPPS_CONDITION_CHECK_TYPE_VALUES,
+    SPPS_CONDITION_SIDE_VALUES,
+    SPPS_CONDITION_TYPE_VALUES,
+    SPPS_MEASURE_TYPE_VALUES,
+    SppsPowerFlowFailurePolicy,
+)
 
 
 @dataclasses.dataclass
@@ -137,13 +144,13 @@ class SppsConditionsPandapowerSchema(pa.DataFrameModel):
     scheme_name: Series[str]
     """Name of the rule scheme: conditions with the same name are evaluated as one logical group."""
 
-    condition_type: Series[str] = pa.Field(isin=["current", "active_power", "reactive_power", "voltage", "state"])
+    condition_type: Series[str] = pa.Field(isin=SPPS_CONDITION_TYPE_VALUES)
     """What is being checked (e.g. current, power, voltage, or element state)."""
 
-    condition_check_type: Series[str] = pa.Field(isin=[">", "<", "=", "failed", "de_energized"])
+    condition_check_type: Series[str] = pa.Field(isin=SPPS_CONDITION_CHECK_TYPE_VALUES)
     """How the condition is evaluated (comparison or state check)."""
 
-    condition_side: Series[str] = pa.Field(isin=["primary", "secondary", "tertiary", "maximum_value"])
+    condition_side: Series[str] = pa.Field(isin=SPPS_CONDITION_SIDE_VALUES)
     """Which side or value of the element is used for the check."""
 
     condition_limit_value: Series[float] = pa.Field(
@@ -165,7 +172,7 @@ class SppsActionsPandapowerSchema(pa.DataFrameModel):
     scheme_name: Series[str]
     """Name of the rule scheme: actions in a scheme are applied when all its conditions pass."""
 
-    measure_type: Series[str] = pa.Field(isin=["active_power", "reactive_power", "voltage", "switching_state"])
+    measure_type: Series[str] = pa.Field(isin=SPPS_MEASURE_TYPE_VALUES)
     """What is applied when the scheme activates."""
 
     measure_value: Series[object]
@@ -310,6 +317,15 @@ class ContingencyAnalysisConfig(BaseModel):
     a single outage calculation.
     """
 
+    on_power_flow_error: SppsPowerFlowFailurePolicy = SppsPowerFlowFailurePolicy.RAISE
+    """SpPS in-loop power-flow policy (ignored when there are no SpPS rules).
+
+    Forwarded to ``run_spps``. :attr:`~SppsPowerFlowFailurePolicy.RAISE` re-raises
+    solver failures as ``SppsPowerFlowError``;
+    :attr:`~SppsPowerFlowFailurePolicy.KEEP_PREVIOUS` keeps the last successful
+    ``res_*`` state on failure; see the SpPS engine for details.
+    """
+
 
 class SingleOutageContext(BaseModel):
     """Shared execution context for a single outage calculation.
@@ -386,6 +402,15 @@ class SingleOutageContext(BaseModel):
     :func:`pandapower.rundcpp` depending on the selected method.
     """
 
+    on_power_flow_error: SppsPowerFlowFailurePolicy = SppsPowerFlowFailurePolicy.RAISE
+    """SpPS in-loop power-flow policy (ignored when there are no SpPS rules).
+
+        Forwarded to ``run_spps``. :attr:`~SppsPowerFlowFailurePolicy.RAISE` re-raises
+        solver failures as ``SppsPowerFlowError``;
+        :attr:`~SppsPowerFlowFailurePolicy.KEEP_PREVIOUS` keeps the last successful
+        ``res_*`` state on failure; see the SpPS engine for details.
+        """
+
 
 class SequentialContingencyAnalysisContext(BaseModel):
     """Shared context for sequential N-1 contingency analysis.
@@ -447,6 +472,15 @@ class SequentialContingencyAnalysisContext(BaseModel):
     runpp_kwargs: dict[str, Any] | None = None
     """Additional keyword arguments forwarded to pandapower load-flow execution."""
 
+    on_power_flow_error: SppsPowerFlowFailurePolicy = SppsPowerFlowFailurePolicy.RAISE
+    """SpPS in-loop power-flow policy (ignored when there are no SpPS rules).
+
+        Forwarded to ``run_spps``. :attr:`~SppsPowerFlowFailurePolicy.RAISE` re-raises
+        solver failures as ``SppsPowerFlowError``;
+        :attr:`~SppsPowerFlowFailurePolicy.KEEP_PREVIOUS` keeps the last successful
+        ``res_*`` state on failure; see the SpPS engine for details.
+        """
+
 
 class ParallelContingencyAnalysisContext(BaseModel):
     """Shared context for parallel N-1 contingency analysis.
@@ -492,6 +526,15 @@ class ParallelContingencyAnalysisContext(BaseModel):
     Limits how many times rules can be evaluated and applied during
     a single outage calculation.
     """
+
+    on_power_flow_error: SppsPowerFlowFailurePolicy = SppsPowerFlowFailurePolicy.RAISE
+    """SpPS in-loop power-flow policy (ignored when there are no SpPS rules).
+
+        Forwarded to ``run_spps``. :attr:`~SppsPowerFlowFailurePolicy.RAISE` re-raises
+        solver failures as ``SppsPowerFlowError``;
+        :attr:`~SppsPowerFlowFailurePolicy.KEEP_PREVIOUS` keeps the last successful
+        ``res_*`` state on failure; see the SpPS engine for details.
+        """
 
     parallel: ParallelConfig = Field(default_factory=ParallelConfig)
     """Parallel execution settings for contingency processing.

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -24,6 +24,7 @@ from toop_engine_interfaces.nminus1_definition import (
 )
 from toop_engine_interfaces.spps_parameters import (
     SPPS_CONDITION_CHECK_TYPE_VALUES,
+    SPPS_CONDITION_LOGIC_VALUES,
     SPPS_CONDITION_SIDE_VALUES,
     SPPS_CONDITION_TYPE_VALUES,
     SPPS_MEASURE_TYPE_VALUES,
@@ -144,6 +145,9 @@ class SppsConditionsPandapowerSchema(pa.DataFrameModel):
     scheme_name: Series[str]
     """Name of the rule scheme: conditions with the same name are evaluated as one logical group."""
 
+    condition_logic: Series[str] = pa.Field(isin=SPPS_CONDITION_LOGIC_VALUES)
+    """Per-row copy of the scheme's condition combination mode (``all`` vs ``any``); identical for all rows of a scheme."""
+
     condition_type: Series[str] = pa.Field(isin=SPPS_CONDITION_TYPE_VALUES)
     """What is being checked (e.g. current, power, voltage, or element state)."""
 
@@ -170,7 +174,7 @@ class SppsActionsPandapowerSchema(pa.DataFrameModel):
     """Pandera schema for resolved SpPS action rows (one row per action)."""
 
     scheme_name: Series[str]
-    """Name of the rule scheme: actions in a scheme are applied when all its conditions pass."""
+    """Name of the rule scheme: actions apply when that scheme's conditions pass per ``condition_logic``."""
 
     measure_type: Series[str] = pa.Field(isin=SPPS_MEASURE_TYPE_VALUES)
     """What is applied when the scheme activates."""
@@ -220,7 +224,8 @@ class PandapowerNMinus1Definition(BaseModel):
     Each row is one check (voltage, current, power, element state, etc.); columns
     follow the SpPS conditions schema (including ``scheme_name``). All rows with
     the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
-    engine iteration when every one of its conditions is met. This table is copied
+    engine iteration according to each row's ``condition_logic`` (``all`` or ``any``).
+    This table is copied
     into each per-outage execution context and evaluated against the post-outage
     network. If it is empty, no SpPS is run: each contingency uses a standard
     pandapower load flow only, and any ``spps_actions`` data are ignored.
@@ -231,8 +236,8 @@ class PandapowerNMinus1Definition(BaseModel):
 
      Each row is one control step (e.g. switch a device, set a tap) tied to
      ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
-     linked to the conditions table by the same ``scheme_name``: when all
-     conditions of that scheme are satisfied, the SpPS engine applies the ordered
+     linked to the conditions table by the same ``scheme_name``: when that scheme's
+     conditions pass (per ``condition_logic`` on condition rows), the SpPS engine applies the ordered
      set of actions for that scheme, then re-runs the load flow, and repeats until
      no scheme triggers or the iteration cap is hit. The table is passed through
      to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
@@ -408,7 +413,8 @@ class SingleOutageContext(BaseModel):
     Each row is one check (voltage, current, power, element state, etc.); columns
     follow the SpPS conditions schema (including ``scheme_name``). All rows with
     the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
-    engine iteration when every one of its conditions is met. This table is copied
+    engine iteration according to each row's ``condition_logic`` (``all`` or ``any``).
+    This table is copied
     into each per-outage execution context and evaluated against the post-outage
     network. If it is empty, no SpPS is run: each contingency uses a standard
     pandapower load flow only, and any ``spps_actions`` data are ignored.
@@ -419,8 +425,8 @@ class SingleOutageContext(BaseModel):
 
      Each row is one control step (e.g. switch a device, set a tap) tied to
      ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
-     linked to the conditions table by the same ``scheme_name``: when all
-     conditions of that scheme are satisfied, the SpPS engine applies the ordered
+     linked to the conditions table by the same ``scheme_name``: when that scheme's
+     conditions pass (per ``condition_logic`` on condition rows), the SpPS engine applies the ordered
      set of actions for that scheme, then re-runs the load flow, and repeats until
      no scheme triggers or the iteration cap is hit. The table is passed through
      to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
@@ -498,7 +504,8 @@ class SequentialContingencyAnalysisContext(BaseModel):
     Each row is one check (voltage, current, power, element state, etc.); columns
     follow the SpPS conditions schema (including ``scheme_name``). All rows with
     the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
-    engine iteration when every one of its conditions is met. This table is copied
+    engine iteration according to each row's ``condition_logic`` (``all`` or ``any``).
+    This table is copied
     into each per-outage execution context and evaluated against the post-outage
     network. If it is empty, no SpPS is run: each contingency uses a standard
     pandapower load flow only, and any ``spps_actions`` data are ignored.
@@ -509,8 +516,8 @@ class SequentialContingencyAnalysisContext(BaseModel):
 
     Each row is one control step (e.g. switch a device, set a tap) tied to
     ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
-    linked to the conditions table by the same ``scheme_name``: when all
-    conditions of that scheme are satisfied, the SpPS engine applies the ordered
+    linked to the conditions table by the same ``scheme_name``: when that scheme's
+    conditions pass (per ``condition_logic`` on condition rows), the SpPS engine applies the ordered
     set of actions for that scheme, then re-runs the load flow, and repeats until
     no scheme triggers or the iteration cap is hit. The table is passed through
     to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
@@ -576,7 +583,8 @@ class ParallelContingencyAnalysisContext(BaseModel):
     Each row is one check (voltage, current, power, element state, etc.); columns
     follow the SpPS conditions schema (including ``scheme_name``). All rows with
     the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
-    engine iteration when every one of its conditions is met. This table is copied
+    engine iteration according to each row's ``condition_logic`` (``all`` or ``any``).
+    This table is copied
     into each parallel worker and into each per-outage execution context, and is
     evaluated on the post-outage network. If it is empty, no SpPS is run: each
     contingency uses a standard pandapower load flow only, and any
@@ -587,8 +595,8 @@ class ParallelContingencyAnalysisContext(BaseModel):
 
     Each row is one control step (e.g. switch a device, set a tap) tied to
     ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
-    linked to the conditions table by the same ``scheme_name``: when all
-    conditions of that scheme are satisfied, the SpPS engine applies the ordered
+    linked to the conditions table by the same ``scheme_name``: when that scheme's
+    conditions pass (per ``condition_logic`` on condition rows), the SpPS engine applies the ordered
     set of actions for that scheme, then re-runs the load flow, and repeats until
     no scheme triggers or the iteration cap is hit. The same tables are used
     across all parallel workers and for each outage. If ``spps_conditions`` is

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -215,9 +215,31 @@ class PandapowerNMinus1Definition(BaseModel):
     """A dictionary mapping the element kind to a list of element ids that are monitored."""
 
     spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema] = Field(default_factory=_default_spps_conditions)
-    """Resolved SpPS conditions (monitoring) keyed by ``scheme_name``."""
+    """Resolved SpPS condition rows for the entire N-1 job.
+
+    Each row is one check (voltage, current, power, element state, etc.); columns
+    follow the SpPS conditions schema (including ``scheme_name``). All rows with
+    the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
+    engine iteration when every one of its conditions is met. This table is copied
+    into each per-outage execution context and evaluated against the post-outage
+    network. If it is empty, no SpPS is run: each contingency uses a standard
+    pandapower load flow only, and any ``spps_actions`` data are ignored.
+    """
+
     spps_actions: pat.DataFrame[SppsActionsPandapowerSchema] = Field(default_factory=_default_spps_actions)
-    """Resolved SpPS actions (setpoints) keyed by ``scheme_name``."""
+    """Resolved SpPS action rows for the entire N-1 job.
+
+     Each row is one control step (e.g. switch a device, set a tap) tied to
+     ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
+     linked to the conditions table by the same ``scheme_name``: when all
+     conditions of that scheme are satisfied, the SpPS engine applies the ordered
+     set of actions for that scheme, then re-runs the load flow, and repeats until
+     no scheme triggers or the iteration cap is hit. The table is passed through
+     to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
+     executed and this table is not applied. If conditions are non-empty, action
+     rows are expected to match the project ruleset (typically one or more
+     actions per defined scheme).
+     """
 
     missing_elements: list[GridElement]
     """A list of monitored elements that were not found in the network."""
@@ -381,12 +403,31 @@ class SingleOutageContext(BaseModel):
     """
 
     spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
-    """SpPS conditions for the outage (see ``spps_actions`` for matching actions)."""
-    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
-    """SpPS actions applied when a scheme's conditions are all satisfied.
+    """Resolved SpPS condition rows for the entire N-1 job.
 
-    If ``spps_conditions`` is empty, a standard load flow is executed.
+    Each row is one check (voltage, current, power, element state, etc.); columns
+    follow the SpPS conditions schema (including ``scheme_name``). All rows with
+    the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
+    engine iteration when every one of its conditions is met. This table is copied
+    into each per-outage execution context and evaluated against the post-outage
+    network. If it is empty, no SpPS is run: each contingency uses a standard
+    pandapower load flow only, and any ``spps_actions`` data are ignored.
     """
+
+    spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
+    """Resolved SpPS action rows for the entire N-1 job.
+
+     Each row is one control step (e.g. switch a device, set a tap) tied to
+     ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
+     linked to the conditions table by the same ``scheme_name``: when all
+     conditions of that scheme are satisfied, the SpPS engine applies the ordered
+     set of actions for that scheme, then re-runs the load flow, and repeats until
+     no scheme triggers or the iteration cap is hit. The table is passed through
+     to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
+     executed and this table is not applied. If conditions are non-empty, action
+     rows are expected to match the project ruleset (typically one or more
+     actions per defined scheme).
+     """
 
     spps_rules_max_iterations: int = Field(default=10, ge=1)
     """Maximum number of iterations for the SpPS engine.
@@ -452,8 +493,31 @@ class SequentialContingencyAnalysisContext(BaseModel):
     """
 
     spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
+    """Resolved SpPS condition rows for the entire N-1 job.
+
+    Each row is one check (voltage, current, power, element state, etc.); columns
+    follow the SpPS conditions schema (including ``scheme_name``). All rows with
+    the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
+    engine iteration when every one of its conditions is met. This table is copied
+    into each per-outage execution context and evaluated against the post-outage
+    network. If it is empty, no SpPS is run: each contingency uses a standard
+    pandapower load flow only, and any ``spps_actions`` data are ignored.
+    """
+
     spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
-    """SpPS condition and action tables for each outage (see :class:`SingleOutageContext`)."""
+    """Resolved SpPS action rows for the entire N-1 job.
+
+    Each row is one control step (e.g. switch a device, set a tap) tied to
+    ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
+    linked to the conditions table by the same ``scheme_name``: when all
+    conditions of that scheme are satisfied, the SpPS engine applies the ordered
+    set of actions for that scheme, then re-runs the load flow, and repeats until
+    no scheme triggers or the iteration cap is hit. The table is passed through
+    to each per-outage run. If ``spps_conditions`` is empty, a normal load flow is
+    executed and this table is not applied. If conditions are non-empty, action
+    rows are expected to match the project ruleset (typically one or more
+    actions per defined scheme).
+    """
 
     spps_rules_max_iterations: int = Field(default=10, ge=1)
     """Maximum number of iterations for the SpPS engine.
@@ -507,8 +571,31 @@ class ParallelContingencyAnalysisContext(BaseModel):
     """Mapping between switches and connected elements."""
 
     spps_conditions: pat.DataFrame[SppsConditionsPandapowerSchema]
+    """Resolved SpPS condition rows for the entire N-1 job.
+
+    Each row is one check (voltage, current, power, element state, etc.); columns
+    follow the SpPS conditions schema (including ``scheme_name``). All rows with
+    the same ``scheme_name`` belong to one scheme: that scheme is satisfied in an
+    engine iteration when every one of its conditions is met. This table is copied
+    into each parallel worker and into each per-outage execution context, and is
+    evaluated on the post-outage network. If it is empty, no SpPS is run: each
+    contingency uses a standard pandapower load flow only, and any
+    ``spps_actions`` data are ignored.
+    """
     spps_actions: pat.DataFrame[SppsActionsPandapowerSchema]
-    """SpPS condition and action tables for each outage."""
+    """Resolved SpPS action rows for the entire N-1 job.
+
+    Each row is one control step (e.g. switch a device, set a tap) tied to
+    ``scheme_name``; column meanings follow the SpPS actions schema. A scheme is
+    linked to the conditions table by the same ``scheme_name``: when all
+    conditions of that scheme are satisfied, the SpPS engine applies the ordered
+    set of actions for that scheme, then re-runs the load flow, and repeats until
+    no scheme triggers or the iteration cap is hit. The same tables are used
+    across all parallel workers and for each outage. If ``spps_conditions`` is
+    empty, a normal load flow is executed and this table is not applied. If
+    conditions are non-empty, action rows are expected to match the project
+    ruleset (typically one or more actions per defined scheme).
+    """
 
     method: Literal["ac", "dc"] = "ac"
     """Load-flow method used for the base case and contingency calculations.

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
@@ -174,7 +174,7 @@ def translate_spps_rules(
     Returns
     -------
     pat.DataFrame[SppsConditionsPandapowerSchema]
-        One row per condition; uses ``scheme_name`` to group with actions.
+        One row per condition; uses ``scheme_name`` (and ``condition_logic``) to group with actions.
     pat.DataFrame[SppsActionsPandapowerSchema]
         One row per action; uses ``scheme_name`` to group with conditions.
     list[SppsRule]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
@@ -17,11 +17,15 @@ from toop_engine_contingency_analysis.pandapower.pandapower_helpers.extractors i
     extract_contingencies_with_unique_pandapower_id,
     extract_monitored_elements_with_cgmes_id,
     extract_monitored_elements_with_unique_pandapower_id,
+    extract_spps_rules_with_cgmes_id,
+    extract_spps_rules_with_unique_pandapower_id,
 )
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     PandapowerContingency,
     PandapowerMonitoredElementSchema,
     PandapowerNMinus1Definition,
+    SppsActionsPandapowerSchema,
+    SppsConditionsPandapowerSchema,
 )
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.va_diff_info import get_va_diff_info
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import (
@@ -33,6 +37,7 @@ from toop_engine_interfaces.nminus1_definition import (
     Contingency,
     GridElement,
     Nminus1Definition,
+    SppsRule,
 )
 
 
@@ -146,6 +151,48 @@ def get_node_to_switch_map(net: pandapowerNet, id_type: PANDAPOWER_SUPPORTED_ID_
     return node_to_switch_map
 
 
+def translate_spps_rules(
+    net: pandapowerNet,
+    rules: list[SppsRule],
+    id_type: PANDAPOWER_SUPPORTED_ID_TYPES = "unique_pandapower",
+) -> tuple[
+    pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
+]:
+    """Translate SpPS rules to pandapower-ready condition and action DataFrames.
+
+    Parameters
+    ----------
+    net : pandapowerNet
+        The pandapower network to use for the translation. Used to resolve
+        each condition's ``condition_element_unique_id`` and each action's
+        ``measure_element_unique_id`` into a pandapower
+        ``(table, table_id)`` pair.
+    rules : list[SppsRule]
+        The list of SpPS rules to translate.
+    id_type: PANDAPOWER_SUPPORTED_ID_TYPES
+        The type of ids to use for the contingencies. Currently, only "unique_pandapower" and "cgmes" are supported.
+
+    Returns
+    -------
+    pat.DataFrame[SppsConditionsPandapowerSchema]
+        One row per condition; uses ``scheme_name`` to group with actions.
+    pat.DataFrame[SppsActionsPandapowerSchema]
+        One row per action; uses ``scheme_name`` to group with conditions.
+    list[SppsRule]
+        SpPS rules that could not be translated because a referenced element
+        was not found in ``net`` (or, for ``"unique_pandapower"``, the id
+        could not be parsed).
+    list[str]
+        A list of ids that were not unique in the grid. This is only relevant
+        for cgmes ids.
+    """
+    if id_type == "unique_pandapower":
+        return extract_spps_rules_with_unique_pandapower_id(net, rules)
+    if id_type == "cgmes":
+        return extract_spps_rules_with_cgmes_id(net, rules)
+    raise ValueError(f"Unsupported id_type: {id_type}. Supported id_types are: ['unique_pandapower', 'cgmes']")
+
+
 def translate_contingencies(
     net: pandapowerNet, contingencies: list[Contingency], id_type: ELEMENT_ID_TYPES = "unique_pandapower"
 ) -> tuple[list[PandapowerContingency], list[Contingency], list[str]]:
@@ -249,10 +296,16 @@ def translate_nminus1_for_pandapower(
         net, n_minus_1_definition.contingencies, id_type=id_type
     )
 
+    spps_conditions, spps_actions, _missing_spps_rules, duplicated_spps_ids = translate_spps_rules(
+        net, n_minus_1_definition.spps_rules, id_type=id_type
+    )
+
     return PandapowerNMinus1Definition(
         monitored_elements=pandapower_monitored_elements,
         missing_elements=missing_elements,
         contingencies=contingencies,
         missing_contingencies=missing_contingencies,
-        duplicated_grid_elements=duplicated_monitored_ids + duplicated_outaged_element_ids,
+        spps_conditions=spps_conditions,
+        spps_actions=spps_actions,
+        duplicated_grid_elements=duplicated_monitored_ids + duplicated_outaged_element_ids + duplicated_spps_ids,
     )

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/translators.py
@@ -7,6 +7,8 @@
 
 """Translation utilities for converting N-1 definitions into pandapower-ready monitored elements and contingencies."""
 
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 import pandera.typing as pat
@@ -153,7 +155,7 @@ def get_node_to_switch_map(net: pandapowerNet, id_type: PANDAPOWER_SUPPORTED_ID_
 
 def translate_spps_rules(
     net: pandapowerNet,
-    rules: list[SppsRule],
+    rules: Optional[list[SppsRule]],
     id_type: PANDAPOWER_SUPPORTED_ID_TYPES = "unique_pandapower",
 ) -> tuple[
     pat.DataFrame[SppsConditionsPandapowerSchema], pat.DataFrame[SppsActionsPandapowerSchema], list[SppsRule], list[str]
@@ -163,11 +165,8 @@ def translate_spps_rules(
     Parameters
     ----------
     net : pandapowerNet
-        The pandapower network to use for the translation. Used to resolve
-        each condition's ``condition_element_unique_id`` and each action's
-        ``measure_element_unique_id`` into a pandapower
-        ``(table, table_id)`` pair.
-    rules : list[SppsRule]
+        The pandapower network to use for the translation.
+    rules : Optional[list[SppsRule]]
         The list of SpPS rules to translate.
     id_type: PANDAPOWER_SUPPORTED_ID_TYPES
         The type of ids to use for the contingencies. Currently, only "unique_pandapower" and "cgmes" are supported.
@@ -281,8 +280,8 @@ def translate_nminus1_for_pandapower(
 
     Returns
     -------
-    PowsyblNMinus1Definition
-        The translated N-1 definition that can be used in Powsybl.
+    PandapowerNMinus1Definition
+        The translated N-1 definition that can be used in Pandapower.
     """
     id_type = n_minus_1_definition.id_type or "unique_pandapower"
     # If no id_type is specified, we assume pandapower's unique ids

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
@@ -8,13 +8,27 @@ from toop_engine_contingency_analysis.pandapower.spps.schema import (
     RESULT_COLUMNS,
     SppsResult,
 )
+from toop_engine_interfaces.spps_parameters import (
+    SppsConditionCheckType,
+    SppsConditionSide,
+    SppsConditionType,
+    SppsMeasureType,
+    SppsPowerFlowFailurePolicy,
+    SppsSwitchActionTarget,
+)
 
 __all__ = [
     "ACTION_COLUMNS",
     "ELEMENT_TABLES",
     "RESULT_COLUMNS",
+    "SppsConditionCheckType",
+    "SppsConditionSide",
+    "SppsConditionType",
     "SppsError",
+    "SppsMeasureType",
     "SppsPowerFlowError",
+    "SppsPowerFlowFailurePolicy",
     "SppsResult",
+    "SppsSwitchActionTarget",
     "run_spps",
 ]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
@@ -17,6 +17,7 @@ from toop_engine_contingency_analysis.pandapower.spps.schema import (
 )
 from toop_engine_interfaces.spps_parameters import (
     SppsConditionCheckType,
+    SppsConditionLogic,
     SppsConditionSide,
     SppsConditionType,
     SppsMeasureType,
@@ -29,6 +30,7 @@ __all__ = [
     "ELEMENT_TABLES",
     "RESULT_COLUMNS",
     "SppsConditionCheckType",
+    "SppsConditionLogic",
     "SppsConditionSide",
     "SppsConditionType",
     "SppsError",

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
 """SpPS (Special Protection Scheme) rule engine."""
 
 from toop_engine_contingency_analysis.pandapower.spps.engine import run_spps

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/__init__.py
@@ -1,0 +1,20 @@
+"""SpPS (Special Protection Scheme) rule engine."""
+
+from toop_engine_contingency_analysis.pandapower.spps.engine import run_spps
+from toop_engine_contingency_analysis.pandapower.spps.errors import SppsError, SppsPowerFlowError
+from toop_engine_contingency_analysis.pandapower.spps.schema import (
+    ACTION_COLUMNS,
+    ELEMENT_TABLES,
+    RESULT_COLUMNS,
+    SppsResult,
+)
+
+__all__ = [
+    "ACTION_COLUMNS",
+    "ELEMENT_TABLES",
+    "RESULT_COLUMNS",
+    "SppsError",
+    "SppsPowerFlowError",
+    "SppsResult",
+    "run_spps",
+]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -326,7 +326,7 @@ def _evaluate_conditions(conditions: pat.DataFrame[SppsConditionsPandapowerSchem
     Parameters
     ----------
     conditions : pat.DataFrame[SppsConditionsPandapowerSchema]
-        Rule rows. Must have ``condition_check_type``, ``condition_element_value``,
+        Conditions rows. Must have ``condition_check_type``, ``condition_element_value``,
         ``condition_limit_value``, and for state checks the ``failed`` and
         ``energized`` columns from :func:`_populate_failed` and
         :func:`_populate_energized`. Mutated in place.
@@ -369,8 +369,7 @@ def _satisfied_scheme_names(conditions: pat.DataFrame[SppsConditionsPandapowerSc
     Parameters
     ----------
     conditions
-        Conditions SppsConditionsPandapowerSchema with ``is_condition`` populated by
-        :func:`_evaluate_conditions`.
+        Conditions SppsConditionsPandapowerSchema
     """
     satisfied = conditions["is_condition"].fillna(False).groupby(conditions["scheme_name"]).all()
     return set(satisfied[satisfied].index.tolist())
@@ -382,13 +381,27 @@ def _satisfied_scheme_names(conditions: pat.DataFrame[SppsConditionsPandapowerSc
 
 
 def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
-    """Apply every switch-targeted action by writing ``net.switch.closed``.
+    """Apply switch rows in *actions* by writing ``net.switch.closed``.
 
-    For string ``measure_value``, **closed** is recognized case-insensitively
-    (e.g. ``"closed"`` or ``"Closed"``). Any other string, including
-    ``"open"`` / ``"Open"``, sets ``closed = False``.
+    Only rows with ``measure_element_table == "switch"`` are considered.
+    ``measure_value`` is compared to :attr:`SppsSwitchActionTarget.CLOSED`
+    (wire value ``"closed"``); a match sets ``closed = True``, any other
+    value sets ``closed = False``. If there are no switch rows, this is a
+    no-op.
 
-    Mutates *net* in place.
+    Parameters
+    ----------
+    actions : pd.DataFrame
+        Must include ``measure_element_table``, ``measure_element_table_id``,
+        and ``measure_value``. Not modified.
+    net : pandapower.pandapowerNet
+        ``net.switch`` rows referenced by id are updated in place.
+
+    Returns
+    -------
+    None
+        *net.switch.closed* is written for the affected indices; *actions* is
+        unchanged.
     """
     sw = actions[actions["measure_element_table"] == "switch"]
     if sw.empty:
@@ -402,21 +415,29 @@ def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
 def _apply_actions(actions: pat.DataFrame[SppsActionsPandapowerSchema], net: pp.pandapowerNet) -> None:
     """Apply every action row in *actions* to *net*.
 
-    Dispatches as follows:
+    * Rows with ``measure_element_table == "switch"`` go to
+      :func:`_apply_switch_actions` (``net.switch.closed`` from ``measure_value``).
+    * All other supported ``(measure_element_table, measure_type)`` pairs are
+      resolved via :data:`ACTION_COLUMNS` to a column on ``net.<table>`` and
+      written with ``pd.to_numeric`` (``p_mw``, ``q_mvar``, ``vm_pu``, etc.).
 
-    * Switch rows → :func:`_apply_switch_actions` (string ``"Open"`` /
-      ``"Closed"``).
-    * Everything else → looked up in :data:`spps.schema.ACTION_COLUMNS` by
-      ``(measure_element_table, measure_type)`` and written as a numeric
-      value to the corresponding pandapower column (``p_mw``, ``q_mvar``,
-      ``vm_pu``, ...).
+    Voltage setpoints must already be in per-unit; see
+    :func:`spps.preprocessing.convert_voltage_rules_to_pu`. Combinations not
+    present in :data:`ACTION_COLUMNS` are skipped. If *actions* is empty,
+    this is a no-op.
 
-    Voltage ``measure_value`` must already be in per-unit — call
-    :func:`spps.preprocessing.convert_voltage_rules_to_pu` during
-    preprocessing. Rows whose ``(table, measure_type)`` pair isn't in
-    :data:`spps.schema.ACTION_COLUMNS` are silently skipped (no-op).
+    Parameters
+    ----------
+    actions : pat.DataFrame[SppsActionsPandapowerSchema]
+        One row per action to apply (``scheme_name``, ``measure_element_table``,
+        ``measure_element_table_id``, ``measure_type``, ``measure_value``).
+    net : pandapower.pandapowerNet
+        Network whose element and switch tables are updated in place.
 
-    Mutates *net* in place.
+    Returns
+    -------
+    None
+        *net* is mutated; *actions* is not modified.
     """
     if actions.empty:
         return

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -1,3 +1,10 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
 """Core rule-engine algorithm: ``run_spps`` and its private helpers.
 
 Mental model
@@ -41,6 +48,13 @@ from toop_engine_contingency_analysis.pandapower.spps.schema import (
     SppsResult,
 )
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR
+from toop_engine_interfaces.spps_parameters import (
+    SppsConditionCheckType,
+    SppsConditionSide,
+    SppsConditionType,
+    SppsPowerFlowFailurePolicy,
+    SppsSwitchActionTarget,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +73,7 @@ def _populate_energized(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
     * switches → ``net.switch.closed``
     * everything else → ``net.<table>.in_service``
 
-    The resulting ``energized`` column is used by both the ``"De-energized"``
+    The resulting ``energized`` column is used by both the ``"de_energized"``
     check (``energized == False``) and the NaN-based failure auto-detection
     inside :func:`_populate_failed` (only energized elements can legitimately
     be flagged as "failed in place").
@@ -101,11 +115,11 @@ def _populate_failed(
     failed_elements: set[str],
     net: pp.pandapowerNet,
 ) -> None:
-    """Write a ``failed`` boolean column onto *rules* for ``"Failed"`` checks.
+    """Write a ``failed`` boolean column onto *rules* for ``"failed"`` checks.
 
-    Only rows whose ``condition_check_type == "Failed"`` are evaluated; every
+    Only rows whose ``condition_check_type == "failed"`` are evaluated; every
     other row gets ``failed = False`` and is ignored by
-    :func:`_evaluate_conditions`'s "Failed" branch.
+    :func:`_evaluate_conditions`'s ``"failed"`` branch.
 
     A condition element is flagged as failed when **either**:
 
@@ -128,7 +142,7 @@ def _populate_failed(
         Pandapower network; only ``res_*`` tables are read.
     """
     rules["failed"] = False
-    failed_type_mask = rules["condition_check_type"] == "Failed"
+    failed_type_mask = rules["condition_check_type"] == SppsConditionCheckType.FAILED
     if not failed_type_mask.any():
         return
 
@@ -197,7 +211,7 @@ def _extract_res_values(
             continue
         all_cols = list(dict.fromkeys(sides.values()))
 
-        max_mask = type_mask & (rules["condition_side"] == "Maximum value")
+        max_mask = type_mask & (rules["condition_side"] == SppsConditionSide.MAXIMUM_VALUE)
         if max_mask.any():
             ids = rules.loc[max_mask, "condition_element_table_id"]
             vals = res_table.loc[ids, all_cols].abs()
@@ -223,7 +237,7 @@ def _extract_bus_voltage(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
 
     Mutates *rules* in place.
     """
-    mask = (rules["condition_element_table"] == "bus") & (rules["condition_type"] == "Voltage")
+    mask = (rules["condition_element_table"] == "bus") & (rules["condition_type"] == SppsConditionType.VOLTAGE)
     if not mask.any():
         return
     ids = rules.loc[mask, "condition_element_table_id"]
@@ -264,9 +278,9 @@ def _evaluate_conditions(rules: pd.DataFrame) -> None:
     * ``">"``  — ``condition_element_value > condition_limit_value``
     * ``"<"``  — ``condition_element_value < condition_limit_value``
     * ``"="``  — ``condition_element_value == condition_limit_value``
-    * ``"Failed"``       — the ``failed`` column populated by
+    * ``"failed"`` — the ``failed`` column populated by
       :func:`_populate_failed`
-    * ``"De-energized"`` — the ``energized`` column populated by
+    * ``"de_energized"`` — the ``energized`` column from
       :func:`_populate_energized` is explicitly ``False``
 
     Any NaN (e.g. unsupported element type, missing power-flow result)
@@ -282,19 +296,19 @@ def _evaluate_conditions(rules: pd.DataFrame) -> None:
     value = rules["condition_element_value"]
     limit = rules["condition_limit_value"]
 
-    gt_mask = check == ">"
+    gt_mask = check == SppsConditionCheckType.GT
     rules.loc[gt_mask, "is_condition"] = (value[gt_mask] > limit[gt_mask]).fillna(False)
 
-    lt_mask = check == "<"
+    lt_mask = check == SppsConditionCheckType.LT
     rules.loc[lt_mask, "is_condition"] = (value[lt_mask] < limit[lt_mask]).fillna(False)
 
-    eq_mask = check == "="
+    eq_mask = check == SppsConditionCheckType.EQ
     rules.loc[eq_mask, "is_condition"] = (value[eq_mask] == limit[eq_mask]).fillna(False)
 
-    failed_mask = check == "Failed"
+    failed_mask = check == SppsConditionCheckType.FAILED
     rules.loc[failed_mask, "is_condition"] = rules.loc[failed_mask, "failed"].fillna(False)
 
-    de_mask = check == "De-energized"
+    de_mask = check == SppsConditionCheckType.DE_ENERGIZED
     rules.loc[de_mask, "is_condition"] = (rules.loc[de_mask, "energized"] == False).fillna(False)  # noqa: E712
 
 
@@ -323,10 +337,9 @@ def _satisfied_scheme_names(conditions: pd.DataFrame) -> set[str]:
 def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
     """Apply every switch-targeted action by writing ``net.switch.closed``.
 
-    ``measure_value`` for switch rows is the string ``"Open"`` or
-    ``"Closed"``. Anything other than the literal string ``"Closed"`` is
-    interpreted as *open* (``closed = False``). Consider validating the
-    value upstream if you want strict error reporting on typos.
+    For string ``measure_value``, **closed** is recognized case-insensitively
+    (e.g. ``"closed"`` or ``"Closed"``). Any other string, including
+    ``"open"`` / ``"Open"``, sets ``closed = False``.
 
     Mutates *net* in place.
     """
@@ -334,7 +347,7 @@ def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
     if sw.empty:
         return
     ids = sw["measure_element_table_id"]
-    closed = (sw["measure_value"] == "Closed").to_numpy()
+    closed = sw["measure_value"] == SppsSwitchActionTarget.CLOSED.value
     net.switch.loc[ids, "closed"] = closed
     logger.debug("Applied %d switch actions (ids=%s)", len(sw), ids.tolist())
 
@@ -393,9 +406,9 @@ def _snapshot_res_tables(net: pp.pandapowerNet) -> dict[str, pd.DataFrame]:
 
     Each value is a full (deep) pandas ``DataFrame.copy()`` so subsequent
     solver calls cannot mutate it. Non-DataFrame entries under the ``res_``
-    prefix (if any) are ignored. Only used when
-    ``on_power_flow_error == "keep_previous"`` so the normal path pays no
-    copy cost.
+    prefix (if any) are ignored.     Only used when
+    :attr:`SppsPowerFlowFailurePolicy.KEEP_PREVIOUS` is selected so the normal
+    path pays no copy cost.
     """
     return {k: v.copy() for k, v in net.items() if k.startswith("res_") and isinstance(v, pd.DataFrame)}
 
@@ -445,7 +458,7 @@ def run_spps(
     method: Literal["ac", "dc"] = "ac",
     max_iterations: int = 1,
     runpp_kwargs: dict[str, Any] | None = None,
-    on_power_flow_error: Literal["raise", "keep_previous"] = "raise",
+    on_power_flow_error: SppsPowerFlowFailurePolicy = SppsPowerFlowFailurePolicy.RAISE,
 ) -> SppsResult:
     """Execute the SpPS rule engine.
 
@@ -459,7 +472,7 @@ def run_spps(
         Action rows sharing ``scheme_name`` with *conditions*:
         :class:`SppsActionsPandapowerSchema`.
     failed_elements
-        Compound uids of elements considered failed (for ``"Failed"`` checks).
+        Compound uids of elements considered failed (for ``"failed"`` checks).
         Each uid must follow the format ``f"{elem_id}{SEPARATOR}{elem_type}"``
         (see :func:`spps.schema.make_element_uid`) and can reference
         ``switch``, ``line``, ``bus``, ``trafo``, ``trafo3w``, ``impedance``,
@@ -469,12 +482,13 @@ def run_spps(
         ``"ac"`` (default) runs ``pp.runpp``; ``"dc"`` runs ``pp.rundcpp``.
     max_iterations
         Upper bound on iterations. The loop stops early when no scheme triggers.
+        After each batch of actions (including on the final iteration), a
+        power flow is run so ``res_*`` matches the updated net.
     runpp_kwargs
         Keyword arguments forwarded to the power-flow solver on every call.
     on_power_flow_error
-        Strategy for power-flow failures *inside* the iteration loop
-        (the initial PF always raises, as there is no previous state to fall
-        back on):
+        Strategy for power-flow failures after applying actions (the initial PF
+        always raises, as there is no previous state to fall back on):
 
         * ``"raise"`` (default) — wrap the underlying exception in
           :class:`spps.errors.SppsPowerFlowError` and re-raise.
@@ -493,8 +507,9 @@ def run_spps(
     Raises
     ------
     SppsPowerFlowError
-        If the initial power flow fails, or an iteration-level power flow
-        fails while ``on_power_flow_error="raise"``.
+        If the initial power flow fails, or a post-action power flow fails
+        while ``on_power_flow_error="raise"``. Subclasses of :class:`SppsError`
+        raised by the solver path are not double-wrapped.
     """
     schemes_per_iter: list[list[str]] = []
     activated_scheme_names: set[str] = set()
@@ -509,10 +524,7 @@ def run_spps(
     # are handled as "failed" instead of updating energized status dynamically.
     _populate_energized(conditions, net)
 
-    try:
-        _run_power_flow(net, method, runpp_kwargs)
-    except Exception as exc:
-        raise SppsPowerFlowError(f"Initial power flow failed; cannot run SpPS: {exc}") from exc
+    _run_power_flow(net, method, runpp_kwargs)
 
     for iteration in range(1, max_iterations + 1):
         iterations = iteration
@@ -546,23 +558,23 @@ def run_spps(
         activated_scheme_names.update(new_schemes)
         _apply_actions(active_actions, net)
 
-        if iteration < max_iterations:
-            snapshot = _snapshot_res_tables(net) if on_power_flow_error == "keep_previous" else None
-            try:
-                _run_power_flow(net, method, runpp_kwargs)
-            except Exception as exc:
-                if on_power_flow_error == "raise":
-                    raise SppsPowerFlowError(f"Power flow failed on iteration {iteration}: {exc}") from exc
-                logger.warning(
-                    "Power flow failed on iteration %d; keeping previous res_* tables and stopping loop: %s",
-                    iteration,
-                    exc,
-                )
-                if snapshot is not None:
-                    _restore_res_tables(net, snapshot)
-                power_flow_failed = True
-                break
-        else:
+        snapshot = _snapshot_res_tables(net) if on_power_flow_error == SppsPowerFlowFailurePolicy.KEEP_PREVIOUS else None
+        try:
+            _run_power_flow(net, method, runpp_kwargs)
+        except Exception as exc:
+            if on_power_flow_error == SppsPowerFlowFailurePolicy.RAISE:
+                raise SppsPowerFlowError(f"Power flow failed on iteration {iteration}: {exc}") from exc
+            logger.warning(
+                "Power flow failed on iteration %d; keeping previous res_* tables and stopping loop: %s",
+                iteration,
+                exc,
+            )
+            if snapshot is not None:
+                _restore_res_tables(net, snapshot)
+            power_flow_failed = True
+            break
+
+        if iteration == max_iterations:
             max_iterations_reached = True
 
     if max_iterations_reached:
@@ -570,6 +582,11 @@ def run_spps(
             "SpPS exhausted max_iterations=%d while still activating schemes.",
             max_iterations,
         )
+
+        if on_power_flow_error == SppsPowerFlowFailurePolicy.RAISE:
+            raise SppsPowerFlowError(
+                f"SpPS exhausted max_iterations={max_iterations} while new schemes were still activating."
+            )
 
     return SppsResult(
         net=net,

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -64,35 +64,44 @@ logger = logging.getLogger(__name__)
 # --------------------------------------------------------------------------- #
 
 
-def _populate_energized(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
-    """Write an ``energized`` boolean column onto *rules* from the network state.
+def _populate_energized(conditions: pat.DataFrame[SppsConditionsPandapowerSchema], net: pp.pandapowerNet) -> None:
+    """Write an ``energized`` boolean column onto *conditions* from the network state.
 
-    For each rule row, look up the condition element in its pandapower table
-    and read a single "is it electrically alive?" flag:
+    For each row, the condition element is looked up in its pandapower table
+    and a single "electrically alive" flag is read:
 
-    * switches → ``net.switch.closed``
-    * everything else → ``net.<table>.in_service``
+    * ``switch`` → ``net.switch.closed`` (``True`` = closed = energized)
+    * any other table in :data:`ELEMENT_TABLES` → ``net.<table>.in_service``
 
-    The resulting ``energized`` column is used by both the ``"de_energized"``
-    check (``energized == False``) and the NaN-based failure auto-detection
-    inside :func:`_populate_failed` (only energized elements can legitimately
-    be flagged as "failed in place").
+    The ``energized`` column is used for the wire value ``de_energized`` in
+    :func:`_evaluate_conditions` and for NaN-based auto-detection in
+    :func:`_populate_failed` (only energized elements can be marked failed
+    in place from result tables). Tables not in :data:`ELEMENT_TABLES` leave
+    ``pd.NA`` for that row. Column dtype is nullable pandas ``"boolean"``.
 
-    Rules whose ``condition_element_table`` does not match any registered
-    table keep a ``pd.NA`` (no value). The column dtype is pandas'
-    ``"boolean"`` (nullable).
+    Parameters
+    ----------
+    conditions : pat.DataFrame[SppsConditionsPandapowerSchema]
+        Condition rows; must include ``condition_element_table`` and
+        ``condition_element_table_id``. Mutated in place.
+    net : pandapower.pandapowerNet
+        Network whose static element tables (``switch`` / ``in_service``) are
+        read. Not modified.
 
-    Mutates *rules* in place; does not touch *net*.
+    Returns
+    -------
+    None
+        *conditions* gains a new ``energized`` column; *net* is unchanged.
     """
-    rules["energized"] = pd.Series(pd.NA, index=rules.index, dtype="boolean")
+    conditions["energized"] = pd.Series(pd.NA, index=conditions.index, dtype="boolean")
     for table in ELEMENT_TABLES:
-        mask = rules["condition_element_table"] == table
+        mask = conditions["condition_element_table"] == table
         if not mask.any():
             continue
-        ids = rules.loc[mask, "condition_element_table_id"]
+        ids = conditions.loc[mask, "condition_element_table_id"]
         element_df = getattr(net, table)
         col = "closed" if table == "switch" else "in_service"
-        rules.loc[mask, "energized"] = element_df.loc[ids, col].to_numpy()
+        conditions.loc[mask, "energized"] = element_df.loc[ids, col].to_numpy()
 
 
 _FAILURE_RESULT_TABLES: Final[tuple[str, ...]] = (
@@ -111,11 +120,11 @@ _FAILURE_RESULT_TABLES: Final[tuple[str, ...]] = (
 
 
 def _populate_failed(
-    rules: pd.DataFrame,
+    conditions: pat.DataFrame[SppsConditionsPandapowerSchema],
     failed_elements: set[str],
     net: pp.pandapowerNet,
 ) -> None:
-    """Write a ``failed`` boolean column onto *rules* for ``"failed"`` checks.
+    """Write a ``failed`` boolean column onto *conditions* for ``"failed"`` checks.
 
     Only rows whose ``condition_check_type == "failed"`` are evaluated; every
     other row gets ``failed = False`` and is ignored by
@@ -133,36 +142,39 @@ def _populate_failed(
 
     Parameters
     ----------
-    rules
-        Rules DataFrame. Must already have ``energized`` populated (see
+    conditions
+        Conditions DataFrame. Must already have ``energized`` populated (see
         :func:`_populate_energized`). Mutated in place.
     failed_elements
         Set of compound uids (see :func:`spps.schema.make_element_uid`).
     net
         Pandapower network; only ``res_*`` tables are read.
     """
-    rules["failed"] = False
-    failed_type_mask = rules["condition_check_type"] == SppsConditionCheckType.FAILED
+    conditions["failed"] = False
+    failed_type_mask = conditions["condition_check_type"] == SppsConditionCheckType.FAILED
     if not failed_type_mask.any():
         return
 
-    uids = rules["condition_element_table_id"].astype(str) + SEPARATOR + rules["condition_element_table"].astype(str)
-    rules.loc[failed_type_mask, "failed"] = uids.loc[failed_type_mask].isin(failed_elements).to_numpy()
+    uids = (
+        conditions["condition_element_table_id"].astype(str) + SEPARATOR + conditions["condition_element_table"].astype(str)
+    )
 
-    energized = rules["energized"].fillna(False).astype(bool)
+    conditions.loc[failed_type_mask, "failed"] = uids.loc[failed_type_mask].isin(failed_elements).to_numpy()
+
+    energized = conditions["energized"].fillna(False).astype(bool)
 
     for table in _FAILURE_RESULT_TABLES:
-        mask = (rules["condition_element_table"] == table) & failed_type_mask
+        mask = (conditions["condition_element_table"] == table) & failed_type_mask
         if not mask.any():
             continue
         res = getattr(net, f"res_{table}", None)
         if res is None or res.empty:
             continue
 
-        ids = rules.loc[mask, "condition_element_table_id"]
+        ids = conditions.loc[mask, "condition_element_table_id"]
         has_nan = res.reindex(ids).isna().any(axis=1).to_numpy()
         auto = energized.loc[mask].to_numpy() & has_nan
-        rules.loc[mask, "failed"] = rules.loc[mask, "failed"].to_numpy() | auto
+        conditions.loc[mask, "failed"] = conditions.loc[mask, "failed"].to_numpy() | auto
 
 
 # --------------------------------------------------------------------------- #
@@ -226,43 +238,67 @@ def _extract_res_values(
             rules.loc[mask, "condition_element_value"] = res_table.loc[ids, col].abs().to_numpy()
 
 
-def _extract_bus_voltage(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
+def _extract_bus_voltage(conditions: pat.DataFrame[SppsConditionsPandapowerSchema], net: pp.pandapowerNet) -> None:
     """Copy bus voltage magnitudes (p.u.) into ``condition_element_value``.
 
-    Applies only to rows where ``condition_element_table == "bus"`` and
-    ``condition_type == "Voltage"``. The engine works entirely in p.u. for
-    voltage — callers must convert ``condition_limit_value`` to p.u.
-    up-front (see :func:`spps.preprocessing.convert_voltage_rules_to_pu`)
-    so the comparison in :func:`_evaluate_conditions` is unit-consistent.
+    Only rows with ``condition_element_table == "bus"`` and
+    ``condition_type`` equal to :attr:`SppsConditionType.VOLTAGE` are updated;
+    ``vm_pu`` is read from ``net.res_bus``. All voltages in this path are in
+    per-unit; ``condition_limit_value`` for those rows should already be in
+    p.u. (see :func:`spps.preprocessing.convert_voltage_rules_to_pu`) so
+    :func:`_evaluate_conditions` compares like units.
 
-    Mutates *rules* in place.
+    Parameters
+    ----------
+    conditions : pat.DataFrame[SppsConditionsPandapowerSchema]
+        Rule rows; must already have ``condition_element_value`` (typically
+        pre-filled by :func:`_extract_condition_values`). Mutated in place.
+    net : pandapower.pandapowerNet
+        Network with ``res_bus`` containing ``vm_pu`` for the current solve.
+        Not modified.
+
+    Returns
+    -------
+    None
+        Matching rows in *conditions* get ``condition_element_value`` from
+        ``res_bus``; other rows are left unchanged by this helper.
     """
-    mask = (rules["condition_element_table"] == "bus") & (rules["condition_type"] == SppsConditionType.VOLTAGE)
+    mask = (conditions["condition_element_table"] == "bus") & (conditions["condition_type"] == SppsConditionType.VOLTAGE)
     if not mask.any():
         return
-    ids = rules.loc[mask, "condition_element_table_id"]
-    rules.loc[mask, "condition_element_value"] = net.res_bus.loc[ids, "vm_pu"].to_numpy()
+    ids = conditions.loc[mask, "condition_element_table_id"]
+    conditions.loc[mask, "condition_element_value"] = net.res_bus.loc[ids, "vm_pu"].to_numpy()
 
 
-def _extract_condition_values(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
+def _extract_condition_values(conditions: pat.DataFrame[SppsConditionsPandapowerSchema], net: pp.pandapowerNet) -> None:
     """Populate ``condition_element_value`` with the current power-flow result.
 
-    Initialises the column to NaN, then fills it from ``net.res_*`` tables:
+    The column is initialised to NaN for every row, then values are filled from
+    ``net`` result tables: branch-style elements (line, trafo, trafo3w) use
+    :data:`RESULT_COLUMNS` via :func:`_extract_res_values`, and bus rows use
+    :func:`_extract_bus_voltage`. Unmatched ``(condition_element_table,
+    condition_type, condition_side)`` combinations stay NaN and fail numeric
+    checks in :func:`_evaluate_conditions`.
 
-    * lines / trafos / trafo3w via :data:`spps.schema.RESULT_COLUMNS` and
-      :func:`_extract_res_values`;
-    * bus voltages via :func:`_extract_bus_voltage`.
+    Parameters
+    ----------
+    conditions : pat.DataFrame[SppsConditionsPandapowerSchema]
+        Rule rows; must include ``condition_element_table`` and related
+        condition columns. Mutated in place.
+    net : pandapower.pandapowerNet
+        Network with converged or last-good ``res_*`` tables (``res_bus``,
+        ``res_line``, etc.) for the current solve. Not modified.
 
-    Rows whose ``(condition_element_table, condition_type)`` combination is
-    not supported keep NaN, which then evaluates to ``False`` in every
-    numeric check inside :func:`_evaluate_conditions`.
-
-    Mutates *rules* in place.
+    Returns
+    -------
+    None
+        *conditions* gains a ``condition_element_value`` column (float); *net*
+        is unchanged.
     """
-    rules["condition_element_value"] = pd.Series(float("nan"), index=rules.index, dtype="float64")
+    conditions["condition_element_value"] = pd.Series(float("nan"), index=conditions.index, dtype="float64")
     for element_type, col_map in RESULT_COLUMNS.items():
-        _extract_res_values(rules, net, element_type, col_map)
-    _extract_bus_voltage(rules, net)
+        _extract_res_values(conditions, net, element_type, col_map)
+    _extract_bus_voltage(conditions, net)
 
 
 # --------------------------------------------------------------------------- #
@@ -270,49 +306,60 @@ def _extract_condition_values(rules: pd.DataFrame, net: pp.pandapowerNet) -> Non
 # --------------------------------------------------------------------------- #
 
 
-def _evaluate_conditions(rules: pd.DataFrame) -> None:
+def _evaluate_conditions(conditions: pat.DataFrame[SppsConditionsPandapowerSchema]) -> None:
     """Evaluate every rule's check and write the result into ``is_condition``.
 
-    Supported ``condition_check_type`` values and their semantics:
+    For each row, ``condition_check_type`` (see :class:`SppsConditionCheckType`
+    wire values) selects the branch:
 
-    * ``">"``  — ``condition_element_value > condition_limit_value``
-    * ``"<"``  — ``condition_element_value < condition_limit_value``
-    * ``"="``  — ``condition_element_value == condition_limit_value``
-    * ``"failed"`` — the ``failed`` column populated by
-      :func:`_populate_failed`
-    * ``"de_energized"`` — the ``energized`` column from
-      :func:`_populate_energized` is explicitly ``False``
+    * :attr:`SppsConditionCheckType.GT` / LT / EQ — compare ``condition_element_value`` to
+      ``condition_limit_value`` for numeric thresholds.
+    * :attr:`SppsConditionCheckType.FAILED` — use the ``failed`` column from
+      :func:`_populate_failed`.
+    * :attr:`SppsConditionCheckType.DE_ENERGIZED` — use ``energized`` from
+      :func:`_populate_energized` (pass when ``energized`` is false).
 
-    Any NaN (e.g. unsupported element type, missing power-flow result)
-    evaluates to ``False`` — missing data is never treated as a passing
-    condition. Rows with an unknown check type silently keep
-    ``is_condition = False``; consider adding stricter validation upstream.
+    NaNs in value/limit/failed/energized comparisons yield ``False`` for that
+    row. Unknown or unsupported check types keep ``is_condition == False``
+    (consider validating upstream with :class:`SppsConditionsPandapowerSchema`).
 
-    Mutates *rules* in place.
+    Parameters
+    ----------
+    conditions : pat.DataFrame[SppsConditionsPandapowerSchema]
+        Rule rows. Must have ``condition_check_type``, ``condition_element_value``,
+        ``condition_limit_value``, and for state checks the ``failed`` and
+        ``energized`` columns from :func:`_populate_failed` and
+        :func:`_populate_energized`. Mutated in place.
+
+    Returns
+    -------
+    None
+        *conditions* gets a boolean column ``is_condition`` (overwritten in full
+        on each call).
     """
-    rules["is_condition"] = False
+    conditions["is_condition"] = False
 
-    check = rules["condition_check_type"]
-    value = rules["condition_element_value"]
-    limit = rules["condition_limit_value"]
+    check = conditions["condition_check_type"]
+    value = conditions["condition_element_value"]
+    limit = conditions["condition_limit_value"]
 
     gt_mask = check == SppsConditionCheckType.GT
-    rules.loc[gt_mask, "is_condition"] = (value[gt_mask] > limit[gt_mask]).fillna(False)
+    conditions.loc[gt_mask, "is_condition"] = (value[gt_mask] > limit[gt_mask]).fillna(False)
 
     lt_mask = check == SppsConditionCheckType.LT
-    rules.loc[lt_mask, "is_condition"] = (value[lt_mask] < limit[lt_mask]).fillna(False)
+    conditions.loc[lt_mask, "is_condition"] = (value[lt_mask] < limit[lt_mask]).fillna(False)
 
     eq_mask = check == SppsConditionCheckType.EQ
-    rules.loc[eq_mask, "is_condition"] = (value[eq_mask] == limit[eq_mask]).fillna(False)
+    conditions.loc[eq_mask, "is_condition"] = (value[eq_mask] == limit[eq_mask]).fillna(False)
 
     failed_mask = check == SppsConditionCheckType.FAILED
-    rules.loc[failed_mask, "is_condition"] = rules.loc[failed_mask, "failed"].fillna(False)
+    conditions.loc[failed_mask, "is_condition"] = conditions.loc[failed_mask, "failed"].fillna(False)
 
     de_mask = check == SppsConditionCheckType.DE_ENERGIZED
-    rules.loc[de_mask, "is_condition"] = (rules.loc[de_mask, "energized"] == False).fillna(False)  # noqa: E712
+    conditions.loc[de_mask, "is_condition"] = ~conditions.loc[de_mask, "energized"].fillna(False)
 
 
-def _satisfied_scheme_names(conditions: pd.DataFrame) -> set[str]:
+def _satisfied_scheme_names(conditions: pat.DataFrame[SppsConditionsPandapowerSchema]) -> set[str]:
     """Return the names of schemes for which every condition row passes.
 
     A scheme is satisfied when **all** of its condition rows have
@@ -322,7 +369,7 @@ def _satisfied_scheme_names(conditions: pd.DataFrame) -> set[str]:
     Parameters
     ----------
     conditions
-        Conditions DataFrame with ``is_condition`` populated by
+        Conditions SppsConditionsPandapowerSchema with ``is_condition`` populated by
         :func:`_evaluate_conditions`.
     """
     satisfied = conditions["is_condition"].fillna(False).groupby(conditions["scheme_name"]).all()
@@ -347,12 +394,12 @@ def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
     if sw.empty:
         return
     ids = sw["measure_element_table_id"]
-    closed = sw["measure_value"] == SppsSwitchActionTarget.CLOSED.value
+    closed = (sw["measure_value"] == SppsSwitchActionTarget.CLOSED.value).to_numpy()
     net.switch.loc[ids, "closed"] = closed
     logger.debug("Applied %d switch actions (ids=%s)", len(sw), ids.tolist())
 
 
-def _apply_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
+def _apply_actions(actions: pat.DataFrame[SppsActionsPandapowerSchema], net: pp.pandapowerNet) -> None:
     """Apply every action row in *actions* to *net*.
 
     Dispatches as follows:
@@ -430,14 +477,30 @@ def _run_power_flow(
     method: Literal["ac", "dc"],
     runpp_kwargs: dict[str, Any],
 ) -> None:
-    """Dispatch to the right pandapower solver.
+    """Dispatch to the pandapower load-flow solver for *net*.
 
-    * ``method="ac"`` → :func:`pandapower.runpp` (Newton AC power flow).
-    * ``method="dc"`` → :func:`pandapower.rundcpp` (linear DC power flow).
+    * ``method="ac"`` — :func:`pandapower.runpp` (AC Newton power flow).
+    * ``method="dc"`` — :func:`pandapower.rundcpp` (linear DC power flow).
 
-    *runpp_kwargs* is forwarded verbatim. This helper exists so the
-    pre-loop call and every in-loop call go through the exact same code
-    path.
+    ``runpp_kwargs`` is forwarded unchanged. Used so the initial solve and every
+    in-loop solve share one code path. Exceptions (e.g. non-convergence) are
+    not caught here.
+
+    Parameters
+    ----------
+    net : pandapower.pandapowerNet
+        Network to solve; ``res_*`` and element tables are updated in place by
+        pandapower.
+    method : {"ac", "dc"}
+        ``"ac"`` for full AC, ``"dc"`` for DC approximation.
+    runpp_kwargs : dict[str, Any]
+        Extra keyword arguments for :func:`pandapower.runpp` or
+        :func:`pandapower.rundcpp` (empty dict is fine).
+
+    Returns
+    -------
+    None
+        *net* holds the solver result on success; on failure, pandapower raises.
     """
     if method == "dc":
         pp.rundcpp(net, **runpp_kwargs)

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -611,13 +611,16 @@ def run_spps(
     _run_power_flow(net, method, runpp_kwargs)
 
     for iteration in range(1, max_iterations + 1):
-        iterations = iteration
-
         _populate_failed(conditions, failed_elements, net)
         _extract_condition_values(conditions, net)
         _evaluate_conditions(conditions)
         candidate_schemes = _satisfied_scheme_names(conditions)
         new_schemes = sorted(n for n in candidate_schemes if n not in activated_scheme_names)
+        if not new_schemes:
+            logger.info("No new schemes triggered — stopping.")
+            break
+
+        iterations = iteration
         active_actions = actions[actions["scheme_name"].isin(new_schemes)].copy() if new_schemes else actions.iloc[0:0]
         active_actions = active_actions.assign(_iteration=iteration)
 
@@ -629,10 +632,6 @@ def run_spps(
             len(active_actions),
             new_schemes,
         )
-
-        if not new_schemes:
-            logger.info("No new schemes triggered — stopping.")
-            break
 
         switch_activations = active_actions[active_actions["measure_element_table"] == "switch"]
         if not switch_activations.empty:

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -1,0 +1,580 @@
+"""Core rule-engine algorithm: ``run_spps`` and its private helpers.
+
+Mental model
+------------
+A *scheme* is a group of rows sharing the same ``scheme_name`` across the
+*conditions* and *actions* DataFrames. A scheme is activated on an iteration
+when **all** of its condition rows evaluate to ``True``; activation applies
+**every** action row with that ``scheme_name`` to the network, and the loop
+re-runs a power flow so the next iteration sees the new state.
+
+Side effects
+------------
+The engine mutates ``net`` in place (setpoint changes, switch states,
+``res_*`` tables). It also mutates the supplied ``conditions`` DataFrame by
+adding auxiliary columns (``energized``, ``failed``, ``condition_element_value``,
+``is_condition``) and mutates ``failed_elements`` in place as switches are
+opened. Pass ``.copy()``'d inputs if immutability is required.
+
+Concurrency
+-----------
+The engine is not reentrant: it relies on mutating ``net`` between iterations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Final, Literal
+
+import pandapower as pp
+import pandas as pd
+import pandera.typing as pat
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
+    SppsActionsPandapowerSchema,
+    SppsConditionsPandapowerSchema,
+)
+from toop_engine_contingency_analysis.pandapower.spps.errors import SppsPowerFlowError
+from toop_engine_contingency_analysis.pandapower.spps.schema import (
+    ACTION_COLUMNS,
+    ELEMENT_TABLES,
+    RESULT_COLUMNS,
+    SppsResult,
+)
+from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers — state population
+# --------------------------------------------------------------------------- #
+
+
+def _populate_energized(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
+    """Write an ``energized`` boolean column onto *rules* from the network state.
+
+    For each rule row, look up the condition element in its pandapower table
+    and read a single "is it electrically alive?" flag:
+
+    * switches → ``net.switch.closed``
+    * everything else → ``net.<table>.in_service``
+
+    The resulting ``energized`` column is used by both the ``"De-energized"``
+    check (``energized == False``) and the NaN-based failure auto-detection
+    inside :func:`_populate_failed` (only energized elements can legitimately
+    be flagged as "failed in place").
+
+    Rules whose ``condition_element_table`` does not match any registered
+    table keep a ``pd.NA`` (no value). The column dtype is pandas'
+    ``"boolean"`` (nullable).
+
+    Mutates *rules* in place; does not touch *net*.
+    """
+    rules["energized"] = pd.Series(pd.NA, index=rules.index, dtype="boolean")
+    for table in ELEMENT_TABLES:
+        mask = rules["condition_element_table"] == table
+        if not mask.any():
+            continue
+        ids = rules.loc[mask, "condition_element_table_id"]
+        element_df = getattr(net, table)
+        col = "closed" if table == "switch" else "in_service"
+        rules.loc[mask, "energized"] = element_df.loc[ids, col].to_numpy()
+
+
+_FAILURE_RESULT_TABLES: Final[tuple[str, ...]] = (
+    "line",
+    "trafo",
+    "trafo3w",
+    "impedance",
+    "bus",
+    "gen",
+    "sgen",
+    "load",
+    "shunt",
+    "ward",
+    "xward",
+)
+
+
+def _populate_failed(
+    rules: pd.DataFrame,
+    failed_elements: set[str],
+    net: pp.pandapowerNet,
+) -> None:
+    """Write a ``failed`` boolean column onto *rules* for ``"Failed"`` checks.
+
+    Only rows whose ``condition_check_type == "Failed"`` are evaluated; every
+    other row gets ``failed = False`` and is ignored by
+    :func:`_evaluate_conditions`'s "Failed" branch.
+
+    A condition element is flagged as failed when **either**:
+
+    1. Its compound uid (``f"{id}{SEPARATOR}{table}"``) is present in
+       *failed_elements*. This is the explicit/caller-supplied path, and also
+       how switches opened earlier in the run are recycled as failures.
+    2. It is energized (``in_service`` / ``closed`` == ``True``) yet its row
+       in ``net.res_<table>`` contains at least one NaN — meaning pandapower
+       couldn't produce a valid power-flow result for it. This auto-detection
+       catches elements that became islanded after earlier actions.
+
+    Parameters
+    ----------
+    rules
+        Rules DataFrame. Must already have ``energized`` populated (see
+        :func:`_populate_energized`). Mutated in place.
+    failed_elements
+        Set of compound uids (see :func:`spps.schema.make_element_uid`).
+    net
+        Pandapower network; only ``res_*`` tables are read.
+    """
+    rules["failed"] = False
+    failed_type_mask = rules["condition_check_type"] == "Failed"
+    if not failed_type_mask.any():
+        return
+
+    uids = rules["condition_element_table_id"].astype(str) + SEPARATOR + rules["condition_element_table"].astype(str)
+    rules.loc[failed_type_mask, "failed"] = uids.loc[failed_type_mask].isin(failed_elements).to_numpy()
+
+    energized = rules["energized"].fillna(False).astype(bool)
+
+    for table in _FAILURE_RESULT_TABLES:
+        mask = (rules["condition_element_table"] == table) & failed_type_mask
+        if not mask.any():
+            continue
+        res = getattr(net, f"res_{table}", None)
+        if res is None or res.empty:
+            continue
+
+        ids = rules.loc[mask, "condition_element_table_id"]
+        has_nan = res.reindex(ids).isna().any(axis=1).to_numpy()
+        auto = energized.loc[mask].to_numpy() & has_nan
+        rules.loc[mask, "failed"] = rules.loc[mask, "failed"].to_numpy() | auto
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers — measurement extraction
+# --------------------------------------------------------------------------- #
+
+
+def _extract_res_values(
+    rules: pd.DataFrame,
+    net: pp.pandapowerNet,
+    element_type: str,
+    col_map: dict[str, dict[str, str]],
+) -> None:
+    """Extract ``res_<element_type>`` values into ``rules.condition_element_value``.
+
+    For every combination of ``(condition_type, condition_side)`` supported
+    by *col_map*, copy the corresponding absolute value from
+    ``net.res_<element_type>`` into the rule's ``condition_element_value``.
+    The special ``condition_side == "Maximum value"`` picks the largest
+    absolute value across all sides (e.g. max of ``i_from_ka`` and ``i_to_ka``
+    for a line) — handy for "overload at either end" rules.
+
+    Absolute values are used so that sign conventions (direction of flow)
+    don't flip a condition.
+
+    Parameters
+    ----------
+    rules
+        Rules DataFrame. Mutated in place.
+    net
+        Pandapower network (``res_<element_type>`` must exist and be filled).
+    element_type
+        Pandapower table name (``"line"``, ``"trafo"``, ``"trafo3w"``).
+    col_map
+        Mapping ``condition_type -> {condition_side -> res_column}``; one of
+        the values of :data:`spps.schema.RESULT_COLUMNS`.
+    """
+    res_table = getattr(net, f"res_{element_type}")
+    base_mask = rules["condition_element_table"] == element_type
+    if not base_mask.any():
+        return
+
+    for cond_type, sides in col_map.items():
+        type_mask = base_mask & (rules["condition_type"] == cond_type)
+        if not type_mask.any():
+            continue
+        all_cols = list(dict.fromkeys(sides.values()))
+
+        max_mask = type_mask & (rules["condition_side"] == "Maximum value")
+        if max_mask.any():
+            ids = rules.loc[max_mask, "condition_element_table_id"]
+            vals = res_table.loc[ids, all_cols].abs()
+            merged = vals.iloc[:, 0] if len(all_cols) == 1 else vals.max(axis=1)
+            rules.loc[max_mask, "condition_element_value"] = merged.to_numpy()
+
+        for side, col in sides.items():
+            mask = type_mask & (rules["condition_side"] == side)
+            if not mask.any():
+                continue
+            ids = rules.loc[mask, "condition_element_table_id"]
+            rules.loc[mask, "condition_element_value"] = res_table.loc[ids, col].abs().to_numpy()
+
+
+def _extract_bus_voltage(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
+    """Copy bus voltage magnitudes (p.u.) into ``condition_element_value``.
+
+    Applies only to rows where ``condition_element_table == "bus"`` and
+    ``condition_type == "Voltage"``. The engine works entirely in p.u. for
+    voltage — callers must convert ``condition_limit_value`` to p.u.
+    up-front (see :func:`spps.preprocessing.convert_voltage_rules_to_pu`)
+    so the comparison in :func:`_evaluate_conditions` is unit-consistent.
+
+    Mutates *rules* in place.
+    """
+    mask = (rules["condition_element_table"] == "bus") & (rules["condition_type"] == "Voltage")
+    if not mask.any():
+        return
+    ids = rules.loc[mask, "condition_element_table_id"]
+    rules.loc[mask, "condition_element_value"] = net.res_bus.loc[ids, "vm_pu"].to_numpy()
+
+
+def _extract_condition_values(rules: pd.DataFrame, net: pp.pandapowerNet) -> None:
+    """Populate ``condition_element_value`` with the current power-flow result.
+
+    Initialises the column to NaN, then fills it from ``net.res_*`` tables:
+
+    * lines / trafos / trafo3w via :data:`spps.schema.RESULT_COLUMNS` and
+      :func:`_extract_res_values`;
+    * bus voltages via :func:`_extract_bus_voltage`.
+
+    Rows whose ``(condition_element_table, condition_type)`` combination is
+    not supported keep NaN, which then evaluates to ``False`` in every
+    numeric check inside :func:`_evaluate_conditions`.
+
+    Mutates *rules* in place.
+    """
+    rules["condition_element_value"] = pd.Series(float("nan"), index=rules.index, dtype="float64")
+    for element_type, col_map in RESULT_COLUMNS.items():
+        _extract_res_values(rules, net, element_type, col_map)
+    _extract_bus_voltage(rules, net)
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers — condition evaluation & activation
+# --------------------------------------------------------------------------- #
+
+
+def _evaluate_conditions(rules: pd.DataFrame) -> None:
+    """Evaluate every rule's check and write the result into ``is_condition``.
+
+    Supported ``condition_check_type`` values and their semantics:
+
+    * ``">"``  — ``condition_element_value > condition_limit_value``
+    * ``"<"``  — ``condition_element_value < condition_limit_value``
+    * ``"="``  — ``condition_element_value == condition_limit_value``
+    * ``"Failed"``       — the ``failed`` column populated by
+      :func:`_populate_failed`
+    * ``"De-energized"`` — the ``energized`` column populated by
+      :func:`_populate_energized` is explicitly ``False``
+
+    Any NaN (e.g. unsupported element type, missing power-flow result)
+    evaluates to ``False`` — missing data is never treated as a passing
+    condition. Rows with an unknown check type silently keep
+    ``is_condition = False``; consider adding stricter validation upstream.
+
+    Mutates *rules* in place.
+    """
+    rules["is_condition"] = False
+
+    check = rules["condition_check_type"]
+    value = rules["condition_element_value"]
+    limit = rules["condition_limit_value"]
+
+    gt_mask = check == ">"
+    rules.loc[gt_mask, "is_condition"] = (value[gt_mask] > limit[gt_mask]).fillna(False)
+
+    lt_mask = check == "<"
+    rules.loc[lt_mask, "is_condition"] = (value[lt_mask] < limit[lt_mask]).fillna(False)
+
+    eq_mask = check == "="
+    rules.loc[eq_mask, "is_condition"] = (value[eq_mask] == limit[eq_mask]).fillna(False)
+
+    failed_mask = check == "Failed"
+    rules.loc[failed_mask, "is_condition"] = rules.loc[failed_mask, "failed"].fillna(False)
+
+    de_mask = check == "De-energized"
+    rules.loc[de_mask, "is_condition"] = (rules.loc[de_mask, "energized"] == False).fillna(False)  # noqa: E712
+
+
+def _satisfied_scheme_names(conditions: pd.DataFrame) -> set[str]:
+    """Return the names of schemes for which every condition row passes.
+
+    A scheme is satisfied when **all** of its condition rows have
+    ``is_condition == True`` (one row per :class:`SppsConditionsPandapowerSchema`
+    line).
+
+    Parameters
+    ----------
+    conditions
+        Conditions DataFrame with ``is_condition`` populated by
+        :func:`_evaluate_conditions`.
+    """
+    satisfied = conditions["is_condition"].fillna(False).groupby(conditions["scheme_name"]).all()
+    return set(satisfied[satisfied].index.tolist())
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers — action application
+# --------------------------------------------------------------------------- #
+
+
+def _apply_switch_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
+    """Apply every switch-targeted action by writing ``net.switch.closed``.
+
+    ``measure_value`` for switch rows is the string ``"Open"`` or
+    ``"Closed"``. Anything other than the literal string ``"Closed"`` is
+    interpreted as *open* (``closed = False``). Consider validating the
+    value upstream if you want strict error reporting on typos.
+
+    Mutates *net* in place.
+    """
+    sw = actions[actions["measure_element_table"] == "switch"]
+    if sw.empty:
+        return
+    ids = sw["measure_element_table_id"]
+    closed = (sw["measure_value"] == "Closed").to_numpy()
+    net.switch.loc[ids, "closed"] = closed
+    logger.debug("Applied %d switch actions (ids=%s)", len(sw), ids.tolist())
+
+
+def _apply_actions(actions: pd.DataFrame, net: pp.pandapowerNet) -> None:
+    """Apply every action row in *actions* to *net*.
+
+    Dispatches as follows:
+
+    * Switch rows → :func:`_apply_switch_actions` (string ``"Open"`` /
+      ``"Closed"``).
+    * Everything else → looked up in :data:`spps.schema.ACTION_COLUMNS` by
+      ``(measure_element_table, measure_type)`` and written as a numeric
+      value to the corresponding pandapower column (``p_mw``, ``q_mvar``,
+      ``vm_pu``, ...).
+
+    Voltage ``measure_value`` must already be in per-unit — call
+    :func:`spps.preprocessing.convert_voltage_rules_to_pu` during
+    preprocessing. Rows whose ``(table, measure_type)`` pair isn't in
+    :data:`spps.schema.ACTION_COLUMNS` are silently skipped (no-op).
+
+    Mutates *net* in place.
+    """
+    if actions.empty:
+        return
+    _apply_switch_actions(actions, net)
+
+    for table, type_to_col in ACTION_COLUMNS.items():
+        df = actions[actions["measure_element_table"] == table]
+        if df.empty:
+            continue
+        target = getattr(net, table)
+        for measure_type, col in type_to_col.items():
+            sub = df[df["measure_type"] == measure_type]
+            if sub.empty:
+                continue
+            ids = sub["measure_element_table_id"]
+            target.loc[ids, col] = pd.to_numeric(sub["measure_value"], errors="coerce").to_numpy()
+            logger.debug(
+                "Applied %d %s '%s' updates to net.%s.%s",
+                len(sub),
+                table,
+                measure_type,
+                table,
+                col,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Power-flow helpers
+# --------------------------------------------------------------------------- #
+
+
+def _snapshot_res_tables(net: pp.pandapowerNet) -> dict[str, pd.DataFrame]:
+    """Return a name→copy mapping of every ``res_*`` DataFrame on *net*.
+
+    Each value is a full (deep) pandas ``DataFrame.copy()`` so subsequent
+    solver calls cannot mutate it. Non-DataFrame entries under the ``res_``
+    prefix (if any) are ignored. Only used when
+    ``on_power_flow_error == "keep_previous"`` so the normal path pays no
+    copy cost.
+    """
+    return {k: v.copy() for k, v in net.items() if k.startswith("res_") and isinstance(v, pd.DataFrame)}
+
+
+def _restore_res_tables(net: pp.pandapowerNet, snapshot: dict[str, pd.DataFrame]) -> None:
+    """Write every DataFrame from *snapshot* back onto *net* under its key.
+
+    Used to undo a failed in-loop power-flow call so callers see the last
+    successful ``res_*`` state. Does **not** touch non-``res_`` keys or keys
+    present on *net* but missing from *snapshot* (e.g. tables created
+    mid-flight by the failed solver call).
+    """
+    for k, v in snapshot.items():
+        net[k] = v
+
+
+def _run_power_flow(
+    net: pp.pandapowerNet,
+    method: Literal["ac", "dc"],
+    runpp_kwargs: dict[str, Any],
+) -> None:
+    """Dispatch to the right pandapower solver.
+
+    * ``method="ac"`` → :func:`pandapower.runpp` (Newton AC power flow).
+    * ``method="dc"`` → :func:`pandapower.rundcpp` (linear DC power flow).
+
+    *runpp_kwargs* is forwarded verbatim. This helper exists so the
+    pre-loop call and every in-loop call go through the exact same code
+    path.
+    """
+    if method == "dc":
+        pp.rundcpp(net, **runpp_kwargs)
+    else:
+        pp.runpp(net, **runpp_kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Main entry point
+# --------------------------------------------------------------------------- #
+
+
+def run_spps(
+    net: pp.pandapowerNet,
+    conditions: pat.DataFrame[SppsConditionsPandapowerSchema],
+    actions: pat.DataFrame[SppsActionsPandapowerSchema],
+    failed_elements: set[str],
+    method: Literal["ac", "dc"] = "ac",
+    max_iterations: int = 1,
+    runpp_kwargs: dict[str, Any] | None = None,
+    on_power_flow_error: Literal["raise", "keep_previous"] = "raise",
+) -> SppsResult:
+    """Execute the SpPS rule engine.
+
+    Parameters
+    ----------
+    net
+        Pandapower network. Mutated in place.
+    conditions
+        Condition rows: :class:`SppsConditionsPandapowerSchema`.
+    actions
+        Action rows sharing ``scheme_name`` with *conditions*:
+        :class:`SppsActionsPandapowerSchema`.
+    failed_elements
+        Compound uids of elements considered failed (for ``"Failed"`` checks).
+        Each uid must follow the format ``f"{elem_id}{SEPARATOR}{elem_type}"``
+        (see :func:`spps.schema.make_element_uid`) and can reference
+        ``switch``, ``line``, ``bus``, ``trafo``, ``trafo3w``, ``impedance``,
+        ``ward``, ``xward``, etc. The set is mutated in-place as switches are
+        opened by activated schemes.
+    method
+        ``"ac"`` (default) runs ``pp.runpp``; ``"dc"`` runs ``pp.rundcpp``.
+    max_iterations
+        Upper bound on iterations. The loop stops early when no scheme triggers.
+    runpp_kwargs
+        Keyword arguments forwarded to the power-flow solver on every call.
+    on_power_flow_error
+        Strategy for power-flow failures *inside* the iteration loop
+        (the initial PF always raises, as there is no previous state to fall
+        back on):
+
+        * ``"raise"`` (default) — wrap the underlying exception in
+          :class:`spps.errors.SppsPowerFlowError` and re-raise.
+        * ``"keep_previous"`` — log a warning, restore ``res_*`` tables from a
+          snapshot taken before the failing PF so the returned ``net`` still
+          contains the last successful power-flow results, stop the loop, and
+          set :attr:`SppsResult.power_flow_failed` to ``True``. Setpoint
+          changes applied earlier in the iteration (switch openings, etc.)
+          are left in place.
+
+    Returns
+    -------
+    SppsResult
+        See class docstring.
+
+    Raises
+    ------
+    SppsPowerFlowError
+        If the initial power flow fails, or an iteration-level power flow
+        fails while ``on_power_flow_error="raise"``.
+    """
+    schemes_per_iter: list[list[str]] = []
+    activated_scheme_names: set[str] = set()
+    max_iterations_reached = False
+    power_flow_failed = False
+    iterations = 0
+    runpp_kwargs = runpp_kwargs or {}
+
+    # IMPORTANT:
+    # Must be executed once before the loop.
+    # Energization is treated as static; elements de-energized during the process
+    # are handled as "failed" instead of updating energized status dynamically.
+    _populate_energized(conditions, net)
+
+    try:
+        _run_power_flow(net, method, runpp_kwargs)
+    except Exception as exc:
+        raise SppsPowerFlowError(f"Initial power flow failed; cannot run SpPS: {exc}") from exc
+
+    for iteration in range(1, max_iterations + 1):
+        iterations = iteration
+
+        _populate_failed(conditions, failed_elements, net)
+        _extract_condition_values(conditions, net)
+        _evaluate_conditions(conditions)
+        candidate_schemes = _satisfied_scheme_names(conditions)
+        new_schemes = sorted(n for n in candidate_schemes if n not in activated_scheme_names)
+        active_actions = actions[actions["scheme_name"].isin(new_schemes)].copy() if new_schemes else actions.iloc[0:0]
+        active_actions = active_actions.assign(_iteration=iteration)
+
+        schemes_per_iter.append(new_schemes)
+        logger.info(
+            "Iteration %d: activated %d scheme(s), %d action row(s): %s",
+            iteration,
+            len(new_schemes),
+            len(active_actions),
+            new_schemes,
+        )
+
+        if not new_schemes:
+            logger.info("No new schemes triggered — stopping.")
+            break
+
+        switch_activations = active_actions[active_actions["measure_element_table"] == "switch"]
+        if not switch_activations.empty:
+            opened_uids = switch_activations["measure_element_table_id"].astype(int).astype(str) + SEPARATOR + "switch"
+            failed_elements.update(opened_uids.tolist())
+
+        activated_scheme_names.update(new_schemes)
+        _apply_actions(active_actions, net)
+
+        if iteration < max_iterations:
+            snapshot = _snapshot_res_tables(net) if on_power_flow_error == "keep_previous" else None
+            try:
+                _run_power_flow(net, method, runpp_kwargs)
+            except Exception as exc:
+                if on_power_flow_error == "raise":
+                    raise SppsPowerFlowError(f"Power flow failed on iteration {iteration}: {exc}") from exc
+                logger.warning(
+                    "Power flow failed on iteration %d; keeping previous res_* tables and stopping loop: %s",
+                    iteration,
+                    exc,
+                )
+                if snapshot is not None:
+                    _restore_res_tables(net, snapshot)
+                power_flow_failed = True
+                break
+        else:
+            max_iterations_reached = True
+
+    if max_iterations_reached:
+        logger.warning(
+            "SpPS exhausted max_iterations=%d while still activating schemes.",
+            max_iterations,
+        )
+
+    return SppsResult(
+        net=net,
+        iterations=iterations,
+        activated_schemes_per_iter=schemes_per_iter,
+        max_iterations_reached=max_iterations_reached,
+        power_flow_failed=power_flow_failed,
+    )

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -11,9 +11,11 @@ Mental model
 ------------
 A *scheme* is a group of rows sharing the same ``scheme_name`` across the
 *conditions* and *actions* DataFrames. A scheme is activated on an iteration
-when **all** of its condition rows evaluate to ``True``; activation applies
-**every** action row with that ``scheme_name`` to the network, and the loop
-re-runs a power flow so the next iteration sees the new state.
+when its condition rows pass according to each row's ``condition_logic``:
+``all`` requires **every** condition to be true; ``any`` requires **at least
+one**. Activation applies **every** action row with that ``scheme_name`` to
+the network, and the loop re-runs a power flow so the next iteration sees the
+new state.
 
 Side effects
 ------------
@@ -50,6 +52,7 @@ from toop_engine_contingency_analysis.pandapower.spps.schema import (
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR
 from toop_engine_interfaces.spps_parameters import (
     SppsConditionCheckType,
+    SppsConditionLogic,
     SppsConditionSide,
     SppsConditionType,
     SppsPowerFlowFailurePolicy,
@@ -360,19 +363,34 @@ def _evaluate_conditions(conditions: pat.DataFrame[SppsConditionsPandapowerSchem
 
 
 def _satisfied_scheme_names(conditions: pat.DataFrame[SppsConditionsPandapowerSchema]) -> set[str]:
-    """Return the names of schemes for which every condition row passes.
+    """Return scheme names whose condition rows pass under that scheme's ``condition_logic``.
 
-    A scheme is satisfied when **all** of its condition rows have
-    ``is_condition == True`` (one row per :class:`SppsConditionsPandapowerSchema`
-    line).
+    For each ``scheme_name``, all condition rows carry the same ``condition_logic``
+    (``all`` = logical AND over ``is_condition``, ``any`` = logical OR).
+
+    If ``condition_logic`` is absent (legacy tables), ``all`` is assumed.
 
     Parameters
     ----------
     conditions
         Conditions SppsConditionsPandapowerSchema
     """
-    satisfied = conditions["is_condition"].fillna(False).groupby(conditions["scheme_name"]).all()
-    return set(satisfied[satisfied].index.tolist())
+    ic = conditions["is_condition"].fillna(False)
+    names = conditions["scheme_name"]
+    if "condition_logic" not in conditions.columns:
+        satisfied = ic.groupby(names).all()
+        return set(satisfied[satisfied].index.tolist())
+
+    out: set[str] = set()
+    for scheme_name, grp in conditions.groupby("scheme_name", sort=False):
+        mode = grp["condition_logic"].iloc[0]
+        g_ic = ic.loc[grp.index]
+        if mode == SppsConditionLogic.ANY.value:
+            if bool(g_ic.any()):
+                out.add(scheme_name)
+        elif bool(g_ic.all()):
+            out.add(scheme_name)
+    return out
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/errors.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/errors.py
@@ -1,3 +1,10 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
 """Exception hierarchy for the SpPS (Special Protection Scheme) engine."""
 
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/errors.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/errors.py
@@ -1,0 +1,25 @@
+"""Exception hierarchy for the SpPS (Special Protection Scheme) engine."""
+
+
+class SppsError(Exception):
+    """Base class for every exception raised by the SpPS package.
+
+    Catch :class:`SppsError` to cover any engine-specific failure without
+    accidentally swallowing unrelated exceptions (e.g. ``KeyboardInterrupt``,
+    ``ValueError`` from callers).
+    """
+
+
+class SppsPowerFlowError(SppsError):
+    """The pandapower solver (``pp.runpp`` / ``pp.rundcpp``) failed.
+
+    Raised by :func:`spps.engine.run_spps` when either:
+
+    * the *initial* power flow (before the iteration loop) does not converge —
+      in which case SpPS cannot run at all, or
+    * an in-loop power flow fails and the caller asked for
+      ``on_power_flow_error="raise"``.
+
+    The underlying solver exception is attached as ``__cause__`` (via
+    ``raise ... from exc``) so the original traceback is preserved.
+    """

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
@@ -1,0 +1,124 @@
+"""Data contracts for the SpPS engine.
+
+This module declares the two stable *shapes* that travel in and out of
+:func:`spps.engine.run_spps`:
+
+* ``SppsConditionsPandapowerSchema`` and ``SppsActionsPandapowerSchema`` (Pandera) — input tables.
+* :class:`SppsResult` — the typed return bundle (Pydantic).
+
+It also holds the static lookup tables that describe which pandapower
+columns to read (:data:`RESULT_COLUMNS`) and write (:data:`ACTION_COLUMNS`)
+for each element type, plus the compound-uid helpers used to reference
+failed elements across tables.
+"""
+
+from typing import Final
+
+import pandapower as pp
+from pydantic import BaseModel, ConfigDict
+
+ELEMENT_TABLES: Final[tuple[str, ...]] = (
+    "line",
+    "trafo",
+    "trafo3w",
+    "impedance",
+    "bus",
+    "switch",
+    "gen",
+    "load",
+    "sgen",
+    "shunt",
+    "ward",
+    "xward",
+)
+
+RESULT_COLUMNS: Final[dict[str, dict[str, dict[str, str]]]] = {
+    "trafo3w": {
+        "Current": {
+            "Primary": "i_hv_ka",
+            "Secondary": "i_mv_ka",
+            "Tertiary": "i_lv_ka",
+        },
+        "Active power": {
+            "Primary": "p_hv_mw",
+            "Secondary": "p_mv_mw",
+            "Tertiary": "p_lv_mw",
+        },
+        "Reactive power": {
+            "Primary": "q_hv_mvar",
+            "Secondary": "q_mv_mvar",
+            "Tertiary": "q_lv_mvar",
+        },
+    },
+    "trafo": {
+        "Current": {"Primary": "i_hv_ka", "Secondary": "i_lv_ka"},
+        "Active power": {"Primary": "p_hv_mw", "Secondary": "p_lv_mw"},
+        "Reactive power": {"Primary": "q_hv_mvar", "Secondary": "q_lv_mvar"},
+    },
+    "line": {
+        "Current": {"Primary": "i_from_ka", "Secondary": "i_to_ka"},
+        "Active power": {"Primary": "p_from_mw", "Secondary": "p_to_mw"},
+        "Reactive power": {"Primary": "q_from_mvar", "Secondary": "q_to_mvar"},
+    },
+}
+
+ACTION_COLUMNS: Final[dict[str, dict[str, str]]] = {
+    "gen": {"Active power": "p_mw", "Voltage": "vm_pu"},
+    "sgen": {"Active power": "p_mw", "Reactive power": "q_mvar"},
+    "load": {"Active power": "p_mw", "Reactive power": "q_mvar"},
+    "shunt": {"Active power": "p_mw", "Reactive power": "q_mvar"},
+    "ward": {"Active power": "ps_mw", "Reactive power": "qs_mvar"},
+    "xward": {"Active power": "ps_mw", "Reactive power": "qs_mvar"},
+}
+
+
+class SppsResult(BaseModel):
+    """Typed result bundle returned by :func:`spps.engine.run_spps`.
+
+    ``arbitrary_types_allowed=True`` is set so Pydantic can wrap the
+    (non-Pydantic) :class:`pandapower.pandapowerNet` instance without
+    trying to validate its internals.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    net: pp.pandapowerNet
+    """The pandapower network after all SpPS actions have been applied.
+
+    Mutated *in place* — this is the same object the caller passed in.
+    """
+
+    iterations: int
+    """Number of iterations actually executed (1-based count).
+
+    Equal to ``len(activated_schemes_per_iter)``.
+    """
+
+    activated_schemes_per_iter: list[list[str]]
+    """Per-iteration list of scheme names that fired (order preserved).
+
+    ``activated_schemes_per_iter[i]`` is the sorted list of unique scheme
+    names activated on iteration ``i + 1``. The last entry is empty iff the
+    loop exited early because no more schemes triggered.
+    """
+
+    max_iterations_reached: bool
+    """``True`` when the engine ran out of iteration budget.
+
+    Specifically: the loop reached ``max_iterations`` while the final
+    iteration was still producing new scheme activations. ``False`` means the
+    loop exited cleanly (either no scheme triggered, or a PF failure stopped
+    it). This is **not** a convergence indicator — see
+    :attr:`power_flow_failed` for that.
+    """
+
+    power_flow_failed: bool = False
+    """``True`` if an iteration-level power flow failed under
+    ``on_power_flow_error="keep_previous"``.
+
+    When ``True``, the engine restored the ``res_*`` tables on :attr:`net`
+    from the snapshot taken *before* the failing solver call, so the result
+    tables reflect the last successful iteration. Setpoint changes applied
+    during the failing iteration (switch openings, gen/load adjustments) are
+    left in place.
+    """

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
@@ -1,3 +1,10 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
 """Data contracts for the SpPS engine.
 
 This module declares the two stable *shapes* that travel in and out of

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/schema.py
@@ -34,41 +34,41 @@ ELEMENT_TABLES: Final[tuple[str, ...]] = (
 
 RESULT_COLUMNS: Final[dict[str, dict[str, dict[str, str]]]] = {
     "trafo3w": {
-        "Current": {
-            "Primary": "i_hv_ka",
-            "Secondary": "i_mv_ka",
-            "Tertiary": "i_lv_ka",
+        "current": {
+            "primary": "i_hv_ka",
+            "secondary": "i_mv_ka",
+            "tertiary": "i_lv_ka",
         },
-        "Active power": {
-            "Primary": "p_hv_mw",
-            "Secondary": "p_mv_mw",
-            "Tertiary": "p_lv_mw",
+        "active_power": {
+            "primary": "p_hv_mw",
+            "secondary": "p_mv_mw",
+            "tertiary": "p_lv_mw",
         },
-        "Reactive power": {
-            "Primary": "q_hv_mvar",
-            "Secondary": "q_mv_mvar",
-            "Tertiary": "q_lv_mvar",
+        "reactive_power": {
+            "primary": "q_hv_mvar",
+            "secondary": "q_mv_mvar",
+            "tertiary": "q_lv_mvar",
         },
     },
     "trafo": {
-        "Current": {"Primary": "i_hv_ka", "Secondary": "i_lv_ka"},
-        "Active power": {"Primary": "p_hv_mw", "Secondary": "p_lv_mw"},
-        "Reactive power": {"Primary": "q_hv_mvar", "Secondary": "q_lv_mvar"},
+        "current": {"primary": "i_hv_ka", "secondary": "i_lv_ka"},
+        "active_power": {"primary": "p_hv_mw", "secondary": "p_lv_mw"},
+        "reactive_power": {"primary": "q_hv_mvar", "secondary": "q_lv_mvar"},
     },
     "line": {
-        "Current": {"Primary": "i_from_ka", "Secondary": "i_to_ka"},
-        "Active power": {"Primary": "p_from_mw", "Secondary": "p_to_mw"},
-        "Reactive power": {"Primary": "q_from_mvar", "Secondary": "q_to_mvar"},
+        "current": {"primary": "i_from_ka", "secondary": "i_to_ka"},
+        "active_power": {"primary": "p_from_mw", "secondary": "p_to_mw"},
+        "reactive_power": {"primary": "q_from_mvar", "secondary": "q_to_mvar"},
     },
 }
 
 ACTION_COLUMNS: Final[dict[str, dict[str, str]]] = {
-    "gen": {"Active power": "p_mw", "Voltage": "vm_pu"},
-    "sgen": {"Active power": "p_mw", "Reactive power": "q_mvar"},
-    "load": {"Active power": "p_mw", "Reactive power": "q_mvar"},
-    "shunt": {"Active power": "p_mw", "Reactive power": "q_mvar"},
-    "ward": {"Active power": "ps_mw", "Reactive power": "qs_mvar"},
-    "xward": {"Active power": "ps_mw", "Reactive power": "qs_mvar"},
+    "gen": {"active_power": "p_mw", "voltage": "vm_pu"},
+    "sgen": {"active_power": "p_mw", "reactive_power": "q_mvar"},
+    "load": {"active_power": "p_mw", "reactive_power": "q_mvar"},
+    "shunt": {"active_power": "p_mw", "reactive_power": "q_mvar"},
+    "ward": {"active_power": "ps_mw", "reactive_power": "qs_mvar"},
+    "xward": {"active_power": "ps_mw", "reactive_power": "qs_mvar"},
 }
 
 

--- a/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
@@ -1,0 +1,240 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+import uuid
+
+import pandapower as pp
+import pytest
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.translators import translate_spps_rules
+from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
+from toop_engine_interfaces.nminus1_definition import Action, Condition, SppsRule
+from toop_engine_interfaces.spps_parameters import (
+    SppsConditionCheckType,
+    SppsConditionSide,
+    SppsConditionType,
+    SppsMeasureType,
+)
+
+
+def _sample_rule(line_idx_cond: int, line_idx_meas: int, scheme: str = "scheme_a") -> SppsRule:
+    cond_uid = get_globally_unique_id(line_idx_cond, "line")
+    meas_uid = get_globally_unique_id(line_idx_meas, "line")
+    return SppsRule(
+        scheme_name=scheme,
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.CURRENT,
+                condition_check_type=SppsConditionCheckType.GT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=100.0,
+                condition_element_unique_id=cond_uid,
+            )
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=meas_uid,
+                measure_type=SppsMeasureType.ACTIVE_POWER,
+                measure_value=10.0,
+            )
+        ],
+    )
+
+
+def test_translate_spps_rules_none_returns_empty_tables(pandapower_net: pp.pandapowerNet) -> None:
+    cond, act, missing, dupes = translate_spps_rules(pandapower_net, None)
+    assert cond.empty and act.empty
+    assert missing == [] and dupes == []
+
+
+def test_translate_spps_rules_empty_list_returns_empty_tables(pandapower_net: pp.pandapowerNet) -> None:
+    cond, act, missing, dupes = translate_spps_rules(pandapower_net, [], id_type="unique_pandapower")
+    assert cond.empty and act.empty
+    assert missing == [] and dupes == []
+
+
+def test_translate_spps_rules_unique_pandapower_default_id_type(pandapower_net: pp.pandapowerNet) -> None:
+    first_line = int(pandapower_net.line.index[0])
+    second_line = int(pandapower_net.line.index[1])
+    rule = _sample_rule(first_line, second_line)
+    cond, act, missing, dupes = translate_spps_rules(pandapower_net, [rule])
+    assert missing == [] and dupes == []
+    assert len(cond) == 1 and len(act) == 1
+    assert cond.iloc[0]["scheme_name"] == rule.scheme_name
+    assert cond.iloc[0]["condition_element_table"] == "line"
+    assert int(cond.iloc[0]["condition_element_table_id"]) == first_line
+    assert act.iloc[0]["measure_element_table"] == "line"
+    assert int(act.iloc[0]["measure_element_table_id"]) == second_line
+
+
+def test_translate_spps_rules_unique_pandapower_unknown_element_in_missing(
+    pandapower_net: pp.pandapowerNet,
+) -> None:
+    bad_id = "999999%%line"
+    rule = SppsRule(
+        scheme_name="bad",
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.VOLTAGE,
+                condition_check_type=SppsConditionCheckType.LT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=0.9,
+                condition_element_unique_id=bad_id,
+            )
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.line.index[0]), "line"),
+                measure_type=SppsMeasureType.VOLTAGE,
+                measure_value=1.0,
+            )
+        ],
+    )
+    cond, act, missing, dupes = translate_spps_rules(pandapower_net, [rule], id_type="unique_pandapower")
+    assert len(missing) == 1 and missing[0] is rule
+    assert dupes == []
+    assert cond.empty and act.empty
+
+
+def test_translate_spps_rules_unique_pandapower_no_conditions_in_missing(
+    pandapower_net: pp.pandapowerNet,
+) -> None:
+    rule = SppsRule(
+        scheme_name="no_cond",
+        conditions=[],
+        actions=[
+            Action(
+                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.line.index[0]), "line"),
+                measure_type=SppsMeasureType.ACTIVE_POWER,
+                measure_value=0.0,
+            )
+        ],
+    )
+    cond, act, missing, _ = translate_spps_rules(pandapower_net, [rule], id_type="unique_pandapower")
+    assert missing == [rule] and cond.empty and act.empty
+
+
+def test_translate_spps_rules_unique_pandapower_no_actions_in_missing(
+    pandapower_net: pp.pandapowerNet,
+) -> None:
+    rule = SppsRule(
+        scheme_name="no_act",
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.CURRENT,
+                condition_check_type=SppsConditionCheckType.GT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=1.0,
+                condition_element_unique_id=get_globally_unique_id(int(pandapower_net.line.index[0]), "line"),
+            )
+        ],
+        actions=[],
+    )
+    cond, act, missing, _ = translate_spps_rules(pandapower_net, [rule], id_type="unique_pandapower")
+    assert missing == [rule] and cond.empty and act.empty
+
+
+def test_translate_spps_rules_unsupported_id_type_raises(pandapower_net: pp.pandapowerNet) -> None:
+    rule = _sample_rule(int(pandapower_net.line.index[0]), int(pandapower_net.line.index[0]))
+    with pytest.raises(ValueError, match="Unsupported id_type"):
+        translate_spps_rules(pandapower_net, [rule], id_type="ucte")  # type: ignore[arg-type]
+
+
+def test_translate_spps_rules_cgmes_resolves_origin_id(pandapower_net: pp.pandapowerNet) -> None:
+    net = pandapower_net
+    idx0 = int(net.line.index[0])
+    idx1 = int(net.line.index[1]) if len(net.line.index) > 1 else idx0
+    guid0, guid1 = str(uuid.uuid4()), str(uuid.uuid4())
+    net.line.loc[idx0, "origin_id"] = guid0
+    net.line.loc[idx1, "origin_id"] = guid1
+
+    rule = SppsRule(
+        scheme_name="cgmes_scheme",
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.ACTIVE_POWER,
+                condition_check_type=SppsConditionCheckType.GT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=50.0,
+                condition_element_unique_id=guid0,
+            )
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=guid1,
+                measure_type=SppsMeasureType.REACTIVE_POWER,
+                measure_value=5.0,
+            )
+        ],
+    )
+    cond, act, missing, dupes = translate_spps_rules(net, [rule], id_type="cgmes")
+    assert missing == [] and dupes == []
+    assert len(cond) == 1 and len(act) == 1
+    assert cond.iloc[0]["condition_element_table"] == "line" and int(cond.iloc[0]["condition_element_table_id"]) == idx0
+    assert act.iloc[0]["measure_element_table"] == "line" and int(act.iloc[0]["measure_element_table_id"]) == idx1
+
+
+def test_translate_spps_rules_cgmes_unknown_guid_missing(pandapower_net: pp.pandapowerNet) -> None:
+    net = pandapower_net
+    idx0 = int(net.line.index[0])
+    net.line.loc[idx0, "origin_id"] = str(uuid.uuid4())
+    rule = SppsRule(
+        scheme_name="missing_guid",
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.VOLTAGE,
+                condition_check_type=SppsConditionCheckType.LT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=1.0,
+                condition_element_unique_id=str(uuid.uuid4()),
+            )
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=str(net.line.loc[idx0, "origin_id"]),
+                measure_type=SppsMeasureType.VOLTAGE,
+                measure_value=1.0,
+            )
+        ],
+    )
+    cond, act, missing, dupes = translate_spps_rules(net, [rule], id_type="cgmes")
+    assert len(missing) == 1 and missing[0] is rule
+    assert cond.empty and act.empty
+    assert dupes == []
+
+
+def test_translate_spps_rules_cgmes_duplicate_origin_id_reported(pandapower_net: pp.pandapowerNet) -> None:
+    net = pandapower_net
+    if len(net.line.index) < 2:
+        pytest.skip("need at least two lines for duplicate origin_id test")
+    idx0 = int(net.line.index[0])
+    idx1 = int(net.line.index[1])
+    shared = str(uuid.uuid4())
+    net.line.loc[idx0, "origin_id"] = shared
+    net.line.loc[idx1, "origin_id"] = shared
+
+    rule = SppsRule(
+        scheme_name="dup",
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.CURRENT,
+                condition_check_type=SppsConditionCheckType.GT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=0.0,
+                condition_element_unique_id=shared,
+            )
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=shared,
+                measure_type=SppsMeasureType.ACTIVE_POWER,
+                measure_value=0.0,
+            )
+        ],
+    )
+    _cond, _act, missing, dupes = translate_spps_rules(net, [rule], id_type="cgmes")
+    assert missing == []
+    assert dupes == [shared]

--- a/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
@@ -178,12 +178,6 @@ def test_translate_spps_rules_unique_pandapower_no_actions_in_missing(
     assert missing == [rule] and cond.empty and act.empty
 
 
-def test_translate_spps_rules_unsupported_id_type_raises(pandapower_net: pp.pandapowerNet) -> None:
-    rule = _sample_rule(int(pandapower_net.line.index[0]), int(pandapower_net.switch.index[0]))
-    with pytest.raises(ValueError, match="Unsupported id_type"):
-        translate_spps_rules(pandapower_net, [rule], id_type="ucte")  # type: ignore[arg-type]
-
-
 def test_translate_spps_rules_cgmes_resolves_origin_id(pandapower_net: pp.pandapowerNet) -> None:
     net = pandapower_net
     line_idx = int(net.line.index[0])

--- a/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/pandapower_helpers/test_translate_spps_rules.py
@@ -14,15 +14,17 @@ from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_global
 from toop_engine_interfaces.nminus1_definition import Action, Condition, SppsRule
 from toop_engine_interfaces.spps_parameters import (
     SppsConditionCheckType,
+    SppsConditionLogic,
     SppsConditionSide,
     SppsConditionType,
     SppsMeasureType,
+    SppsSwitchActionTarget,
 )
 
 
-def _sample_rule(line_idx_cond: int, line_idx_meas: int, scheme: str = "scheme_a") -> SppsRule:
+def _sample_rule(line_idx_cond: int, switch_idx_meas: int, scheme: str = "scheme_a") -> SppsRule:
     cond_uid = get_globally_unique_id(line_idx_cond, "line")
-    meas_uid = get_globally_unique_id(line_idx_meas, "line")
+    meas_uid = get_globally_unique_id(switch_idx_meas, "switch")
     return SppsRule(
         scheme_name=scheme,
         conditions=[
@@ -37,8 +39,8 @@ def _sample_rule(line_idx_cond: int, line_idx_meas: int, scheme: str = "scheme_a
         actions=[
             Action(
                 measure_element_unique_id=meas_uid,
-                measure_type=SppsMeasureType.ACTIVE_POWER,
-                measure_value=10.0,
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.CLOSED,
             )
         ],
     )
@@ -58,16 +60,19 @@ def test_translate_spps_rules_empty_list_returns_empty_tables(pandapower_net: pp
 
 def test_translate_spps_rules_unique_pandapower_default_id_type(pandapower_net: pp.pandapowerNet) -> None:
     first_line = int(pandapower_net.line.index[0])
-    second_line = int(pandapower_net.line.index[1])
-    rule = _sample_rule(first_line, second_line)
+    first_switch = int(pandapower_net.switch.index[0])
+    rule = _sample_rule(first_line, first_switch)
     cond, act, missing, dupes = translate_spps_rules(pandapower_net, [rule])
     assert missing == [] and dupes == []
     assert len(cond) == 1 and len(act) == 1
     assert cond.iloc[0]["scheme_name"] == rule.scheme_name
     assert cond.iloc[0]["condition_element_table"] == "line"
     assert int(cond.iloc[0]["condition_element_table_id"]) == first_line
-    assert act.iloc[0]["measure_element_table"] == "line"
-    assert int(act.iloc[0]["measure_element_table_id"]) == second_line
+    assert act.iloc[0]["measure_element_table"] == "switch"
+    assert int(act.iloc[0]["measure_element_table_id"]) == first_switch
+    assert act.iloc[0]["measure_type"] == SppsMeasureType.SWITCHING_STATE
+    assert act.iloc[0]["measure_value"] == SppsSwitchActionTarget.CLOSED
+    assert (cond["condition_logic"] == SppsConditionLogic.ALL.value).all()
 
 
 def test_translate_spps_rules_unique_pandapower_unknown_element_in_missing(
@@ -87,9 +92,9 @@ def test_translate_spps_rules_unique_pandapower_unknown_element_in_missing(
         ],
         actions=[
             Action(
-                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.line.index[0]), "line"),
-                measure_type=SppsMeasureType.VOLTAGE,
-                measure_value=1.0,
+                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.switch.index[0]), "switch"),
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.OPEN,
             )
         ],
     )
@@ -99,17 +104,53 @@ def test_translate_spps_rules_unique_pandapower_unknown_element_in_missing(
     assert cond.empty and act.empty
 
 
-def test_translate_spps_rules_unique_pandapower_no_conditions_in_missing(
+def test_translate_spps_rules_condition_logic_any_on_condition_rows(
     pandapower_net: pp.pandapowerNet,
 ) -> None:
+    net = pandapower_net
+    line_a = int(net.line.index[0])
+    line_b = int(net.line.index[1]) if len(net.line.index) > 1 else line_a
+    sw = int(net.switch.index[0])
+    rule = SppsRule(
+        scheme_name="any_scheme",
+        condition_logic=SppsConditionLogic.ANY,
+        conditions=[
+            Condition(
+                condition_type=SppsConditionType.CURRENT,
+                condition_check_type=SppsConditionCheckType.GT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=1.0,
+                condition_element_unique_id=get_globally_unique_id(line_a, "line"),
+            ),
+            Condition(
+                condition_type=SppsConditionType.VOLTAGE,
+                condition_check_type=SppsConditionCheckType.LT,
+                condition_side=SppsConditionSide.PRIMARY,
+                condition_limit_value=2.0,
+                condition_element_unique_id=get_globally_unique_id(line_b, "line"),
+            ),
+        ],
+        actions=[
+            Action(
+                measure_element_unique_id=get_globally_unique_id(sw, "switch"),
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.CLOSED,
+            )
+        ],
+    )
+    cond, act, missing, dupes = translate_spps_rules(net, [rule], id_type="unique_pandapower")
+    assert missing == [] and dupes == []
+    assert len(cond) == 2 and len(act) == 1
+    assert (cond["condition_logic"] == SppsConditionLogic.ANY.value).all()
+
     rule = SppsRule(
         scheme_name="no_cond",
         conditions=[],
         actions=[
             Action(
-                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.line.index[0]), "line"),
-                measure_type=SppsMeasureType.ACTIVE_POWER,
-                measure_value=0.0,
+                measure_element_unique_id=get_globally_unique_id(int(pandapower_net.switch.index[0]), "switch"),
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.CLOSED,
             )
         ],
     )
@@ -138,18 +179,19 @@ def test_translate_spps_rules_unique_pandapower_no_actions_in_missing(
 
 
 def test_translate_spps_rules_unsupported_id_type_raises(pandapower_net: pp.pandapowerNet) -> None:
-    rule = _sample_rule(int(pandapower_net.line.index[0]), int(pandapower_net.line.index[0]))
+    rule = _sample_rule(int(pandapower_net.line.index[0]), int(pandapower_net.switch.index[0]))
     with pytest.raises(ValueError, match="Unsupported id_type"):
         translate_spps_rules(pandapower_net, [rule], id_type="ucte")  # type: ignore[arg-type]
 
 
 def test_translate_spps_rules_cgmes_resolves_origin_id(pandapower_net: pp.pandapowerNet) -> None:
     net = pandapower_net
-    idx0 = int(net.line.index[0])
-    idx1 = int(net.line.index[1]) if len(net.line.index) > 1 else idx0
-    guid0, guid1 = str(uuid.uuid4()), str(uuid.uuid4())
-    net.line.loc[idx0, "origin_id"] = guid0
-    net.line.loc[idx1, "origin_id"] = guid1
+    line_idx = int(net.line.index[0])
+    sw_idx = int(net.switch.index[0])
+    line_guid = str(uuid.uuid4())
+    switch_guid = str(uuid.uuid4())
+    net.line.loc[line_idx, "origin_id"] = line_guid
+    net.switch.loc[sw_idx, "origin_id"] = switch_guid
 
     rule = SppsRule(
         scheme_name="cgmes_scheme",
@@ -159,28 +201,29 @@ def test_translate_spps_rules_cgmes_resolves_origin_id(pandapower_net: pp.pandap
                 condition_check_type=SppsConditionCheckType.GT,
                 condition_side=SppsConditionSide.PRIMARY,
                 condition_limit_value=50.0,
-                condition_element_unique_id=guid0,
+                condition_element_unique_id=line_guid,
             )
         ],
         actions=[
             Action(
-                measure_element_unique_id=guid1,
-                measure_type=SppsMeasureType.REACTIVE_POWER,
-                measure_value=5.0,
+                measure_element_unique_id=switch_guid,
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.OPEN,
             )
         ],
     )
     cond, act, missing, dupes = translate_spps_rules(net, [rule], id_type="cgmes")
     assert missing == [] and dupes == []
     assert len(cond) == 1 and len(act) == 1
-    assert cond.iloc[0]["condition_element_table"] == "line" and int(cond.iloc[0]["condition_element_table_id"]) == idx0
-    assert act.iloc[0]["measure_element_table"] == "line" and int(act.iloc[0]["measure_element_table_id"]) == idx1
+    assert cond.iloc[0]["condition_element_table"] == "line" and int(cond.iloc[0]["condition_element_table_id"]) == line_idx
+    assert act.iloc[0]["measure_element_table"] == "switch" and int(act.iloc[0]["measure_element_table_id"]) == sw_idx
 
 
 def test_translate_spps_rules_cgmes_unknown_guid_missing(pandapower_net: pp.pandapowerNet) -> None:
     net = pandapower_net
-    idx0 = int(net.line.index[0])
-    net.line.loc[idx0, "origin_id"] = str(uuid.uuid4())
+    sw_idx = int(net.switch.index[0])
+    switch_guid = str(uuid.uuid4())
+    net.switch.loc[sw_idx, "origin_id"] = switch_guid
     rule = SppsRule(
         scheme_name="missing_guid",
         conditions=[
@@ -194,9 +237,9 @@ def test_translate_spps_rules_cgmes_unknown_guid_missing(pandapower_net: pp.pand
         ],
         actions=[
             Action(
-                measure_element_unique_id=str(net.line.loc[idx0, "origin_id"]),
-                measure_type=SppsMeasureType.VOLTAGE,
-                measure_value=1.0,
+                measure_element_unique_id=switch_guid,
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.CLOSED,
             )
         ],
     )
@@ -208,13 +251,13 @@ def test_translate_spps_rules_cgmes_unknown_guid_missing(pandapower_net: pp.pand
 
 def test_translate_spps_rules_cgmes_duplicate_origin_id_reported(pandapower_net: pp.pandapowerNet) -> None:
     net = pandapower_net
-    if len(net.line.index) < 2:
-        pytest.skip("need at least two lines for duplicate origin_id test")
-    idx0 = int(net.line.index[0])
-    idx1 = int(net.line.index[1])
+    if len(net.switch.index) < 2:
+        pytest.skip("need at least two switches for duplicate origin_id test")
+    sw0 = int(net.switch.index[0])
+    sw1 = int(net.switch.index[1])
     shared = str(uuid.uuid4())
-    net.line.loc[idx0, "origin_id"] = shared
-    net.line.loc[idx1, "origin_id"] = shared
+    net.switch.loc[sw0, "origin_id"] = shared
+    net.switch.loc[sw1, "origin_id"] = shared
 
     rule = SppsRule(
         scheme_name="dup",
@@ -230,8 +273,8 @@ def test_translate_spps_rules_cgmes_duplicate_origin_id_reported(pandapower_net:
         actions=[
             Action(
                 measure_element_unique_id=shared,
-                measure_type=SppsMeasureType.ACTIVE_POWER,
-                measure_value=0.0,
+                measure_type=SppsMeasureType.SWITCHING_STATE,
+                measure_value=SppsSwitchActionTarget.OPEN,
             )
         ],
     )

--- a/packages/contingency_analysis_pkg/tests/pandapower/spps/test_engine.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/spps/test_engine.py
@@ -1,0 +1,434 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+from copy import deepcopy
+from unittest import mock
+
+import pandapower as pp
+import pandas as pd
+import pytest
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
+    SppsActionsPandapowerSchema,
+    SppsConditionsPandapowerSchema,
+)
+from toop_engine_contingency_analysis.pandapower.spps.engine import (
+    _apply_actions,
+    _apply_switch_actions,
+    _evaluate_conditions,
+    _extract_condition_values,
+    _populate_energized,
+    _populate_failed,
+    _restore_res_tables,
+    _run_power_flow,
+    _snapshot_res_tables,
+    run_spps,
+)
+from toop_engine_contingency_analysis.pandapower.spps.errors import SppsPowerFlowError
+from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR
+from toop_engine_interfaces.spps_parameters import (
+    SppsConditionCheckType,
+    SppsConditionLogic,
+    SppsConditionSide,
+    SppsConditionType,
+    SppsMeasureType,
+    SppsPowerFlowFailurePolicy,
+    SppsSwitchActionTarget,
+)
+
+
+def _cond_row(
+    *,
+    scheme: str = "s1",
+    logic: str = SppsConditionLogic.ALL.value,
+    ctype: str = SppsConditionType.CURRENT.value,
+    check: str = SppsConditionCheckType.GT.value,
+    side: str = SppsConditionSide.PRIMARY.value,
+    limit: float | None = 0.0,
+    table: str = "line",
+    table_id: int = 0,
+) -> dict:
+    return {
+        "scheme_name": scheme,
+        "condition_logic": logic,
+        "condition_type": ctype,
+        "condition_check_type": check,
+        "condition_side": side,
+        "condition_limit_value": limit,
+        "condition_element_table": table,
+        "condition_element_table_id": table_id,
+    }
+
+
+def _act_row(
+    *,
+    scheme: str = "s1",
+    mtype: str = SppsMeasureType.SWITCHING_STATE.value,
+    mvalue: str | float = SppsSwitchActionTarget.OPEN.value,
+    table: str = "switch",
+    table_id: int = 0,
+) -> dict:
+    return {
+        "scheme_name": scheme,
+        "measure_type": mtype,
+        "measure_value": mvalue,
+        "measure_element_table": table,
+        "measure_element_table_id": table_id,
+    }
+
+
+def _validate_conditions(df: pd.DataFrame) -> pd.DataFrame:
+    return SppsConditionsPandapowerSchema.validate(df)
+
+
+def _validate_actions(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    if "measure_value" in df.columns:
+        # Schema expects object dtype; literals otherwise become float64.
+        df["measure_value"] = df["measure_value"].astype(object)
+    return SppsActionsPandapowerSchema.validate(df)
+
+
+def test_populate_energized_line_reads_in_service(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    cond = _validate_conditions(pd.DataFrame([_cond_row(table="line", table_id=lid)]))
+    _populate_energized(cond, net)
+    assert cond.loc[0, "energized"] == bool(net.line.loc[lid, "in_service"])
+
+
+def test_populate_energized_switch_reads_closed(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    sid = int(net.switch.index[0])
+    cond = _validate_conditions(
+        pd.DataFrame([_cond_row(table="switch", table_id=sid, check=SppsConditionCheckType.DE_ENERGIZED.value, limit=None)])
+    )
+    _populate_energized(cond, net)
+    assert cond.loc[0, "energized"] == bool(net.switch.loc[sid, "closed"])
+
+
+def test_evaluate_de_energized_passes_when_switch_open(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    sid = int(net.switch.index[0])
+    net.switch.loc[sid, "closed"] = False
+    cond = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    table="switch",
+                    table_id=sid,
+                    ctype=SppsConditionType.CURRENT.value,
+                    check=SppsConditionCheckType.DE_ENERGIZED.value,
+                    limit=None,
+                )
+            ]
+        )
+    )
+    _populate_energized(cond, net)
+    cond["failed"] = False
+    cond["condition_element_value"] = 0.0
+    _evaluate_conditions(cond)
+    assert cond.loc[0, "is_condition"]
+
+
+def test_evaluate_gt_lt_eq(pandapower_net: pp.pandapowerNet) -> None:
+    lid = int(pandapower_net.line.index[0])
+    cond = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(scheme="a", check=SppsConditionCheckType.GT.value, limit=1.0, table_id=lid),
+                _cond_row(scheme="b", check=SppsConditionCheckType.LT.value, limit=10.0, table_id=lid),
+                _cond_row(scheme="c", check=SppsConditionCheckType.EQ.value, limit=3.0, table_id=lid),
+            ]
+        )
+    )
+    cond["failed"] = False
+    cond["energized"] = True
+    cond.loc[0, "condition_element_value"] = 2.0
+    cond.loc[1, "condition_element_value"] = 2.0
+    cond.loc[2, "condition_element_value"] = 3.0
+    _evaluate_conditions(cond)
+    assert cond.loc[0, "is_condition"]
+    assert cond.loc[1, "is_condition"]
+    assert cond.loc[2, "is_condition"]
+
+
+def test_evaluate_failed_uses_failed_column(pandapower_net: pp.pandapowerNet) -> None:
+    lid = int(pandapower_net.line.index[0])
+    cond = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    check=SppsConditionCheckType.FAILED.value,
+                    limit=None,
+                    table_id=lid,
+                )
+            ]
+        )
+    )
+    cond["failed"] = True
+    cond["energized"] = True
+    cond["condition_element_value"] = 0.0
+    _evaluate_conditions(cond)
+    assert cond.loc[0, "is_condition"]
+
+
+def test_populate_failed_explicit_uid(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    uid = f"{lid}{SEPARATOR}line"
+    cond = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    check=SppsConditionCheckType.FAILED.value,
+                    limit=None,
+                    table_id=lid,
+                )
+            ]
+        )
+    )
+    _populate_energized(cond, net)
+    _populate_failed(cond, {uid}, net)
+    assert cond.loc[0, "failed"]
+
+
+def test_extract_condition_values_line_current(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    pp.runpp(net, lightsim2grid=False)
+    lid = int(net.line.index[0])
+    cond = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    ctype=SppsConditionType.CURRENT.value,
+                    check=SppsConditionCheckType.GT.value,
+                    side=SppsConditionSide.PRIMARY.value,
+                    limit=0.0,
+                    table_id=lid,
+                )
+            ]
+        )
+    )
+    _extract_condition_values(cond, net)
+    assert pd.notna(cond.loc[0, "condition_element_value"])
+    assert cond.loc[0, "condition_element_value"] >= 0.0
+
+
+def test_apply_switch_actions_open_and_closed(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    s0 = int(net.switch.index[0])
+    s1 = int(net.switch.index[1]) if len(net.switch.index) > 1 else None
+    net.switch.loc[s0, "closed"] = True
+    if s1 is not None:
+        net.switch.loc[s1, "closed"] = True
+    rows = [
+        {
+            "measure_element_table": "switch",
+            "measure_element_table_id": s0,
+            "measure_value": SppsSwitchActionTarget.OPEN.value,
+        },
+    ]
+    if s1 is not None:
+        rows.append(
+            {
+                "measure_element_table": "switch",
+                "measure_element_table_id": s1,
+                "measure_value": SppsSwitchActionTarget.CLOSED.value,
+            }
+        )
+    _apply_switch_actions(pd.DataFrame(rows), net)
+    assert not net.switch.loc[s0, "closed"]
+    if s1 is not None:
+        assert net.switch.loc[s1, "closed"]
+
+
+def test_apply_actions_gen_active_power(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    if net.gen.empty:
+        pytest.skip("network has no generators")
+    gid = int(net.gen.index[0])
+    old_p = float(net.gen.loc[gid, "p_mw"])
+    actions = _validate_actions(
+        pd.DataFrame(
+            [
+                {
+                    "scheme_name": "g",
+                    "measure_type": SppsMeasureType.ACTIVE_POWER.value,
+                    "measure_value": old_p + 1.0,
+                    "measure_element_table": "gen",
+                    "measure_element_table_id": gid,
+                }
+            ]
+        )
+    )
+    _apply_actions(actions, net)
+    assert net.gen.loc[gid, "p_mw"] == pytest.approx(old_p + 1.0)
+
+
+def test_snapshot_and_restore_res_tables(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    pp.runpp(net, lightsim2grid=False)
+    snap = _snapshot_res_tables(net)
+    assert "res_bus" in snap
+    orig_vm = net.res_bus["vm_pu"].copy()
+    net.res_bus["vm_pu"] = -999.0
+    _restore_res_tables(net, snap)
+    pd.testing.assert_series_equal(net.res_bus["vm_pu"], orig_vm, check_names=True)
+
+
+def test_run_power_flow_dc(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    _run_power_flow(net, "dc", {})
+    assert net.converged
+
+
+def test_run_spps_activates_scheme_applies_switch_dc(pandapower_net: pp.pandapowerNet) -> None:
+    """Use max_iterations>1 so the engine does not treat hitting max_iters as an error after one activation."""
+    net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    sid = int(net.switch.index[0])
+    was_closed = bool(net.switch.loc[sid, "closed"])
+
+    conditions = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    scheme="trip",
+                    table="line",
+                    table_id=lid,
+                    ctype=SppsConditionType.CURRENT.value,
+                    check=SppsConditionCheckType.GT.value,
+                    side=SppsConditionSide.PRIMARY.value,
+                    limit=-1.0,
+                )
+            ]
+        )
+    )
+    actions = _validate_actions(
+        pd.DataFrame(
+            [
+                _act_row(
+                    scheme="trip",
+                    table_id=sid,
+                    mvalue=SppsSwitchActionTarget.OPEN.value,
+                )
+            ]
+        )
+    )
+    failed: set[str] = set()
+    result = run_spps(net, conditions, actions, failed, method="dc", max_iterations=5, runpp_kwargs={})
+    assert result.iterations >= 1
+    assert result.activated_schemes_per_iter
+    assert any("trip" in batch for batch in result.activated_schemes_per_iter)
+    assert not result.power_flow_failed
+    assert not result.max_iterations_reached
+    if was_closed:
+        assert not net.switch.loc[sid, "closed"]
+        assert f"{sid}{SEPARATOR}switch" in failed
+
+
+def test_run_spps_no_activation_when_condition_false(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    conditions = _validate_conditions(
+        pd.DataFrame(
+            [
+                _cond_row(
+                    scheme="never",
+                    table="line",
+                    table_id=lid,
+                    ctype=SppsConditionType.CURRENT.value,
+                    check=SppsConditionCheckType.GT.value,
+                    side=SppsConditionSide.PRIMARY.value,
+                    limit=1.0e30,
+                )
+            ]
+        )
+    )
+    actions = _validate_actions(pd.DataFrame([_act_row(scheme="never", table_id=int(net.switch.index[0]))]))
+    result = run_spps(net, conditions, actions, set(), method="dc", max_iterations=3, runpp_kwargs={})
+    assert result.iterations == 0
+    assert result.activated_schemes_per_iter == []
+
+
+def test_run_spps_raises_on_initial_pf_failure() -> None:
+    net = pp.create_empty_network()
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=0)]))
+    actions = _validate_actions(pd.DataFrame([_act_row()]))
+    with pytest.raises(Exception):
+        run_spps(net, conditions, actions, set(), method="dc", max_iterations=2, runpp_kwargs={})
+
+
+def test_run_spps_max_iterations_exhausted_raises(pandapower_net: pp.pandapowerNet) -> None:
+    """Two schemes always eligible; max_iterations=1 completes one iter then raises (engine contract)."""
+    net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    s0, s1 = int(net.switch.index[0]), int(net.switch.index[1]) if len(net.switch.index) > 1 else None
+    if s1 is None:
+        pytest.skip("need two switches")
+    cond_rows = [
+        _cond_row(scheme="A", table_id=lid, limit=-1.0),
+        _cond_row(scheme="B", table_id=lid, limit=-1.0),
+    ]
+    conditions = _validate_conditions(pd.DataFrame(cond_rows))
+    actions = _validate_actions(
+        pd.DataFrame(
+            [
+                _act_row(scheme="A", table_id=s0, mvalue=SppsSwitchActionTarget.OPEN.value),
+                _act_row(scheme="B", table_id=s1, mvalue=SppsSwitchActionTarget.OPEN.value),
+            ]
+        )
+    )
+    with pytest.raises(SppsPowerFlowError, match="max_iterations"):
+        run_spps(
+            net,
+            conditions,
+            actions,
+            set(),
+            method="dc",
+            max_iterations=1,
+            runpp_kwargs={},
+            on_power_flow_error=SppsPowerFlowFailurePolicy.RAISE,
+        )
+
+
+def test_run_spps_keep_previous_restores_res_after_pf_failure(pandapower_net: pp.pandapowerNet) -> None:
+    """Second in-loop PF fails; ``res_*`` are restored from the snapshot taken before that call."""
+    net = deepcopy(pandapower_net)
+    pp.runpp(net, lightsim2grid=False)
+    vm_after_initial = net.res_bus["vm_pu"].copy()
+
+    lid = int(net.line.index[0])
+    sid = int(net.switch.index[0])
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(scheme="x", table_id=lid, limit=-1.0)]))
+    actions = _validate_actions(pd.DataFrame([_act_row(scheme="x", table_id=sid)]))
+
+    calls = {"n": 0}
+
+    def _run_pw(n: pp.pandapowerNet, method: str, runpp_kwargs: dict) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            pp.runpp(n, **runpp_kwargs)
+        elif calls["n"] == 2:
+            raise RuntimeError("simulated pf failure")
+        else:
+            pp.runpp(n, **runpp_kwargs)
+
+    with mock.patch("toop_engine_contingency_analysis.pandapower.spps.engine._run_power_flow", side_effect=_run_pw):
+        result = run_spps(
+            net,
+            conditions,
+            actions,
+            set(),
+            method="dc",
+            max_iterations=2,
+            runpp_kwargs={"lightsim2grid": False},
+            on_power_flow_error=SppsPowerFlowFailurePolicy.KEEP_PREVIOUS,
+        )
+
+    assert result.power_flow_failed is True
+    pd.testing.assert_series_equal(net.res_bus["vm_pu"], vm_after_initial, check_names=True, rtol=0, atol=0)

--- a/packages/contingency_analysis_pkg/tests/pandapower/spps/test_spps_condition_logic.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/spps/test_spps_condition_logic.py
@@ -1,0 +1,67 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+import pandas as pd
+from toop_engine_contingency_analysis.pandapower.spps.engine import _satisfied_scheme_names
+
+
+def test_satisfied_scheme_names_legacy_defaults_to_all() -> None:
+    df = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "is_condition": [True, True],
+        }
+    )
+    assert _satisfied_scheme_names(df) == {"s1"}
+
+    df2 = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "is_condition": [True, False],
+        }
+    )
+    assert _satisfied_scheme_names(df2) == set()
+
+
+def test_satisfied_scheme_names_all_requires_every_row() -> None:
+    df = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "condition_logic": ["all", "all"],
+            "is_condition": [True, False],
+        }
+    )
+    assert _satisfied_scheme_names(df) == set()
+
+    df_ok = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "condition_logic": ["all", "all"],
+            "is_condition": [True, True],
+        }
+    )
+    assert _satisfied_scheme_names(df_ok) == {"s1"}
+
+
+def test_satisfied_scheme_names_any_one_true_suffices() -> None:
+    df = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "condition_logic": ["any", "any"],
+            "is_condition": [False, True],
+        }
+    )
+    assert _satisfied_scheme_names(df) == {"s1"}
+
+    df_none = pd.DataFrame(
+        {
+            "scheme_name": ["s1", "s1"],
+            "condition_logic": ["any", "any"],
+            "is_condition": [False, False],
+        }
+    )
+    assert _satisfied_scheme_names(df_none) == set()

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_result_helpers.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_result_helpers.py
@@ -20,6 +20,7 @@ import polars as pl
 from beartype.typing import Optional, Union
 from fsspec import AbstractFileSystem
 from jaxtyping import Bool, Float
+from toop_engine_interfaces.interface_helpers import get_empty_dataframe_from_model
 from toop_engine_interfaces.loadflow_results import (
     BranchResultSchema,
     BranchSide,
@@ -28,6 +29,7 @@ from toop_engine_interfaces.loadflow_results import (
     LoadflowResults,
     NodeResultSchema,
     RegulatingElementResultSchema,
+    SppsResultsSchema,
     VADiffResultSchema,
 )
 from toop_engine_interfaces.loadflow_results_polars import LoadflowResultsPolars
@@ -179,6 +181,13 @@ def concatenate_loadflow_results(
         for lf_results in loadflow_results_list
         for additional_information in lf_results.additional_information
     ]
+    spps_results = pd.concat(
+        [
+            lf.spps_results if lf.spps_results is not None else get_empty_dataframe_from_model(SppsResultsSchema)
+            for lf in loadflow_results_list
+        ],
+        axis=0,
+    )
     return LoadflowResults(
         job_id=loadflow_results_list[0].job_id,
         branch_results=branch_results,
@@ -189,6 +198,7 @@ def concatenate_loadflow_results(
         switch_results=switch_results,
         warnings=warnings,
         additional_information=additional_information,
+        spps_results=spps_results,
     )
 
 
@@ -512,6 +522,9 @@ def select_timestep(loadflow_results: LoadflowResults, timestep: Integral) -> Lo
         regulating_element_results=safe_xs(loadflow_results.regulating_element_results),
         converged=safe_xs(loadflow_results.converged),
         va_diff_results=safe_xs(loadflow_results.va_diff_results),
+        spps_results=safe_xs(loadflow_results.spps_results)
+        if loadflow_results.spps_results is not None
+        else get_empty_dataframe_from_model(SppsResultsSchema),
     )
 
 
@@ -558,6 +571,10 @@ def convert_polars_loadflow_results_to_pandas(
             pdf = pdf.set_index(index_cols)
         return pdf
 
+    spps_pandas = polars_to_pandas(loadflow_results_polars.spps_results)
+    if spps_pandas is None:
+        spps_pandas = get_empty_dataframe_from_model(SppsResultsSchema)
+
     return LoadflowResults(
         job_id=loadflow_results_polars.job_id,
         branch_results=polars_to_pandas(loadflow_results_polars.branch_results),
@@ -567,6 +584,7 @@ def convert_polars_loadflow_results_to_pandas(
         va_diff_results=polars_to_pandas(loadflow_results_polars.va_diff_results),
         warnings=loadflow_results_polars.warnings,
         additional_information=loadflow_results_polars.additional_information,
+        spps_results=spps_pandas,
     )
 
 
@@ -607,6 +625,9 @@ def convert_pandas_loadflow_results_to_polars(loadflow_results: LoadflowResults)
             df = df.lazy()  # Assume it's a pandas DataFrame
         return df  # Assume it's already a polars DataFrame
 
+    sps = loadflow_results.spps_results
+    if sps is None:
+        sps = get_empty_dataframe_from_model(SppsResultsSchema)
     return LoadflowResultsPolars(
         job_id=loadflow_results.job_id,
         branch_results=pandas_to_polars(loadflow_results.branch_results, lazy=True),
@@ -618,5 +639,5 @@ def convert_pandas_loadflow_results_to_polars(loadflow_results: LoadflowResults)
         connectivity_result=pandas_to_polars(loadflow_results.connectivity_result, lazy=True),
         warnings=loadflow_results.warnings,
         additional_information=loadflow_results.additional_information,
-        lazy=True,
+        spps_results=pandas_to_polars(sps, lazy=True),
     )

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_result_helpers.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_result_helpers.py
@@ -522,9 +522,6 @@ def select_timestep(loadflow_results: LoadflowResults, timestep: Integral) -> Lo
         regulating_element_results=safe_xs(loadflow_results.regulating_element_results),
         converged=safe_xs(loadflow_results.converged),
         va_diff_results=safe_xs(loadflow_results.va_diff_results),
-        spps_results=safe_xs(loadflow_results.spps_results)
-        if loadflow_results.spps_results is not None
-        else get_empty_dataframe_from_model(SppsResultsSchema),
     )
 
 
@@ -571,10 +568,6 @@ def convert_polars_loadflow_results_to_pandas(
             pdf = pdf.set_index(index_cols)
         return pdf
 
-    spps_pandas = polars_to_pandas(loadflow_results_polars.spps_results)
-    if spps_pandas is None:
-        spps_pandas = get_empty_dataframe_from_model(SppsResultsSchema)
-
     return LoadflowResults(
         job_id=loadflow_results_polars.job_id,
         branch_results=polars_to_pandas(loadflow_results_polars.branch_results),
@@ -584,7 +577,6 @@ def convert_polars_loadflow_results_to_pandas(
         va_diff_results=polars_to_pandas(loadflow_results_polars.va_diff_results),
         warnings=loadflow_results_polars.warnings,
         additional_information=loadflow_results_polars.additional_information,
-        spps_results=spps_pandas,
     )
 
 
@@ -625,9 +617,6 @@ def convert_pandas_loadflow_results_to_polars(loadflow_results: LoadflowResults)
             df = df.lazy()  # Assume it's a pandas DataFrame
         return df  # Assume it's already a polars DataFrame
 
-    sps = loadflow_results.spps_results
-    if sps is None:
-        sps = get_empty_dataframe_from_model(SppsResultsSchema)
     return LoadflowResultsPolars(
         job_id=loadflow_results.job_id,
         branch_results=pandas_to_polars(loadflow_results.branch_results, lazy=True),
@@ -639,5 +628,5 @@ def convert_pandas_loadflow_results_to_polars(loadflow_results: LoadflowResults)
         connectivity_result=pandas_to_polars(loadflow_results.connectivity_result, lazy=True),
         warnings=loadflow_results.warnings,
         additional_information=loadflow_results.additional_information,
-        spps_results=pandas_to_polars(sps, lazy=True),
+        lazy=True,
     )

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_results.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_results.py
@@ -439,6 +439,34 @@ class ConvergedSchema(pa.DataFrameModel):
     """
 
 
+class SppsResultsSchema(pa.DataFrameModel):
+    """SpPS run summaries, one row per (timestep, contingency).
+
+    ``activated_schemes_per_iter`` holds a JSON string encoding of
+    ``list[list[str]]`` (outer list = SpPS outer iterations, inner = scheme
+    names that fired in that iteration), so the table remains parquet-friendly.
+    Use ``json.loads`` to recover the nested structure.
+    """
+
+    timestep: Index[int]
+    """Loadflow timestep index for the outage that produced this row."""
+
+    contingency: Index[str]
+    """Globally unique id of the contingency (same value as in other loadflow result tables)."""
+
+    iterations: Series[int]
+    """Number of SpPS iterations that executed (1-based count)."""
+
+    activated_schemes_per_iter: Series[str] = pa.Field()
+    """JSON string for ``list[list[str]]`` of scheme names that activated per iteration."""
+
+    max_iterations_reached: Series[bool]
+    """Whether the run stopped because the iteration cap was hit while schemes still fired."""
+
+    power_flow_failed: Series[bool]
+    """Whether a post-action power flow failed in keep_previous mode."""
+
+
 LoadflowResultTable = Union[
     pat.DataFrame[NodeResultSchema],
     pat.DataFrame[BranchResultSchema],
@@ -447,6 +475,7 @@ LoadflowResultTable = Union[
     pat.DataFrame[SwitchResultsSchema],
     pat.DataFrame[RegulatingElementResultSchema],
     pat.DataFrame[ConvergedSchema],
+    pat.DataFrame[SppsResultsSchema],
 ]
 
 
@@ -505,6 +534,11 @@ class LoadflowResults(BaseModel):
     additional_information: Optional[list[Any]] = Field(default_factory=list)
     """Additional information that the loadflow solver wants to convey to the user. There is no limitation what can
     be put in here except that it needs to be json serializable."""
+
+    spps_results: DataFrame[SppsResultsSchema] = None
+    """SpPS run summaries, concatenated in single-outage order. When SpPS did not run for a case, that chunk
+    contributes no rows. If no job recorded SpPS, this is the empty DataFrame
+    (default)."""
 
     def __eq__(self, lf_result: object) -> bool:
         """Compare two LoadflowResults objects for equality.

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_results_polars.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/loadflow_results_polars.py
@@ -22,6 +22,7 @@ from toop_engine_interfaces.loadflow_results import (
     ConvergedSchema,
     NodeResultSchema,
     RegulatingElementResultSchema,
+    SppsResultsSchema,
     SwitchResultsSchema,
     VADiffResultSchema,
 )
@@ -69,6 +70,12 @@ class ConvergedSchemaPolars(pal.DataFrameModel, ConvergedSchema):
     pass
 
 
+class SppsResultsSchemaPolars(pal.DataFrameModel, SppsResultsSchema):
+    """Polars variant of SppsResultsSchema."""
+
+    pass
+
+
 LoadflowResultTablePolars = Union[
     patpl.LazyFrame[NodeResultSchemaPolars],
     patpl.LazyFrame[BranchResultSchemaPolars],
@@ -77,6 +84,7 @@ LoadflowResultTablePolars = Union[
     patpl.LazyFrame[SwitchResultsSchemaPolars],
     patpl.LazyFrame[RegulatingElementResultSchemaPolars],
     patpl.LazyFrame[ConvergedSchemaPolars],
+    patpl.LazyFrame[SppsResultsSchemaPolars],
 ]
 
 
@@ -136,6 +144,10 @@ class LoadflowResultsPolars(BaseModel):
     """Additional information that the loadflow solver wants to convey to the user. There is no limitation what can
     be put in here except that it needs to be json serializable."""
 
+    spps_results: Union[patpl.LazyFrame[SppsResultsSchemaPolars], pl.LazyFrame] = None
+    """SpPS run summaries, concatenated in single-outage order. Empty when no
+    SpPS was recorded (default)."""
+
     class Config:
         """Pydantic configuration for the LoadflowResultsPolars model."""
 
@@ -187,6 +199,10 @@ class LoadflowResultsPolars(BaseModel):
             assert_frame_equal(self.regulating_element_results, lf_result.regulating_element_results, **kw_args_testing)
             assert_frame_equal(self.va_diff_results, lf_result.va_diff_results, **kw_args_testing)
             assert_frame_equal(self.converged, lf_result.converged, **kw_args_testing)
+            if self.spps_results is not None and lf_result.spps_results is not None:
+                assert_frame_equal(self.spps_results, lf_result.spps_results, **kw_args_testing)
+            elif self.spps_results is not None or lf_result.spps_results is not None:
+                return False
         except AssertionError:
             return False
 

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 from toop_engine_interfaces.filesystem_helper import load_pydantic_model_fs, save_pydantic_model_fs
 from toop_engine_interfaces.spps_parameters import (
     SppsConditionCheckType,
+    SppsConditionLogic,
     SppsConditionSide,
     SppsConditionType,
     SppsMeasureType,
@@ -153,8 +154,12 @@ class SppsRule(BaseModel):
     scheme_name: str
     """Unique scheme identifier."""
 
+    condition_logic: SppsConditionLogic = SppsConditionLogic.ALL
+    """Whether every condition must pass SppsConditionLogic.ALL
+    or at least one SppsConditionLogic.ANY for the scheme to activate."""
+
     conditions: list[Condition]
-    """All conditions must be satisfied for the rule to activate."""
+    """Condition rows for this scheme; combined according to `condition_logic`."""
 
     actions: list[Action]
     """Actions applied when the rule is activated."""

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
@@ -107,6 +107,53 @@ class Contingency(BaseModel):
         return len(self.elements) == 1
 
 
+class Condition(BaseModel):
+    """Represents a single condition in a rule."""
+
+    condition_type: Literal["current", "active_power", "reactive_power", "voltage", "state"]
+    """Type of condition to evaluate."""
+
+    condition_check_type: Literal[">", "<", "=", "failed", "de_energized"]
+    """Comparison operator or special check."""
+
+    condition_side: Literal["primary", "secondary", "tertiary", "maximum_value"]
+    """Element side or aggregation mode."""
+
+    condition_limit_value: Optional[float] = None
+    """Threshold value for numeric checks."""
+
+    condition_element_unique_id: str
+    """Globally unique identifier of the condition element.
+    """
+
+
+class Action(BaseModel):
+    """Represents a single action in a rule."""
+
+    measure_element_unique_id: str
+    """Globally unique identifier of the element to apply the action to.
+    """
+
+    measure_type: Literal["active_power", "reactive_power", "voltage", "switching_state"]
+    """Type of action."""
+
+    measure_value: Union[float, str]
+    """Target value (numeric or 'Open'/'Closed')."""
+
+
+class SppsRule(BaseModel):
+    """Represents a full scheme with multiple conditions and actions."""
+
+    scheme_name: str
+    """Unique scheme identifier."""
+
+    conditions: list[Condition]
+    """All conditions must be satisfied for the rule to activate."""
+
+    actions: list[Action]
+    """Actions applied when the rule is activated."""
+
+
 class Nminus1Definition(BaseModel):
     """An N-1 definition holds monitored and outaged elements for a grid.
 
@@ -119,6 +166,10 @@ class Nminus1Definition(BaseModel):
 
     contingencies: list[Contingency]
     """A list of contingencies that should be computed during the N-1 computation."""
+
+    spps_rules: Optional[SppsRule] = None
+    """The spps ruleset to use for the N-1 computation. This is optional.
+    If not provided, spps ruleset will not be used."""
 
     id_type: Optional[ELEMENT_ID_TYPES] = None
     """The type of the ids used in the N-1 definition. This is used to determine how to interpret the ids in the

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/nminus1_definition.py
@@ -22,6 +22,12 @@ from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from pydantic import BaseModel
 from toop_engine_interfaces.filesystem_helper import load_pydantic_model_fs, save_pydantic_model_fs
+from toop_engine_interfaces.spps_parameters import (
+    SppsConditionCheckType,
+    SppsConditionSide,
+    SppsConditionType,
+    SppsMeasureType,
+)
 
 # The type of the ids used in the N-1 definition. This changes how the elements are identified in the grid.
 # - unique_pandapower:
@@ -110,13 +116,13 @@ class Contingency(BaseModel):
 class Condition(BaseModel):
     """Represents a single condition in a rule."""
 
-    condition_type: Literal["current", "active_power", "reactive_power", "voltage", "state"]
+    condition_type: SppsConditionType
     """Type of condition to evaluate."""
 
-    condition_check_type: Literal[">", "<", "=", "failed", "de_energized"]
+    condition_check_type: SppsConditionCheckType
     """Comparison operator or special check."""
 
-    condition_side: Literal["primary", "secondary", "tertiary", "maximum_value"]
+    condition_side: SppsConditionSide
     """Element side or aggregation mode."""
 
     condition_limit_value: Optional[float] = None
@@ -134,7 +140,7 @@ class Action(BaseModel):
     """Globally unique identifier of the element to apply the action to.
     """
 
-    measure_type: Literal["active_power", "reactive_power", "voltage", "switching_state"]
+    measure_type: SppsMeasureType
     """Type of action."""
 
     measure_value: Union[float, str]

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/spps_parameters.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/spps_parameters.py
@@ -71,8 +71,19 @@ class SppsSwitchActionTarget(StrEnum):
     CLOSED = "closed"
 
 
+class SppsConditionLogic(StrEnum):
+    """How multiple :class:`~toop_engine_interfaces.nminus1_definition.Condition` rows in one scheme combine."""
+
+    ALL = "all"
+    """Every condition row for the scheme must pass (logical AND)."""
+
+    ANY = "any"
+    """At least one condition row for the scheme must pass (logical OR)."""
+
+
 # For Pandera ``isin=`` and similar (stable order)
 SPPS_CONDITION_TYPE_VALUES: tuple[str, ...] = _values(SppsConditionType)
 SPPS_CONDITION_CHECK_TYPE_VALUES: tuple[str, ...] = _values(SppsConditionCheckType)
 SPPS_CONDITION_SIDE_VALUES: tuple[str, ...] = _values(SppsConditionSide)
+SPPS_CONDITION_LOGIC_VALUES: tuple[str, ...] = _values(SppsConditionLogic)
 SPPS_MEASURE_TYPE_VALUES: tuple[str, ...] = _values(SppsMeasureType)

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/spps_parameters.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/spps_parameters.py
@@ -1,0 +1,78 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+"""String enums for SpPS (Special Protection Scheme) parameters and table columns.
+
+Values match the wire / DataFrame / JSON string literals used in pandapower
+and Pandera schemas. Subclass :class:`str` so members compare equal to their
+string values and serialize as plain strings in Pydantic.
+"""
+
+from enum import StrEnum
+
+
+def _values(e: type[StrEnum]) -> tuple[str, ...]:
+    return tuple(m.value for m in e)
+
+
+class SppsConditionType(StrEnum):
+    """``condition_type`` in :class:`toop_engine_interfaces.nminus1_definition.Condition`."""
+
+    CURRENT = "current"
+    ACTIVE_POWER = "active_power"
+    REACTIVE_POWER = "reactive_power"
+    VOLTAGE = "voltage"
+    STATE = "state"
+
+
+class SppsConditionCheckType(StrEnum):
+    """``condition_check_type`` in :class:`toop_engine_interfaces.nminus1_definition.Condition`."""
+
+    GT = ">"
+    LT = "<"
+    EQ = "="
+    FAILED = "failed"
+    DE_ENERGIZED = "de_energized"
+
+
+class SppsConditionSide(StrEnum):
+    """``condition_side`` in :class:`toop_engine_interfaces.nminus1_definition.Condition`."""
+
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+    TERTIARY = "tertiary"
+    MAXIMUM_VALUE = "maximum_value"
+
+
+class SppsMeasureType(StrEnum):
+    """``measure_type`` in :class:`toop_engine_interfaces.nminus1_definition.Action`."""
+
+    ACTIVE_POWER = "active_power"
+    REACTIVE_POWER = "reactive_power"
+    VOLTAGE = "voltage"
+    SWITCHING_STATE = "switching_state"
+
+
+class SppsPowerFlowFailurePolicy(StrEnum):
+    """In-loop power-flow error handling for :func:`run_spps` and contingency config."""
+
+    RAISE = "raise"
+    KEEP_PREVIOUS = "keep_previous"
+
+
+class SppsSwitchActionTarget(StrEnum):
+    """Lowercase wire values for switch ``switching_state`` (``measure_value`` strings)."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+# For Pandera ``isin=`` and similar (stable order)
+SPPS_CONDITION_TYPE_VALUES: tuple[str, ...] = _values(SppsConditionType)
+SPPS_CONDITION_CHECK_TYPE_VALUES: tuple[str, ...] = _values(SppsConditionCheckType)
+SPPS_CONDITION_SIDE_VALUES: tuple[str, ...] = _values(SppsConditionSide)
+SPPS_MEASURE_TYPE_VALUES: tuple[str, ...] = _values(SppsMeasureType)

--- a/packages/interfaces_pkg/tests/test_loadflow_results_new.py
+++ b/packages/interfaces_pkg/tests/test_loadflow_results_new.py
@@ -17,6 +17,7 @@ from toop_engine_interfaces.loadflow_results import (
     NodeResultSchema,
     RegulatingElementResultSchema,
     RegulatingElementType,
+    SppsResultsSchema,
     SwitchResultsSchema,
     VADiffResultSchema,
 )
@@ -90,6 +91,7 @@ def get_loadflow_results_example(
     va_diff_results = get_empty_dataframe_from_model(VADiffResultSchema)
     converged = get_empty_dataframe_from_model(ConvergedSchema)
     switch_results = get_empty_dataframe_from_model(SwitchResultsSchema)
+    spps_results = get_empty_dataframe_from_model(SppsResultsSchema)
     if contingencies is None:
         contingencies = ["contingency"]
     for i, contingency in enumerate(contingencies):
@@ -108,6 +110,7 @@ def get_loadflow_results_example(
         va_diff_results=va_diff_results,
         converged=converged,
         switch_results=switch_results,
+        spps_results=spps_results,
         additional_information=["This is generated test data"],
         warnings=["warning1"],
     )


### PR DESCRIPTION
Add SpPS rule engine (run_spps) integration into contingency analysis
Overview
This PR integrates the SpPS (Special Protection Scheme) rule engine into the N-1 contingency analysis workflow. It enables dynamic rule-based actions (e.g. switching, setpoint changes) to be evaluated and applied during outage simulations.

Behavior changes
During a contingency:
If SpPS rules are defined → the engine runs iterative:
Evaluate conditions
Activate schemes
Apply actions
Re-run power flow
Otherwise → fallback to standard pp.runpp / pp.rundcpp
Convergence status is now influenced by SpPS execution:
FAILED if:
power flow fails inside SpPS
max iterations reached
CONVERGED otherwise



