### PR TITLE
fix: consider in cascading only monitored elements

### DIFF
--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/loadflow.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/loadflow.py
@@ -84,6 +84,7 @@ def run_spps_with_branch_switch_results(
     switch_element_mapping: pat.DataFrame[SwitchElementMappingSchema],
     timestep: int,
     basecase_net: pp.pandapowerNet,
+    monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
     method: Literal["ac", "dc"] = "ac",
     runpp_kwargs: dict[str, Any] | None = None,
     min_island_size: int = 11,
@@ -117,6 +118,11 @@ def run_spps_with_branch_switch_results(
     min_island_size : int
         Smallest island size that can receive a slack bus; passed through to
         :class:`SlackAllocationConfig`.
+    monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
+        Branch and node results are filtered to this set after
+        the load flow. Only monitored branches and nodes are then used for
+        subsequent cascade trigger detection. When ``None``, no filtering is
+        applied.
 
     Returns
     -------
@@ -157,6 +163,10 @@ def run_spps_with_branch_switch_results(
         node_results,
         switch_element_mapping,
     )
+
+    monitored_index = monitored_elements.index
+    branch_results = branch_results[branch_results.index.isin(monitored_index, level="element")]
+    node_results = node_results[node_results.index.isin(monitored_index, level="element")]
 
     return CascadeSppsBranchSwitchResults(
         convergence_status=convergence_status,

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/loadflow.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/loadflow.py
@@ -121,8 +121,7 @@ def run_spps_with_branch_switch_results(
     monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
         Branch and node results are filtered to this set after
         the load flow. Only monitored branches and nodes are then used for
-        subsequent cascade trigger detection. When ``None``, no filtering is
-        applied.
+        subsequent cascade trigger detection.
 
     Returns
     -------

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
@@ -115,6 +115,7 @@ class CascadeSimulator:
         switch_results_df: pat.DataFrame[SwitchResultsSchema],
         initial_contingency: PandapowerContingency,
         basecase_net: pp.pandapowerNet,
+        monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
     ) -> list[CascadeEvent]:
         """Run the cascade loop starting from initial load-flow results.
 
@@ -133,6 +134,10 @@ class CascadeSimulator:
             contingency outages. Forwarded to each inner load-flow step so that
             SpPS BC-mode conditions are evaluated against the true base-case
             state rather than the previous cascade step.
+        monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
+            Elements to monitor. Branch and node results produced by each inner
+            load-flow step are filtered to this set before being used for
+            subsequent cascade trigger detection.
 
         Returns
         -------
@@ -167,6 +172,14 @@ class CascadeSimulator:
                 triggers=triggers,
                 step_no=step_no,
             )
+            # Filter events to monitored elements only — unmonitored elements
+            # do not appear in the result log.
+            # NOTE: outages are intentionally NOT filtered here. When a violated
+            # element IS monitored, its outage group may include non-monitored
+            # elements (e.g. a busbar or impedance on the same protection zone).
+            # All elements in that group must still be taken out of service so
+            # the network topology stays consistent for subsequent cascade steps.
+            step_events = self._filter_events_to_monitored(step_events, monitored_elements)
             accumulative_outages_pp.extend(self._to_pandapower_outage_elements(net, outages))
 
             contingency = PandapowerContingency(
@@ -179,6 +192,7 @@ class CascadeSimulator:
                 contingency=contingency,
                 monitored_breakers=monitored_breakers,
                 basecase_net=basecase_net,
+                monitored_elements=monitored_elements,
             )
             step_events = self._add_spps_activation_info(
                 events=step_events,
@@ -204,6 +218,7 @@ class CascadeSimulator:
             events=events,
             net=net,
             triggers=triggers,
+            monitored_elements=monitored_elements,
         )
 
     def _detect_triggers_from_results(
@@ -393,6 +408,7 @@ class CascadeSimulator:
         contingency: PandapowerContingency,
         monitored_breakers: pat.DataFrame[PandapowerMonitoredElementSchema],
         basecase_net: pp.pandapowerNet,
+        monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
     ) -> CascadeSppsBranchSwitchResults | None:
         """Run one inner cascade load flow after applying accumulated outages.
 
@@ -409,6 +425,10 @@ class CascadeSimulator:
             contingency outages. Passed to SpPS so that BC-mode conditions are
             evaluated against the true base-case state throughout all cascade
             steps.
+        monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
+            Full monitored-element table. Branch and node results are filtered
+            to this set after the load flow so that only monitored elements are
+            used for subsequent cascade trigger detection.
 
         Returns
         -------
@@ -432,6 +452,7 @@ class CascadeSimulator:
                 method=self._lf_method,
                 runpp_kwargs=self._runpp_kwargs,
                 min_island_size=self._cfg.min_island_size,
+                monitored_elements=monitored_elements,
             )
         except Exception:
             return None
@@ -499,6 +520,7 @@ class CascadeSimulator:
         events: list[CascadeEvent],
         net: pp.pandapowerNet,
         triggers: CascadeTriggers,
+        monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
     ) -> list[CascadeEvent]:
         """Add final events when the cascade reaches its depth limit.
 
@@ -510,6 +532,8 @@ class CascadeSimulator:
             Pandapower network at the final cascade state.
         triggers : CascadeTriggers
             Last triggers that could not be processed because of the limit.
+        monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
+            Only events for elements present in this table are appended.
 
         Returns
         -------
@@ -522,5 +546,32 @@ class CascadeSimulator:
             triggers=triggers,
             step_no=depth_stop_no,
         )
+        depth_events = self._filter_events_to_monitored(depth_events, monitored_elements)
         events.extend(depth_events)
         return events
+
+    @staticmethod
+    def _filter_events_to_monitored(
+        events: list[CascadeEvent],
+        monitored_elements: pat.DataFrame[PandapowerMonitoredElementSchema],
+    ) -> list[CascadeEvent]:
+        """Keep only events whose element is in the monitored-element table.
+
+        Events with ``element_id=None`` (e.g. failed load-flow markers) are
+        always kept because they carry no element identity to filter on.
+
+        Parameters
+        ----------
+        events : list[CascadeEvent]
+            Candidate events from a cascade step.
+        monitored_elements : pat.DataFrame[PandapowerMonitoredElementSchema]
+            Table whose index contains the globally unique IDs of monitored
+            elements.
+
+        Returns
+        -------
+        list[CascadeEvent]
+            Filtered list containing only events for monitored elements.
+        """
+        monitored_ids = set(monitored_elements.index)
+        return [e for e in events if e.element_id is None or e.element_id in monitored_ids]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -195,7 +195,7 @@ def run_single_outage(
         ctx=ctx,
         grouped_contingency=grouped_contingency,
         status=status,
-        branch_results_df=element_results.full_branch_results,
+        branch_results_df=element_results.branch_results,
         switch_results_df=element_results.switch_results,
     )
 
@@ -374,6 +374,7 @@ def _collect_cascade_results(
         switch_results_df,
         initial_contingency=grouped_contingency.contingencies[0],
         basecase_net=ctx.basecase_net,
+        monitored_elements=ctx.monitored_elements,
     )
 
     return _build_cascade_results_df(

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -257,3 +257,109 @@ class TestCascades(unittest.TestCase):
             },
         ]
         assert cascade_events == expected
+
+    def test_cascade_stops_when_step2_elements_not_monitored(self):
+        """Cascade event log stops after step 1 when step-2 triggers are on non-monitored elements.
+
+        Setup
+        -----
+        Same network and line limits as ``test_cascade_with_2_trips``.  The
+        contingency (l1 trip) would normally produce a 2-step cascade:
+
+          step 1 — l2 trips (current overload)
+          step 2 — l4 trips (distance protection) + l7 trips (current overload)
+
+        Here l4 and l7 are **excluded** from ``monitored_elements``.
+
+        Why no step-2 events appear
+        ---------------------------
+        Current overload (l7):
+            Branch results fed to ``_detect_triggers_from_results`` are
+            pre-filtered to monitored elements.  l7 is absent, so the overload
+            detector never sees it as triggered.
+
+        Distance protection (l4 via sw3):
+            Switch results are not filtered — sw3 still fires and its outage
+            group (which includes l4) is fully applied to the network.
+            However, l4 is not monitored so the resulting event is suppressed
+            by ``_filter_events_to_monitored`` and does not appear in the log.
+
+        Outages are intentionally not filtered: when a monitored switch trips,
+        all elements in its outage group must be taken out of service to keep
+        the topology consistent, even if those elements are not monitored.
+        """
+        net = build_cascade_test_net()
+        net.line.loc[0, "max_i_ka"] = 0.3
+        net.line.loc[1, "max_i_ka"] = 0.3
+        net.line.loc[2, "max_i_ka"] = 0.6
+        net.line.loc[3, "max_i_ka"] = 0.4
+        net.line.loc[4, "max_i_ka"] = 0.6
+
+        cascade_cfg = CascadeConfig(
+            depth_limit=3,
+            current_loading_threshold=1.5,
+            min_island_size=2,
+            cascade_log_elements=["line", "switch"],
+            basecase_distance_protection_factor=2,
+            contingency_distance_protection_factor=2,
+        )
+        net.line["global_id"] = net.line.index.map(lambda imp_id: get_globally_unique_id(imp_id, "line"))
+        net.bus["global_id"] = net.bus.index.map(lambda imp_id: get_globally_unique_id(imp_id, "bus"))
+        net.switch["global_id"] = net.switch.index.map(lambda imp_id: get_globally_unique_id(imp_id, "switch"))
+
+        # l4 (idx 6, origin_id="line:l4") and l7 (idx 5, origin_id="line:l7")
+        # are intentionally excluded — they are the step-2 cascade triggers.
+        unmonitored_line_names = {"l4", "l7"}
+        monitored_elements = (
+            [
+                GridElement(id=row.global_id, type="line", kind="branch", name=row.name)
+                for row in net.line.itertuples()
+                if row.name not in unmonitored_line_names
+            ]
+            + [GridElement(id=row.global_id, type="bus", kind="bus", name=row.name) for row in net.bus.itertuples()]
+            + [GridElement(id=row.global_id, type="switch", kind="switch", name=row.name) for row in net.switch.itertuples()]
+        )
+
+        contingencies = [
+            Contingency(id="BASECASE", name="BASECASE", elements=[]),
+            Contingency(
+                id="line:l1",
+                name="l1",
+                elements=[GridElement(id="0%%line", type="line", kind="branch")],
+            ),
+        ]
+        nminus1_def = Nminus1Definition(
+            monitored_elements=monitored_elements,
+            contingencies=contingencies,
+        )
+        cfg = ContingencyAnalysisConfig(
+            method="ac",
+            min_island_size=2,
+            cascade=cascade_cfg,
+            parallel=ParallelConfig(n_processes=1, batch_size=None),
+            runpp_kwargs={"lightsim2grid": False, "enforce_q_lims": True},
+        )
+
+        lf_results = run_contingency_analysis_pandapower(
+            net=net,
+            n_minus_1_definition=nminus1_def,
+            job_id="test",
+            timestep=0,
+            cfg=cfg,
+        )
+
+        all_cascade_events = _cascade_results_to_events(lf_results.cascade_results)
+        cascade_events = [e for e in all_cascade_events if e["contingency_name"] == "l1"]
+
+        # Only the step-1 event (l2 current overload) must appear.
+        # l4 and l7 are not monitored, so their step-2 events are suppressed.
+        assert len(cascade_events) == 1
+        assert cascade_events[0] == {
+            "cascade_number": 1,
+            "cascade_reason": CascadeReasonType.CASCADE_REASON_CURRENT,
+            "contingency_mrid": "line:l1",
+            "contingency_name": "l1",
+            "distance_protection_severity": None,
+            "element_mrid": "line:l2",
+            "element_name": "l2",
+        }


### PR DESCRIPTION
Use only monitored elements in cascade trigger detection and event logging

Cascade trigger detection and event logging now only consider elements that are explicitly marked as monitored. This was introduced on expert recommendation: non-monitored elements may carry incorrect or placeholder settings — for example, a wrong max_i_ka value — which would cause the overload detector to fire on every run, including the base case, producing spurious cascade events that have nothing to do with the actual contingency.

Concretely:
Branch and node results produced by each inner cascade load-flow step are filtered to monitored elements before being fed into the next trigger-detection round (run_spps_with_branch_switch_results).
Cascade events (CascadeEvent) are filtered to monitored elements after each step and at the depth-limit boundary (_filter_events_to_monitored). Events with no element identity (e.g. failed load-flow markers) always pass through.
Outage groups are intentionally not filtered. When a violated monitored element trips, its outage group may include non-monitored elements on the same protection zone. All of them must still be taken out of service to keep the network topology consistent for subsequent cascade steps.
