### PR TITLE
feat: linear pst switching distance and redefinition squared distance

### DIFF
--- a/benchmarks/benchmark_run_single_device_epoch.py
+++ b/benchmarks/benchmark_run_single_device_epoch.py
@@ -189,6 +189,8 @@ def _get_supported_observed_metrics(dynamic_information, solver_config):
 
     if dynamic_information.nodal_injection_information is not None:
         metrics.append("pst_switching_distance")
+        metrics.append("pst_switching_distance_squared")
+        metrics.append("pst_activated")
 
     if dynamic_information.n2_baseline_analysis is not None:
         metrics.append("n_2_penalty")

--- a/docs/dc_solver/quickstart.md
+++ b/docs/dc_solver/quickstart.md
@@ -152,8 +152,8 @@ The possible aggregation metrics can be found [`here`][toop_engine_interfaces.ty
 | "cross_coupler_flow"                      | The sum of the power flowing across the switched busbarcouplers before opening them                                                                                        |
 | "switching_distance"                      | The amount of switching actions have to take place from the original to the proposed topology                                                                              |
 | "split_subs"                              | The amount of busbar couplers were opened                                                                                                                                  |
-| "pst_switching_distance"                  | Squared sum of absolute distances from initial PST tap indices to optimized PST tap indices (summed over PSTs and timesteps)                                                                |
-| "pst_switching_distance_linear"           | Linear distance from initial PST tap indices to optimized PST tap indices, computed as the sum of absolute tap changes across PSTs and timesteps                            |
+| "pst_switching_distance_squared"                  | Squared sum of absolute distances from initial PST tap indices to optimized PST tap indices (summed over PSTs and timesteps)                                                                |
+| "pst_switching_distance"           | Linear distance from initial PST tap indices to optimized PST tap indices, computed as the sum of absolute tap changes across PSTs and timesteps                            |
 | "pst_activated"                        | Number of PST tap indices that changed compared to the initial taps (implicit unit cost, weighted through `target_metrics`)                                                |
 
 #### Branch Weights

--- a/docs/dc_solver/quickstart.md
+++ b/docs/dc_solver/quickstart.md
@@ -152,7 +152,7 @@ The possible aggregation metrics can be found [`here`][toop_engine_interfaces.ty
 | "cross_coupler_flow"                      | The sum of the power flowing across the switched busbarcouplers before opening them                                                                                        |
 | "switching_distance"                      | The amount of switching actions have to take place from the original to the proposed topology                                                                              |
 | "split_subs"                              | The amount of busbar couplers were opened                                                                                                                                  |
-| "pst_switching_distance"                  | Squared distance from initial PST tap indices to optimized PST tap indices (summed over PSTs and timesteps)                                                                |
+| "pst_switching_distance"                  | Squared sum of absolute distances from initial PST tap indices to optimized PST tap indices (summed over PSTs and timesteps)                                                                |
 | "pst_switching_distance_linear"           | Linear distance from initial PST tap indices to optimized PST tap indices, computed as the sum of absolute tap changes across PSTs and timesteps                            |
 | "pst_activated"                        | Number of PST tap indices that changed compared to the initial taps (implicit unit cost, weighted through `target_metrics`)                                                |
 

--- a/docs/dc_solver/quickstart.md
+++ b/docs/dc_solver/quickstart.md
@@ -153,6 +153,7 @@ The possible aggregation metrics can be found [`here`][toop_engine_interfaces.ty
 | "switching_distance"                      | The amount of switching actions have to take place from the original to the proposed topology                                                                              |
 | "split_subs"                              | The amount of busbar couplers were opened                                                                                                                                  |
 | "pst_switching_distance"                  | Squared distance from initial PST tap indices to optimized PST tap indices (summed over PSTs and timesteps)                                                                |
+| "pst_switching_distance_linear"           | Linear distance from initial PST tap indices to optimized PST tap indices, computed as the sum of absolute tap changes across PSTs and timesteps                            |
 | "pst_activated"                        | Number of PST tap indices that changed compared to the initial taps (implicit unit cost, weighted through `target_metrics`)                                                |
 
 #### Branch Weights

--- a/docs/topology_optimizer/metrics.md
+++ b/docs/topology_optimizer/metrics.md
@@ -48,6 +48,8 @@ These metrics measure operational aspects of the topology rather than electrical
 
 - **pst_switching_distance**: Squared distance from the initial PST setpoints to the current optimized ones.
 
+- **pst_switching_distance_linear**: Linear distance from the initial PST setpoints to the current optimized ones, computed as the sum of absolute tap changes.
+
 - **pst_activated**: Number of PST tap positions that differ from their initial tap position (implicit unit cost). This counts changed PST setpoints and can be weighted in `target_metrics`.
 
 ## Other Metrics

--- a/docs/topology_optimizer/metrics.md
+++ b/docs/topology_optimizer/metrics.md
@@ -46,7 +46,7 @@ These metrics measure operational aspects of the topology rather than electrical
 
 - **disconnected_branches**: Number of branches (lines/transformers) that have been intentionally disconnected in the topology.
 
-- **pst_switching_distance**: Squared distance from the initial PST setpoints to the current optimized ones.
+- **pst_switching_distance**: Squared sum of absolute distances from the initial PST setpoints to the current optimized ones.
 
 - **pst_switching_distance_linear**: Linear distance from the initial PST setpoints to the current optimized ones, computed as the sum of absolute tap changes.
 

--- a/docs/topology_optimizer/metrics.md
+++ b/docs/topology_optimizer/metrics.md
@@ -46,9 +46,9 @@ These metrics measure operational aspects of the topology rather than electrical
 
 - **disconnected_branches**: Number of branches (lines/transformers) that have been intentionally disconnected in the topology.
 
-- **pst_switching_distance**: Squared sum of absolute distances from the initial PST setpoints to the current optimized ones.
+- **pst_switching_distance_squared**: Squared sum of absolute distances from the initial PST setpoints to the current optimized ones.
 
-- **pst_switching_distance_linear**: Linear distance from the initial PST setpoints to the current optimized ones, computed as the sum of absolute tap changes.
+- **pst_switching_distance**: Linear distance from the initial PST setpoints to the current optimized ones, computed as the sum of absolute tap changes.
 
 - **pst_activated**: Number of PST tap positions that differ from their initial tap position (implicit unit cost). This counts changed PST setpoints and can be weighted in `target_metrics`.
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
@@ -559,7 +559,7 @@ def get_bb_outage_grid_splits(bb_outage_grid_splits: Optional[Int[Array, " "]]) 
     return bb_outage_grid_splits.astype(float)
 
 
-def get_pst_switching_distance(
+def get_pst_switching_distance_squared(
     optimized_taps: Optional[NodalInjOptimResults],
     initial_tap_idx: Optional[Int[Array, " n_controllable_pst"]],
 ) -> Float[Array, " "]:
@@ -601,7 +601,7 @@ def get_pst_switching_distance(
     return switching_distance_all_timesteps
 
 
-def get_pst_switching_distance_linear(
+def get_pst_switching_distance(
     optimized_taps: Optional[NodalInjOptimResults],
     initial_tap_idx: Optional[Int[Array, " n_controllable_pst"]],
 ) -> Float[Array, " "]:
@@ -610,7 +610,7 @@ def get_pst_switching_distance_linear(
     This metric measures how much the optimized PST tap positions deviate from the initial
     setpoints using L1 distance (sum of absolute differences). It is useful for penalizing
     solutions that require large changes to PST settings without the quadratic amplification
-    used by ``pst_switching_distance``.
+    used by ``pst_switching_distance_squared``.
 
     Parameters
     ----------
@@ -749,7 +749,7 @@ def aggregate_to_metric_batched(
         The metric to use for aggregation.
     initial_pst_tap_idx : Optional[Int[Array, " n_controllable_pst"]], optional
         The initial tap positions for PSTs. Required for computing PST-based metrics.
-        If None, pst_switching_distance, pst_switching_distance_linear and pst_activated will return 0.0
+        If None, pst_switching_distance, pst_switching_distance_squared and pst_activated will return 0.0
 
     Returns
     -------
@@ -853,7 +853,7 @@ def aggregate_to_metric(  # noqa: C901, PLR0912 # Conditions of the same type pe
         e.g. if you want to ignore busbar outage failures in the overload energy calculation.
     initial_pst_tap_idx : Optional[Int[Array, " n_controllable_pst"]], optional
         The initial tap positions for PSTs. Required for computing PST-based metrics.
-        If None, pst_switching_distance, pst_switching_distance_linear and pst_activated will return 0.0
+        If None, pst_switching_distance, pst_switching_distance_squared and pst_activated will return 0.0
 
     Returns
     -------
@@ -877,8 +877,8 @@ def aggregate_to_metric(  # noqa: C901, PLR0912 # Conditions of the same type pe
                 optimized_taps=lf_res.nodal_injections_optimized,
                 initial_tap_idx=initial_pst_tap_idx,
             )
-        case "pst_switching_distance_linear":
-            retval = get_pst_switching_distance_linear(
+        case "pst_switching_distance_squared":
+            retval = get_pst_switching_distance_squared(
                 optimized_taps=lf_res.nodal_injections_optimized,
                 initial_tap_idx=initial_pst_tap_idx,
             )

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
@@ -592,11 +592,13 @@ def get_pst_switching_distance(
     optimized_tap_idx = optimized_taps.pst_tap_idx
 
     # TODO: Proper multi-timestep support.
-    # Compute squared L2 distance (Euclidean distance squared)
+    # Compute square of sum of absolute differences (L1 distance squared)
     diff = optimized_tap_idx.astype(float) - initial_tap_idx.astype(float)[None, :]
-    switching_distance = jnp.sum(jnp.square(diff))
+    abs_diff = jnp.abs(diff)
+    switching_distance = jnp.square(jnp.sum(abs_diff, axis=1))
+    switching_distance_all_timesteps = jnp.sum(switching_distance)
 
-    return switching_distance
+    return switching_distance_all_timesteps
 
 
 def get_pst_switching_distance_linear(

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/aggregate_results.py
@@ -599,6 +599,41 @@ def get_pst_switching_distance(
     return switching_distance
 
 
+def get_pst_switching_distance_linear(
+    optimized_taps: Optional[NodalInjOptimResults],
+    initial_tap_idx: Optional[Int[Array, " n_controllable_pst"]],
+) -> Float[Array, " "]:
+    """Compute the linear PST switching distance from initial PST setpoints.
+
+    This metric measures how much the optimized PST tap positions deviate from the initial
+    setpoints using L1 distance (sum of absolute differences). It is useful for penalizing
+    solutions that require large changes to PST settings without the quadratic amplification
+    used by ``pst_switching_distance``.
+
+    Parameters
+    ----------
+    optimized_taps : Optional[NodalInjOptimResults]
+        The optimized PST tap positions from the solver. If None (PST optimization disabled),
+        returns 0.0.
+    initial_tap_idx : Optional[Int[Array, " n_controllable_pst"]]
+        The initial tap positions for each controllable PST as indices. If None (no PST info
+        available), returns 0.0.
+
+    Returns
+    -------
+    Float[Array, " "]
+        The sum of absolute differences between optimized and initial tap positions across all
+        controllable PSTs and timesteps. Returns 0.0 if PST optimization is not enabled or data
+        is unavailable.
+    """
+    if optimized_taps is None or initial_tap_idx is None:
+        return jnp.array(0.0)
+
+    optimized_tap_idx = optimized_taps.pst_tap_idx
+    diff = optimized_tap_idx.astype(float) - initial_tap_idx.astype(float)[None, :]
+    return jnp.sum(jnp.abs(diff))
+
+
 def get_pst_activated(
     optimized_taps: Optional[NodalInjOptimResults],
     initial_tap_idx: Optional[Int[Array, " n_controllable_pst"]],
@@ -712,7 +747,7 @@ def aggregate_to_metric_batched(
         The metric to use for aggregation.
     initial_pst_tap_idx : Optional[Int[Array, " n_controllable_pst"]], optional
         The initial tap positions for PSTs. Required for computing PST-based metrics.
-        If None, pst_switching_distance and pst_activated will return 0.0
+        If None, pst_switching_distance, pst_switching_distance_linear and pst_activated will return 0.0
 
     Returns
     -------
@@ -816,7 +851,7 @@ def aggregate_to_metric(  # noqa: C901, PLR0912 # Conditions of the same type pe
         e.g. if you want to ignore busbar outage failures in the overload energy calculation.
     initial_pst_tap_idx : Optional[Int[Array, " n_controllable_pst"]], optional
         The initial tap positions for PSTs. Required for computing PST-based metrics.
-        If None, pst_switching_distance and pst_activated will return 0.0
+        If None, pst_switching_distance, pst_switching_distance_linear and pst_activated will return 0.0
 
     Returns
     -------
@@ -837,6 +872,11 @@ def aggregate_to_metric(  # noqa: C901, PLR0912 # Conditions of the same type pe
             )
         case "pst_switching_distance":
             retval = get_pst_switching_distance(
+                optimized_taps=lf_res.nodal_injections_optimized,
+                initial_tap_idx=initial_pst_tap_idx,
+            )
+        case "pst_switching_distance_linear":
+            retval = get_pst_switching_distance_linear(
                 optimized_taps=lf_res.nodal_injections_optimized,
                 initial_tap_idx=initial_pst_tap_idx,
             )

--- a/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
+++ b/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
@@ -967,7 +967,7 @@ def test_get_pst_switching_distance() -> None:
         pst_tap_idx=jnp.array([[3, 4, 5, 6, 7]], dtype=int)  # All shifted by +1
     )
     switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
-    expected_switching_distance = 5.0  # Sum of (3-2)^2 + (4-3)^2 + (5-4)^2 + (6-5)^2 + (7-6)^2 = 1+1+1+1+1 = 5
+    expected_switching_distance = 25.0  # (Sum of |3-2| + |4-3| + |5-4| + |6-5| + |7-6|)^2 = (1+1+1+1+1)^2 = 25
     assert switching_distance == expected_switching_distance, (
         f"Expected switching_distance {expected_switching_distance}, got {switching_distance}"
     )
@@ -978,9 +978,8 @@ def test_get_pst_switching_distance() -> None:
         pst_tap_idx=jnp.array([[3, 7, 5, 4, 8]], dtype=int)  # switching distances: -2, +2, 0, -1, +3
     )
     switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
-    expected_switching_distance = (
-        4.0 + 4.0 + 0.0 + 1.0 + 9.0
-    )  # Squared L2 distance = (-2)^2 + 2^2 + 0^2 + (-1)^2 + 3^2 = 18.0
+    # Square of L1 distance = (2 + 2 + 0 + 1 + 3)^2 = 64.0
+    expected_switching_distance = (2.0 + 2.0 + 0.0 + 1.0 + 3.0) ** 2
     assert switching_distance == expected_switching_distance, (
         f"Expected switching_distance {expected_switching_distance}, got {switching_distance}"
     )
@@ -990,15 +989,15 @@ def test_get_pst_switching_distance() -> None:
     optimized_taps = NodalInjOptimResults(
         pst_tap_idx=jnp.array(
             [
-                [3, 4, 5, 6],  # First timestep: small switching_distance: 1^2 + 1^2 + 1^2 + 1^2 = 4
-                [10, 10, 10, 10],  # Second timestep: 8^2 + 7^2 + 6^2 + 5^2 = 174
-                [0, 0, 0, 0],  # Third timestep: 2^2 + 3^2 + 4^2 + 5^2 = 54
+                [3, 4, 5, 6],  # First timestep: small switching_distance: (1+1+1+1)^2 = 16
+                [10, 10, 10, 10],  # Second timestep: (8+7+6+5)^2 = 676
+                [0, 0, 0, 0],  # Third timestep: (2+3+4+5)^2 = 196
             ],
             dtype=int,
         )  # shape: (n_timesteps=3, n_controllable_pst=4)
     )
     switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
-    expected_switching_distance = 4.0 + 174.0 + 54.0  # Should sum switching distances across all timesteps
+    expected_switching_distance = 16.0 + 676.0 + 196.0  # Should sum switching distances across all timesteps
     assert switching_distance == expected_switching_distance, (
         f"Expected switching_distance {expected_switching_distance}, got {switching_distance}"
     )
@@ -1017,7 +1016,7 @@ def test_get_pst_switching_distance() -> None:
     assert jnp.allclose(switching_distance_jitted, switching_distance_normal), (
         "JIT and non-JIT versions should produce same result"
     )
-    assert switching_distance_jitted == 3.0, f"Expected switching_distance 3.0, got {switching_distance_jitted}"
+    assert switching_distance_jitted == 9.0, f"Expected switching_distance 9.0, got {switching_distance_jitted}"
 
 
 def test_get_pst_activated() -> None:

--- a/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
+++ b/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
@@ -38,7 +38,7 @@ from toop_engine_dc_solver.jax.aggregate_results import (
     get_overload_energy_n_1_matrix,
     get_pst_activated,
     get_pst_switching_distance,
-    get_pst_switching_distance_linear,
+    get_pst_switching_distance_squared,
     get_switching_distance,
     get_transport_n_1_matrix,
     get_underload_energy_n_1_matrix,
@@ -576,10 +576,10 @@ def test_aggregate_to_metric(mocker) -> None:
         branch_limits,
         reassignment_distance,
         n_subs_rel,
-        "pst_switching_distance",
+        "pst_switching_distance_squared",
         initial_pst_tap_idx=initial_pst_tap_idx,
     )
-    ref = get_pst_switching_distance(
+    ref = get_pst_switching_distance_squared(
         optimized_taps=pst_optimized.nodal_injections_optimized,
         initial_tap_idx=initial_pst_tap_idx,
     )
@@ -939,18 +939,18 @@ def test_get_worst_n_k_contingency_basic() -> None:
     assert jnp.all(worst_k_overload.top_k_overloads >= 0)
 
 
-def test_get_pst_switching_distance() -> None:
-    """Test the PST setpoint switching distance metric."""
+def test_get_pst_switching_distance_squared() -> None:
+    """Test the PST setpoint switching distance squared metric."""
 
     # Case 1: No PST optimization enabled (both None)
-    switching_distance = get_pst_switching_distance(optimized_taps=None, initial_tap_idx=None)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=None, initial_tap_idx=None)
     assert switching_distance == 0.0, "Switching distance should be 0 when PST optimization is disabled"
 
     # Case 2: PST optimization enabled but no initial taps provided
     optimized_taps = NodalInjOptimResults(
         pst_tap_idx=jnp.array([[0, 1, 2, 3, 4]], dtype=int)  # shape: (n_timesteps=1, n_controllable_pst)
     )
-    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=None)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=optimized_taps, initial_tap_idx=None)
     assert switching_distance == 0.0, "Switching distance should be 0 when initial tap indices are not provided"
 
     # Case 3: No switching_distance - optimized taps match initial taps
@@ -958,7 +958,7 @@ def test_get_pst_switching_distance() -> None:
     optimized_taps = NodalInjOptimResults(
         pst_tap_idx=jnp.array([[2, 3, 4, 5, 6]], dtype=int)  # shape: (n_timesteps=1, n_controllable_pst)
     )
-    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     assert switching_distance == 0.0, "Switching distance should be 0 when taps haven't changed"
 
     # Case 4: Simple switching_distance case - single timestep
@@ -966,7 +966,7 @@ def test_get_pst_switching_distance() -> None:
     optimized_taps = NodalInjOptimResults(
         pst_tap_idx=jnp.array([[3, 4, 5, 6, 7]], dtype=int)  # All shifted by +1
     )
-    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     expected_switching_distance = 25.0  # (Sum of |3-2| + |4-3| + |5-4| + |6-5| + |7-6|)^2 = (1+1+1+1+1)^2 = 25
     assert switching_distance == expected_switching_distance, (
         f"Expected switching_distance {expected_switching_distance}, got {switching_distance}"
@@ -977,7 +977,7 @@ def test_get_pst_switching_distance() -> None:
     optimized_taps = NodalInjOptimResults(
         pst_tap_idx=jnp.array([[3, 7, 5, 4, 8]], dtype=int)  # switching distances: -2, +2, 0, -1, +3
     )
-    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     # Square of L1 distance = (2 + 2 + 0 + 1 + 3)^2 = 64.0
     expected_switching_distance = (2.0 + 2.0 + 0.0 + 1.0 + 3.0) ** 2
     assert switching_distance == expected_switching_distance, (
@@ -996,7 +996,7 @@ def test_get_pst_switching_distance() -> None:
             dtype=int,
         )  # shape: (n_timesteps=3, n_controllable_pst=4)
     )
-    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance_squared(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     expected_switching_distance = 16.0 + 676.0 + 196.0  # Should sum switching distances across all timesteps
     assert switching_distance == expected_switching_distance, (
         f"Expected switching_distance {expected_switching_distance}, got {switching_distance}"
@@ -1005,13 +1005,13 @@ def test_get_pst_switching_distance() -> None:
     # Case 7: Verify JAX compatibility (can be JIT compiled)
     @jax.jit
     def jitted_switching_distance(optimized_taps, initial_tap_idx):
-        return get_pst_switching_distance(optimized_taps, initial_tap_idx)
+        return get_pst_switching_distance_squared(optimized_taps, initial_tap_idx)
 
     initial_tap_idx = jnp.array([1, 2, 3], dtype=int)
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[2, 3, 4]], dtype=int))
 
     switching_distance_jitted = jitted_switching_distance(optimized_taps, initial_tap_idx)
-    switching_distance_normal = get_pst_switching_distance(optimized_taps, initial_tap_idx)
+    switching_distance_normal = get_pst_switching_distance_squared(optimized_taps, initial_tap_idx)
 
     assert jnp.allclose(switching_distance_jitted, switching_distance_normal), (
         "JIT and non-JIT versions should produce same result"
@@ -1116,28 +1116,28 @@ def test_aggregate_to_metric_pst_activated() -> None:
     assert startup_cost == 1.0, f"Expected startup cost 1.0, got {startup_cost}"
 
 
-def test_get_pst_switching_distance_linear() -> None:
+def test_get_pst_switching_distance() -> None:
     """Test the linear PST setpoint switching distance metric."""
 
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=None, initial_tap_idx=None)
+    switching_distance = get_pst_switching_distance(optimized_taps=None, initial_tap_idx=None)
     assert switching_distance == 0.0, "Linear switching distance should be 0 when PST optimization is disabled"
 
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[0, 1, 2, 3, 4]], dtype=int))
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=None)
+    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=None)
     assert switching_distance == 0.0, "Linear switching distance should be 0 when initial tap indices are not provided"
 
     initial_tap_idx = jnp.array([2, 3, 4, 5, 6], dtype=int)
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[2, 3, 4, 5, 6]], dtype=int))
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     assert switching_distance == 0.0, "Linear switching distance should be 0 when taps have not changed"
 
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[3, 4, 5, 6, 7]], dtype=int))
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     assert switching_distance == 5.0, f"Expected linear switching distance 5.0, got {switching_distance}"
 
     initial_tap_idx = jnp.array([5, 5, 5, 5, 5], dtype=int)
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[3, 7, 5, 4, 8]], dtype=int))
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     expected_switching_distance = 2.0 + 2.0 + 0.0 + 1.0 + 3.0
     assert switching_distance == expected_switching_distance, (
         f"Expected linear switching distance {expected_switching_distance}, got {switching_distance}"
@@ -1154,27 +1154,27 @@ def test_get_pst_switching_distance_linear() -> None:
             dtype=int,
         )
     )
