### PR TITLE
fix: fix node mapping in outage groups

### DIFF
--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/contingency_outage_group.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/contingency_outage_group.py
@@ -179,11 +179,14 @@ def get_outage_group_for_contingency(
             etype = element.table
 
             # Convert element into a node ID
-            node_id = elem_node_id("elem", idx, etype)
+            if etype == "bus":
+                node_id = elem_node_id("bus", idx, etype)
+            else:
+                node_id = elem_node_id("elem", idx, etype)
 
             # If the node is not in any component, create a new single-node component
             if node_id not in node_to_component:
-                new_component = {elem_node_id("bus", idx)}
+                new_component = {node_id}
                 connected_components.append(new_component)
                 comp_idx = len(connected_components) - 1
                 node_to_component[node_id] = comp_idx


### PR DESCRIPTION
When building an outage group for a contingency that includes a bus element, the node was always looked up with the "elem" prefix regardless of element type. Bus nodes are keyed under the "bus" prefix in the connected components graph, so the lookup always missed and fell through to the fallback path. The fallback then created a new single-node component using elem_node_id("bus", idx) — missing the required etype argument entirely. Fixed by branching on etype and reusing the already-resolved node_id in the fallback.

Fixes
Bug fix only — no new behavior. Contingencies with a bus outage element now correctly resolve to the right connected component instead of being silently placed into an isolated single-node component.
