### PR TITLE
chore: disable auto reload of pytest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "python.testing.autoTestDiscoverOnSaveEnabled": false,
   "python.testing.pytestArgs": ["-n", "auto", "--dist", "loadgroup"],
   "python.analysis.extraPaths": [
     "packages/interfaces_pkg/src",


### PR DESCRIPTION
## Checklist

This setting disables auto-reloading all tests on every file change. This triggered a 3s reload up till now every time you changed a small thing in tests or source code, which is annoying. Now you have to manually reload if you add a new test

Please check if the PR fulfills these requirements:

- [ ] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes #

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
