### PR TITLE
fix: remove basecase from N-1 analysis

### DIFF
--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/ac_loadflow_service/compute_metrics.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/ac_loadflow_service/compute_metrics.py
@@ -230,12 +230,23 @@ def compute_metrics(
     dict[MetricType, float]
         A dictionary with the computed metrics.
     """
+    n_1_branch_res = (
+        loadflow_results.branch_results.filter(pl.col("contingency") != base_case_id)
+        if base_case_id is not None
+        else loadflow_results.branch_results
+    )
+    n_1_va_diff_res = (
+        loadflow_results.va_diff_results.filter(pl.col("contingency") != base_case_id)
+        if base_case_id is not None
+        else loadflow_results.va_diff_results
+    )
+
     metrics = {
-        "max_flow_n_1": compute_max_load(loadflow_results.branch_results),
-        "overload_energy_n_1": compute_overload_energy(loadflow_results.branch_results, field="p"),
-        "max_va_diff_n_1": compute_max_va_diff(loadflow_results.va_diff_results),
-        "overload_current_n_1": compute_overload_energy(loadflow_results.branch_results, field="i"),
-        "critical_branch_count_n_1": count_critical_branches(loadflow_results.branch_results),
+        "max_flow_n_1": compute_max_load(n_1_branch_res),
+        "overload_energy_n_1": compute_overload_energy(n_1_branch_res, field="p"),
+        "max_va_diff_n_1": compute_max_va_diff(n_1_va_diff_res),
+        "overload_current_n_1": compute_overload_energy(n_1_branch_res, field="i"),
+        "critical_branch_count_n_1": count_critical_branches(n_1_branch_res),
     }
 
     if base_case_id is not None:

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/ac_loadflow_service/compute_metrics.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/ac_loadflow_service/compute_metrics.py
@@ -215,8 +215,14 @@ def get_worst_k_contingencies_ac(
 def compute_metrics(
     loadflow_results: LoadflowResultsPolars,
     base_case_id: Optional[str] = None,
-) -> dict[MetricType, float]:
+) -> dict[MetricType, float | None]:
     """Compute the metrics from the loadflow results.
+
+    N-1 overload energy will exclude the base case results if base_case_id is provided,
+    otherwise it will include all contingencies.
+    This method will return None for metrics that cannot be computed due to missing or invalid data. For example,
+    if basecase is provided and is the only contingency, then N-1 metrics will be None
+    since there are no valid N-1 contingencies to compute on.
 
     Parameters
     ----------
@@ -227,7 +233,7 @@ def compute_metrics(
 
     Returns
     -------
-    dict[MetricType, float]
+    dict[MetricType, float | None]
         A dictionary with the computed metrics.
     """
     n_1_branch_res = (

--- a/packages/contingency_analysis_pkg/tests/ac_service/test_compute_metrics.py
+++ b/packages/contingency_analysis_pkg/tests/ac_service/test_compute_metrics.py
@@ -7,11 +7,14 @@
 
 import numpy as np
 import pandapower
+import polars as pl
 import pypowsybl
 from toop_engine_contingency_analysis.ac_loadflow_service.ac_loadflow_service import get_ac_loadflow_results
 from toop_engine_contingency_analysis.ac_loadflow_service.compute_metrics import (
+    compute_max_load,
     compute_metrics,
     compute_overload_energy,
+    count_critical_branches,
     get_worst_k_contingencies_ac,
 )
 from toop_engine_contingency_analysis.pandapower import get_full_nminus1_definition_pandapower
@@ -19,6 +22,7 @@ from toop_engine_contingency_analysis.pypowsybl import (
     get_full_nminus1_definition_powsybl,
     run_contingency_analysis_powsybl,
 )
+from toop_engine_interfaces.loadflow_results_polars import LoadflowResultsPolars
 
 
 def test_compute_metrics_pandapower(pandapower_net: pandapower.pandapowerNet):
@@ -144,3 +148,60 @@ def test_get_worst_k_contingencies_ac_k_greater_than_available(branch_results_df
     assert all(len(c) == 3 for c in contingencies)
     for o in overloads:
         assert overload_n_minus_1 == o
+
+
+def test_compute_metrics_excludes_basecase_from_n_1_when_base_case_id_is_given(
+    branch_results_df_fast_failing_polars: pl.LazyFrame,
+) -> None:
+    # Choose strongly overloaded basecase values so inclusion in N-1 metrics is easy to detect.
+    basecase_power = 500.0
+    basecase_current = 50.0
+    basecase_loading_factor = 10.0
+    basecase_branch_results = (
+        branch_results_df_fast_failing_polars.filter(pl.col("timestep") == 0)
+        .filter(pl.col("contingency") == "cont1")
+        .limit(2)
+        .with_columns(
+            contingency=pl.lit("BASECASE"),
+            p=pl.lit(basecase_power),
+            i=pl.lit(basecase_current),
+            loading=pl.lit(basecase_loading_factor),
+        )
+    )
+    branch_results = pl.concat([branch_results_df_fast_failing_polars, basecase_branch_results], how="vertical")
+
+    va_diff_results = pl.DataFrame(
+        {
+            "timestep": [0, 0],
+            "contingency": ["BASECASE", "cont1"],
+            "element": ["branch1", "branch1"],
+            "va_diff": [9.0, 1.0],
+        }
+    ).lazy()
+
+    loadflow_results = LoadflowResultsPolars(
+        job_id="test_job",
+        branch_results=branch_results,
+        va_diff_results=va_diff_results,
+        node_results=pl.LazyFrame(),
+        regulating_element_results=pl.LazyFrame(),
+        converged=pl.LazyFrame(),
+    )
+
+    metrics_without_basecase_filter = compute_metrics(loadflow_results)
+    metrics_with_basecase_filter = compute_metrics(loadflow_results, base_case_id="BASECASE")
+    n_1_only_branch_results = branch_results.filter(pl.col("contingency") != "BASECASE")
+
+    expected_overload_energy_n_1 = compute_overload_energy(n_1_only_branch_results, field="p")
+    expected_overload_current_n_1 = compute_overload_energy(n_1_only_branch_results, field="i")
+    expected_max_flow_n_1 = compute_max_load(n_1_only_branch_results)
+    expected_critical_branch_count_n_1 = count_critical_branches(n_1_only_branch_results)
+
+    assert np.isclose(metrics_with_basecase_filter["overload_energy_n_1"], expected_overload_energy_n_1)
+    assert np.isclose(metrics_with_basecase_filter["overload_current_n_1"], expected_overload_current_n_1)
+    assert np.isclose(metrics_with_basecase_filter["max_flow_n_1"], expected_max_flow_n_1)
+    assert metrics_with_basecase_filter["critical_branch_count_n_1"] == expected_critical_branch_count_n_1
+    assert metrics_without_basecase_filter["overload_energy_n_1"] > metrics_with_basecase_filter["overload_energy_n_1"]
+    expected_basecase_power_overload_per_branch = basecase_power - abs(basecase_power / basecase_loading_factor)
+    assert np.isclose(metrics_with_basecase_filter["overload_energy_n_0"], 2 * expected_basecase_power_overload_per_branch)
+    assert np.isclose(metrics_with_basecase_filter["max_va_diff_n_1"], 1.0)


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes #

## What is the new behavior (if this is a feature change)?


AC validation metrics were mixing BASECASE rows into `*_n_1` calculations when `base_case_id` was provided, creating a mismatch vs DC-side N-1 overload energy.  
This change ensures N-1 metrics are computed strictly from non-basecase contingencies, while N-0 metrics continue to use BASECASE rows.

- **Metric computation fix**
  - `compute_metrics()` now filters branch and va-diff frames to `contingency != base_case_id` for N-1 metrics when `base_case_id` is set.
  - Affected N-1 outputs: `max_flow_n_1`, `overload_energy_n_1`, `overload_current_n_1`, `critical_branch_count_n_1`, `max_va_diff_n_1`.

- **Regression coverage**
  - Added a focused test proving BASECASE exclusion from N-1 paths and validating expected N-1/N-0 separation behavior.

```python
n_1_branch_res = (
    loadflow_results.branch_results.filter(pl.col("contingency") != base_case_id)
    if base_case_id is not None
    else loadflow_results.branch_results
)
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
