### PR TITLE
fix: Remove error string in logger warning

### DIFF
--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -1213,8 +1213,8 @@ def simplify_asset_topology(network_data: NetworkData, close_couplers: bool = Fa
             keep_mask.append(True)
         except ValueError as e:
             logger.warning(
-                f"Station {station.grid_model_id}/{station.name} could not be simplified due to "
-                f"error {e}, removing it from the relevant nodes."
+                f"Station {station.grid_model_id}/{station.name} could not be simplified "
+                f"because {e}, removing it from the relevant nodes."
             )
             simplified_station = station
             keep_mask.append(False)


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Addresses a misguiding error string in a logger warning. This improves string search of logs.

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