-    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    switching_distance = get_pst_switching_distance(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
     expected_switching_distance = 4.0 + 26.0 + 14.0
     assert switching_distance == expected_switching_distance, (
         f"Expected linear switching distance {expected_switching_distance}, got {switching_distance}"
     )
 
     @jax.jit
-    def jitted_switching_distance_linear(optimized_taps, initial_tap_idx):
-        return get_pst_switching_distance_linear(optimized_taps, initial_tap_idx)
+    def jitted_switching_distance(optimized_taps, initial_tap_idx):
+        return get_pst_switching_distance(optimized_taps, initial_tap_idx)
 
     initial_tap_idx = jnp.array([1, 2, 3], dtype=int)
     optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[2, 3, 4]], dtype=int))
-    switching_distance_jitted = jitted_switching_distance_linear(optimized_taps, initial_tap_idx)
-    switching_distance_normal = get_pst_switching_distance_linear(optimized_taps, initial_tap_idx)
+    switching_distance_jitted = jitted_switching_distance(optimized_taps, initial_tap_idx)
+    switching_distance_normal = get_pst_switching_distance(optimized_taps, initial_tap_idx)
     assert jnp.allclose(switching_distance_jitted, switching_distance_normal), (
         "JIT and non-JIT linear switching distance should produce same result"
     )
 
 
-def test_aggregate_to_metric_pst_switching_distance_linear() -> None:
-    """Test aggregate_to_metric routing for pst_switching_distance_linear."""
+def test_aggregate_to_metric_pst_switching_distance() -> None:
+    """Test aggregate_to_metric routing for pst_switching_distance."""
     n_batch = 8
     n_timesteps = 5
     n_failures = 30
@@ -1221,7 +1221,7 @@ def test_aggregate_to_metric_pst_switching_distance_linear() -> None:
         branch_limits=branch_limits,
         reassignment_distance=None,
         n_relevant_subs=0,
-        metric="pst_switching_distance_linear",
+        metric="pst_switching_distance",
         initial_pst_tap_idx=jnp.array([1, 1, 3], dtype=int),
     )
 

--- a/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
+++ b/packages/dc_solver_pkg/tests/jax/test_aggregate_results.py
@@ -38,6 +38,7 @@ from toop_engine_dc_solver.jax.aggregate_results import (
     get_overload_energy_n_1_matrix,
     get_pst_activated,
     get_pst_switching_distance,
+    get_pst_switching_distance_linear,
     get_switching_distance,
     get_transport_n_1_matrix,
     get_underload_energy_n_1_matrix,
@@ -1114,3 +1115,115 @@ def test_aggregate_to_metric_pst_activated() -> None:
     )
 
     assert startup_cost == 1.0, f"Expected startup cost 1.0, got {startup_cost}"
+
+
+def test_get_pst_switching_distance_linear() -> None:
+    """Test the linear PST setpoint switching distance metric."""
+
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=None, initial_tap_idx=None)
+    assert switching_distance == 0.0, "Linear switching distance should be 0 when PST optimization is disabled"
+
+    optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[0, 1, 2, 3, 4]], dtype=int))
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=None)
+    assert switching_distance == 0.0, "Linear switching distance should be 0 when initial tap indices are not provided"
+
+    initial_tap_idx = jnp.array([2, 3, 4, 5, 6], dtype=int)
+    optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[2, 3, 4, 5, 6]], dtype=int))
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    assert switching_distance == 0.0, "Linear switching distance should be 0 when taps have not changed"
+
+    optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[3, 4, 5, 6, 7]], dtype=int))
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    assert switching_distance == 5.0, f"Expected linear switching distance 5.0, got {switching_distance}"
+
+    initial_tap_idx = jnp.array([5, 5, 5, 5, 5], dtype=int)
+    optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[3, 7, 5, 4, 8]], dtype=int))
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    expected_switching_distance = 2.0 + 2.0 + 0.0 + 1.0 + 3.0
+    assert switching_distance == expected_switching_distance, (
+        f"Expected linear switching distance {expected_switching_distance}, got {switching_distance}"
+    )
+
+    initial_tap_idx = jnp.array([2, 3, 4, 5], dtype=int)
+    optimized_taps = NodalInjOptimResults(
+        pst_tap_idx=jnp.array(
+            [
+                [3, 4, 5, 6],
+                [10, 10, 10, 10],
+                [0, 0, 0, 0],
+            ],
+            dtype=int,
+        )
+    )
+    switching_distance = get_pst_switching_distance_linear(optimized_taps=optimized_taps, initial_tap_idx=initial_tap_idx)
+    expected_switching_distance = 4.0 + 26.0 + 14.0
+    assert switching_distance == expected_switching_distance, (
+        f"Expected linear switching distance {expected_switching_distance}, got {switching_distance}"
+    )
+
+    @jax.jit
+    def jitted_switching_distance_linear(optimized_taps, initial_tap_idx):
+        return get_pst_switching_distance_linear(optimized_taps, initial_tap_idx)
+
+    initial_tap_idx = jnp.array([1, 2, 3], dtype=int)
+    optimized_taps = NodalInjOptimResults(pst_tap_idx=jnp.array([[2, 3, 4]], dtype=int))
+    switching_distance_jitted = jitted_switching_distance_linear(optimized_taps, initial_tap_idx)
+    switching_distance_normal = get_pst_switching_distance_linear(optimized_taps, initial_tap_idx)
+    assert jnp.allclose(switching_distance_jitted, switching_distance_normal), (
+        "JIT and non-JIT linear switching distance should produce same result"
+    )
+
+
+def test_aggregate_to_metric_pst_switching_distance_linear() -> None:
+    """Test aggregate_to_metric routing for pst_switching_distance_linear."""
+    n_batch = 8
+    n_timesteps = 5
+    n_failures = 30
+    n_branch = 50
+    n_splits = 10
+    n_subs_rel = 60
+    max_branch_per_sub = 6
+    max_inj_per_sub = 4
+
+    keys = jax.random.split(jax.random.PRNGKey(0), 5)
+
+    flow = jax.random.exponential(keys[0], (n_batch, n_timesteps, n_failures, n_branch))
+    max_mw_flow = jax.random.exponential(keys[1], (n_branch,))
+    branch_topologies = jax.random.randint(keys[2], (n_batch, n_splits, max_branch_per_sub), 0, 2).astype(bool)
+    sub_ids = jax.random.randint(keys[2], (n_batch, n_splits), 0, n_subs_rel)
+    injections = jax.random.randint(keys[3], (n_batch, n_splits, max_inj_per_sub), 0, 2).astype(bool)
+    cross_coupler_flow = jax.random.exponential(keys[3], (n_batch, n_splits, n_timesteps))
+    max_flow_coupler = jax.random.exponential(keys[4], (n_subs_rel,))
+
+    branch_limits = BranchLimits(
+        max_mw_flow=max_mw_flow,
+        max_mw_flow_limited=max_mw_flow * 0.9,
+        coupler_limits=max_flow_coupler,
+    )
+
+    lf_res = SolverLoadflowResults(
+        n_0_matrix=flow[:, :, 0, :],
+        n_1_matrix=flow,
+        cross_coupler_flows=cross_coupler_flow,
+        branch_action_index=None,
+        branch_topology=branch_topologies,
+        sub_ids=sub_ids,
+        injection_topology=injections,
+        nodal_injections_optimized=NodalInjOptimResults(pst_tap_idx=jnp.array([[1, 0, 5]], dtype=int)),
+        n_2_penalty=None,
+        disconnections=None,
+        bb_outage_penalty=None,
+        bb_outage_overload=None,
+        bb_outage_splits=None,
+    )
+
+    switching_distance_linear = aggregate_to_metric(
+        lf_res=lf_res,
+        branch_limits=branch_limits,
+        reassignment_distance=None,
+        n_relevant_subs=0,
+        metric="pst_switching_distance_linear",
+        initial_pst_tap_idx=jnp.array([1, 1, 3], dtype=int),
+    )
+
+    assert switching_distance_linear == 3.0, f"Expected linear switching distance 3.0, got {switching_distance_linear}"

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/types.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/types.py
@@ -46,6 +46,7 @@ OperationMetric: TypeAlias = Literal[
     "disconnected_branches",
     "fitness",
     "pst_switching_distance",
+    "pst_switching_distance_linear",
     "pst_activated",
 ]
 

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/types.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/types.py
@@ -46,7 +46,7 @@ OperationMetric: TypeAlias = Literal[
     "disconnected_branches",
     "fitness",
     "pst_switching_distance",
-    "pst_switching_distance_linear",
+    "pst_switching_distance_squared",
     "pst_activated",
 ]
 

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/initialization.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/initialization.py
@@ -630,7 +630,9 @@ def algo_setup(
         )
 
     pst_metrics_without_optimization = {
-        metric for metric, _ in ga_args.target_metrics if metric in {"pst_switching_distance", "pst_activated"}
+        metric
+        for metric, _ in ga_args.target_metrics
+        if metric in {"pst_switching_distance", "pst_switching_distance_linear", "pst_activated"}
     }
     if not ga_args.enable_nodal_inj_optim and pst_metrics_without_optimization:
         logger.warning(

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/initialization.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/initialization.py
@@ -632,7 +632,7 @@ def algo_setup(
     pst_metrics_without_optimization = {
         metric
         for metric, _ in ga_args.target_metrics
-        if metric in {"pst_switching_distance", "pst_switching_distance_linear", "pst_activated"}
+        if metric in {"pst_switching_distance", "pst_switching_distance_squared", "pst_activated"}
     }
     if not ga_args.enable_nodal_inj_optim and pst_metrics_without_optimization:
         logger.warning(

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/scoring_functions.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/scoring_functions.py
@@ -64,7 +64,7 @@ METRICS = {
     "split_subs": jnp.maximum,
     "n_2_penalty": jnp.add,
     "pst_switching_distance": jnp.maximum,
-    "pst_switching_distance_linear": jnp.maximum,
+    "pst_switching_distance_squared": jnp.maximum,
     "pst_activated": jnp.maximum,
 }
 

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/scoring_functions.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/scoring_functions.py
@@ -64,6 +64,7 @@ METRICS = {
     "split_subs": jnp.maximum,
     "n_2_penalty": jnp.add,
     "pst_switching_distance": jnp.maximum,
+    "pst_switching_distance_linear": jnp.maximum,
     "pst_activated": jnp.maximum,
 }
 

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_scoring_functions.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_scoring_functions.py
@@ -879,8 +879,8 @@ def test_pst_activated_without_pst_optimization(static_information_file: str) ->
     assert jnp.all(jnp.isfinite(fitness))
 
 
-def test_pst_switching_distance_linear_metric_integration(static_information_file_complex: str) -> None:
-    """Test that pst_switching_distance_linear metric works in the scoring function."""
+def test_pst_switching_distance_squared_metric_integration(static_information_file_complex: str) -> None:
+    """Test that pst_switching_distance_squared metric works in the scoring function."""
     static_information = load_static_information(static_information_file_complex)
 
     if (
@@ -936,13 +936,13 @@ def test_pst_switching_distance_linear_metric_integration(static_information_fil
         (static_information.dynamic_information,),
         (static_information.solver_config,),
         target_metrics=(("overload_energy_n_1", 1.0),),
-        observed_metrics=("overload_energy_n_1", "switching_distance", "pst_switching_distance_linear"),
+        observed_metrics=("overload_energy_n_1", "switching_distance", "pst_switching_distance_squared"),
         descriptor_metrics=("switching_distance",),
     )
 
-    assert "pst_switching_distance_linear" in metrics_zero
-    assert metrics_zero["pst_switching_distance_linear"].shape == (batch_size,)
-    assert jnp.all(metrics_zero["pst_switching_distance_linear"] == 0.0)
+    assert "pst_switching_distance_squared" in metrics_zero
+    assert metrics_zero["pst_switching_distance_squared"].shape == (batch_size,)
+    assert jnp.all(metrics_zero["pst_switching_distance_squared"] == 0.0)
 
     pst_mutation_config = replace(
         no_pst_mutation_config,
@@ -966,7 +966,7 @@ def test_pst_switching_distance_linear_metric_integration(static_information_fil
         target_metrics=(("overload_energy_n_1", 1.0),),
         observed_metrics=(
             "overload_energy_n_1",
-            "pst_switching_distance_linear",
+            "pst_switching_distance_squared",
             "pst_switching_distance",
             "pst_activated",
             "switching_distance",
@@ -974,14 +974,17 @@ def test_pst_switching_distance_linear_metric_integration(static_information_fil
         descriptor_metrics=("switching_distance",),
     )
 
-    assert jnp.all(jnp.isfinite(metrics["pst_switching_distance_linear"]))
-    assert jnp.all(metrics["pst_switching_distance_linear"] >= 0.0)
-    assert jnp.all(metrics["pst_activated"] <= metrics["pst_switching_distance_linear"])
-    assert jnp.all(metrics["pst_switching_distance_linear"] <= metrics["pst_switching_distance"])
+    assert jnp.all(jnp.isfinite(metrics["pst_switching_distance"]))
+    assert jnp.all(jnp.isfinite(metrics["pst_switching_distance_squared"]))
+    assert jnp.all(metrics["pst_switching_distance"] >= 0.0)
+    assert jnp.all(metrics["pst_switching_distance_squared"] >= 0.0)
+    assert jnp.all(metrics["pst_activated"] <= metrics["pst_switching_distance"])
+    assert jnp.all(metrics["pst_activated"] <= metrics["pst_switching_distance_squared"])
+    assert jnp.all(metrics["pst_switching_distance"] <= metrics["pst_switching_distance_squared"])
 
 
-def test_pst_switching_distance_linear_in_target_metrics(static_information_file_complex: str) -> None:
-    """Test that pst_switching_distance_linear contributes to fitness when targeted."""
+def test_pst_switching_distance_squared_in_target_metrics(static_information_file_complex: str) -> None:
+    """Test that pst_switching_distance_squared contributes to fitness when targeted."""
     static_information = load_static_information(static_information_file_complex)
 
     if (
@@ -1036,8 +1039,8 @@ def test_pst_switching_distance_linear_in_target_metrics(static_information_file
         key,
         (static_information.dynamic_information,),
         (static_information.solver_config,),
-        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 0.1)),
-        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_squared", 0.1)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_squared", "switching_distance"),
         descriptor_metrics=("switching_distance",),
     )
     fitness_high_weight, _, _, _, _, _ = scoring_function(
@@ -1045,17 +1048,17 @@ def test_pst_switching_distance_linear_in_target_metrics(static_information_file
         key,
         (static_information.dynamic_information,),
         (static_information.solver_config,),
-        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 10.0)),
-        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_squared", 10.0)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_squared", "switching_distance"),
         descriptor_metrics=("switching_distance",),
     )
 
-    assert jnp.all(metrics["pst_switching_distance_linear"] >= 0.0)
+    assert jnp.all(metrics["pst_switching_distance_squared"] >= 0.0)
     assert jnp.less_equal(fitness_high_weight, fitness_low_weight).all()
 
 
-def test_pst_switching_distance_linear_without_pst_optimization(static_information_file: str) -> None:
-    """Test that pst_switching_distance_linear returns 0 when PST optimization is disabled."""
+def test_pst_switching_distance_squared_without_pst_optimization(static_information_file: str) -> None:
+    """Test that pst_switching_distance_squared returns 0 when PST optimization is disabled."""
     static_information = load_static_information(static_information_file)
 
     dynamic_info_no_pst = replace(
@@ -1076,11 +1079,11 @@ def test_pst_switching_distance_linear_without_pst_optimization(static_informati
         key,
         (static_information.dynamic_information,),
         (static_information.solver_config,),
-        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 1.0)),
-        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_squared", 1.0)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_squared", "switching_distance"),
         descriptor_metrics=("switching_distance",),
     )
 
-    assert "pst_switching_distance_linear" in metrics
-    assert jnp.all(metrics["pst_switching_distance_linear"] == 0.0)
+    assert "pst_switching_distance_squared" in metrics
+    assert jnp.all(metrics["pst_switching_distance_squared"] == 0.0)
     assert jnp.all(jnp.isfinite(fitness))

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_scoring_functions.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_scoring_functions.py
@@ -877,3 +877,210 @@ def test_pst_activated_without_pst_optimization(static_information_file: str) ->
     assert "pst_activated" in metrics
     assert jnp.all(metrics["pst_activated"] == 0.0)
     assert jnp.all(jnp.isfinite(fitness))
+
+
+def test_pst_switching_distance_linear_metric_integration(static_information_file_complex: str) -> None:
+    """Test that pst_switching_distance_linear metric works in the scoring function."""
+    static_information = load_static_information(static_information_file_complex)
+
+    if (
+        static_information.dynamic_information.nodal_injection_information is None
+        or len(static_information.dynamic_information.nodal_injection_information.controllable_pst_indices) == 0
+    ):
+        pytest.skip("No controllable PSTs in this grid")
+
+    action_set = static_information.dynamic_information.action_set
+    batch_size = 8
+    n_timesteps = static_information.dynamic_information.n_timesteps
+
+    static_information = replace(
+        static_information,
+        solver_config=replace(static_information.solver_config, batch_size_bsdf=batch_size),
+    )
+
+    starting_taps = static_information.dynamic_information.nodal_injection_information.starting_tap_idx
+    topologies = empty_repertoire(batch_size, 2, 0, n_timesteps, starting_taps)
+
+    key = jax.random.PRNGKey(31)
+    no_pst_mutation_config = MutationConfig(
+        random_topo_prob=0.0,
+        mutation_repetition=1,
+        substation_mutation_config=SubstationMutationConfig(
+            n_subs_mutated_lambda=1.0,
+            add_split_prob=0.0,
+            change_split_prob=0.0,
+            remove_split_prob=0.0,
+            n_rel_subs=static_information.dynamic_information.n_sub_relevant,
+        ),
+        disconnection_mutation_config=DisconnectionMutationConfig(
+            add_disconnection_prob=0.0,
+            change_disconnection_prob=0.0,
+            remove_disconnection_prob=0.0,
+            n_disconnectable_branches=static_information.dynamic_information.n_disconnectable_branches,
+        ),
+        nodal_injection_mutation_config=NodalInjectionMutationConfig(
+            pst_mutation_sigma=0.0,
+            pst_n_taps=static_information.dynamic_information.nodal_injection_information.pst_n_taps,
+        ),
+    )
+    topologies_zero, key = mutate(
+        topologies=topologies,
+        random_key=key,
+        mutation_config=no_pst_mutation_config,
+        action_set=action_set,
+    )
+
+    (_, _, metrics_zero, _, _, _) = scoring_function(
+        topologies_zero,
+        key,
+        (static_information.dynamic_information,),
+        (static_information.solver_config,),
+        target_metrics=(("overload_energy_n_1", 1.0),),
+        observed_metrics=("overload_energy_n_1", "switching_distance", "pst_switching_distance_linear"),
+        descriptor_metrics=("switching_distance",),
+    )
+
+    assert "pst_switching_distance_linear" in metrics_zero
+    assert metrics_zero["pst_switching_distance_linear"].shape == (batch_size,)
+    assert jnp.all(metrics_zero["pst_switching_distance_linear"] == 0.0)
+
+    pst_mutation_config = replace(
+        no_pst_mutation_config,
+        nodal_injection_mutation_config=NodalInjectionMutationConfig(
+            pst_mutation_sigma=2.0,
+            pst_n_taps=static_information.dynamic_information.nodal_injection_information.pst_n_taps,
+        ),
+    )
+    topologies_mutated, key = mutate(
+        topologies=topologies,
+        random_key=key,
+        mutation_config=pst_mutation_config,
+        action_set=action_set,
+    )
+
+    (_, _, metrics, _, _, _) = scoring_function(
+        topologies_mutated,
+        key,
+        (static_information.dynamic_information,),
+        (static_information.solver_config,),
+        target_metrics=(("overload_energy_n_1", 1.0),),
+        observed_metrics=(
+            "overload_energy_n_1",
+            "pst_switching_distance_linear",
+            "pst_switching_distance",
+            "pst_activated",
+            "switching_distance",
+        ),
+        descriptor_metrics=("switching_distance",),
+    )
+
+    assert jnp.all(jnp.isfinite(metrics["pst_switching_distance_linear"]))
+    assert jnp.all(metrics["pst_switching_distance_linear"] >= 0.0)
+    assert jnp.all(metrics["pst_activated"] <= metrics["pst_switching_distance_linear"])
+    assert jnp.all(metrics["pst_switching_distance_linear"] <= metrics["pst_switching_distance"])
+
+
+def test_pst_switching_distance_linear_in_target_metrics(static_information_file_complex: str) -> None:
+    """Test that pst_switching_distance_linear contributes to fitness when targeted."""
+    static_information = load_static_information(static_information_file_complex)
+
+    if (
+        static_information.dynamic_information.nodal_injection_information is None
+        or len(static_information.dynamic_information.nodal_injection_information.controllable_pst_indices) == 0
+    ):
+        pytest.skip("No controllable PSTs in this grid")
+
+    action_set = static_information.dynamic_information.action_set
+    batch_size = 8
+    n_timesteps = static_information.dynamic_information.n_timesteps
+
+    static_information = replace(
+        static_information,
+        solver_config=replace(static_information.solver_config, batch_size_bsdf=batch_size),
+    )
+
+    starting_taps = static_information.dynamic_information.nodal_injection_information.starting_tap_idx
+    topologies = empty_repertoire(batch_size, 2, 0, n_timesteps, starting_taps)
+
+    key = jax.random.PRNGKey(41)
+    mutation_config = MutationConfig(
+        random_topo_prob=0.0,
+        mutation_repetition=1,
+        substation_mutation_config=SubstationMutationConfig(
+            n_subs_mutated_lambda=1.0,
+            add_split_prob=0.0,
+            change_split_prob=0.0,
+            remove_split_prob=0.0,
+            n_rel_subs=static_information.dynamic_information.n_sub_relevant,
+        ),
+        disconnection_mutation_config=DisconnectionMutationConfig(
+            add_disconnection_prob=0.0,
+            change_disconnection_prob=0.0,
+            remove_disconnection_prob=0.0,
+            n_disconnectable_branches=static_information.dynamic_information.n_disconnectable_branches,
+        ),
+        nodal_injection_mutation_config=NodalInjectionMutationConfig(
+            pst_mutation_sigma=2.0,
+            pst_n_taps=static_information.dynamic_information.nodal_injection_information.pst_n_taps,
+        ),
+    )
+    topologies, key = mutate(
+        topologies=topologies,
+        random_key=key,
+        mutation_config=mutation_config,
+        action_set=action_set,
+    )
+
+    fitness_low_weight, _, metrics, _, _, _ = scoring_function(
+        topologies,
+        key,
+        (static_information.dynamic_information,),
+        (static_information.solver_config,),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 0.1)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        descriptor_metrics=("switching_distance",),
+    )
+    fitness_high_weight, _, _, _, _, _ = scoring_function(
+        topologies,
+        key,
+        (static_information.dynamic_information,),
+        (static_information.solver_config,),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 10.0)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        descriptor_metrics=("switching_distance",),
+    )
+
+    assert jnp.all(metrics["pst_switching_distance_linear"] >= 0.0)
+    assert jnp.less_equal(fitness_high_weight, fitness_low_weight).all()
+
+
+def test_pst_switching_distance_linear_without_pst_optimization(static_information_file: str) -> None:
+    """Test that pst_switching_distance_linear returns 0 when PST optimization is disabled."""
+    static_information = load_static_information(static_information_file)
+
+    dynamic_info_no_pst = replace(
+        static_information.dynamic_information,
+        nodal_injection_information=None,
+    )
+    static_information = replace(
+        static_information,
+        solver_config=replace(static_information.solver_config, batch_size_bsdf=4),
+        dynamic_information=dynamic_info_no_pst,
+    )
+
+    topologies = empty_repertoire(4, 2, 0, static_information.dynamic_information.n_timesteps)
+    key = jax.random.PRNGKey(100)
+
+    fitness, _, metrics, _, _, _ = scoring_function(
+        topologies,
+        key,
+        (static_information.dynamic_information,),
+        (static_information.solver_config,),
+        target_metrics=(("overload_energy_n_1", 1.0), ("pst_switching_distance_linear", 1.0)),
+        observed_metrics=("overload_energy_n_1", "pst_switching_distance_linear", "switching_distance"),
+        descriptor_metrics=("switching_distance",),
+    )
+
+    assert "pst_switching_distance_linear" in metrics
+    assert jnp.all(metrics["pst_switching_distance_linear"] == 0.0)
+    assert jnp.all(jnp.isfinite(fitness))

--- a/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
+++ b/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
@@ -53,6 +53,12 @@ def test_infer_missing_observed_metrics():
     assert "overload_energy_n_1" in params.observed_metrics
     assert "underload_energy_n_0" in params.observed_metrics
 
+    params = BatchedMEParameters(
+        target_metrics=(("pst_switching_distance_linear", 1.0),),
+        observed_metrics=("max_flow_n_0",),
+    )
+    assert "pst_switching_distance_linear" in params.observed_metrics
+
 
 def test_deserialization():
     with pytest.raises(ValueError):

--- a/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
+++ b/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
@@ -54,10 +54,10 @@ def test_infer_missing_observed_metrics():
     assert "underload_energy_n_0" in params.observed_metrics
 
     params = BatchedMEParameters(
-        target_metrics=(("pst_switching_distance_linear", 1.0),),
+        target_metrics=(("pst_switching_distance_squared", 1.0),),
         observed_metrics=("max_flow_n_0",),
     )
-    assert "pst_switching_distance_linear" in params.observed_metrics
+    assert "pst_switching_distance_squared" in params.observed_metrics
 
 
 def test_deserialization():


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes #

## What is the new behavior (if this is a feature change)?

PR introduces two changes.
1. Introduces absolute (linear) PST switching distance as a metric (`pst_switching_distance`)
2. Redefines that squared PST switching distance by interchanging sum and squaring (previously called `pst_switching_distance`, now `pst_switching_distance_squared`).

The second change was done in order to penalize the smaller adjustments to a number of PSTs in the same way as adjusting a single PST by a larger number.

Example:
```
psts_inits = [5, 6]
psts_changed_1 = [7, 7]
diff_1 = (2+1)^2 = 9

psts_changed_2 = [8, 6]
diff_2 = (3 + 0)^2 = 9
```
Previously, the metric would evaluate to 5 and 9, respectively. This would favor topologies that use several PSTs with small adjustments rather than a single PST with more adjustment.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
