### PR TITLE
fix: handle controller error

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ Distributed under MPL 2.0. See [LICENSE](./LICENSE).
 
 ## Citation
 
+<!-- markdown-link-check-disable -->
 If you use our work in scientific research, please cite [our paper on load flow solving](https://doi.org/10.1109/PowerTech59965.2025.11180422) or [our paper on the optimizer architecture](https://arxiv.org/abs/2605.10128), depending what parts of the repository you use.
+<!-- markdown-link-check-enable -->
 
 ---
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
@@ -146,6 +146,13 @@ class CascadeSimulator:
             trigger is found.
         """
         self._cascade_context = build_cascade_context(net)
+        # Only protection switches can trip during cascading, so we limit flow computation to them.
+        monitored_breakers = monitored_elements[
+            monitored_elements["monitoring_scope"].apply(lambda s: s is not None and SwitchMonitoringScope.PROTECTION in s)
+        ]
+        switch_results_df = switch_results_df[
+            switch_results_df.index.get_level_values("element").isin(monitored_breakers.index)
+        ]
         triggers = self._detect_triggers_from_results(
             net=net,
             branch_results=branch_results_df,
@@ -157,10 +164,6 @@ class CascadeSimulator:
 
         events: list[CascadeEvent] = []
         accumulative_outages_pp: list[PandapowerElements] = []
-        # Only protection switches can trip during cascading, so we limit flow computation to them.
-        monitored_breakers = monitored_elements[
-            monitored_elements["monitoring_scope"].apply(lambda s: s is not None and SwitchMonitoringScope.PROTECTION in s)
-        ]
 
         for step in range(self._cfg.depth_limit):
             step_no = step + 1

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -8,6 +8,7 @@
 """Compute the N-1 AC/DC power flow for the pandapower network."""
 
 import json
+import logging
 import math
 import uuid
 from copy import deepcopy
@@ -77,6 +78,8 @@ from toop_engine_interfaces.loadflow_results import (
 )
 from toop_engine_interfaces.loadflow_results_polars import LoadflowResultsPolars
 from toop_engine_interfaces.nminus1_definition import Nminus1Definition
+
+logger = logging.getLogger(__name__)
 
 
 def _scrub_enums_for_json(obj: object) -> object:
@@ -684,8 +687,8 @@ def _run_base_case_loadflow(
         else:
             pp.runpp(net, **runpp_kwargs)
 
-    except pp.LoadflowNotConverged:
-        pass
+    except (pp.LoadflowNotConverged, pp.ControllerNotConverged) as exc:
+        logger.warning("Base-case load flow did not converge; continuing with stale res_* tables: %s", exc)
 
 
 def build_connectivity_df(groups: list[PandapowerContingencyGroup]) -> pat.DataFrame[ConnectivityResultSchema]:

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/spps/engine.py
@@ -791,7 +791,19 @@ def run_spps(
     bc_values = conditions.loc[bc_mask, "condition_element_value"].copy()
     # ----------------------------------------------------------------------- #
 
-    _run_power_flow(net, method, runpp_kwargs)
+    try:
+        _run_power_flow(net, method, runpp_kwargs)
+    except (pp.LoadflowNotConverged, pp.ControllerNotConverged) as exc:
+        if on_power_flow_error == SppsPowerFlowFailurePolicy.RAISE:
+            raise SppsPowerFlowError(f"Initial power flow failed: {exc}") from exc
+        logger.warning("Initial power flow failed; returning power_flow_failed=True: %s", exc)
+        return SppsResult(
+            net=net,
+            iterations=0,
+            activated_schemes_per_iter=[],
+            max_iterations_reached=False,
+            power_flow_failed=True,
+        )
 
     ctx = _SppsLoopContext(
         actions=actions,

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -6,19 +6,34 @@
 # Mozilla Public License, version 2.0
 
 import unittest
+from unittest import mock
 
 import numpy as np
 import pandapower as pp
 import pandas as pd
+import pandera as pa
 from toop_engine_contingency_analysis.pandapower import run_contingency_analysis_pandapower
-from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeReasonType
+from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeReasonType, CascadeTriggers
+from toop_engine_contingency_analysis.pandapower.cascade.simulation.simulator import CascadeSimulator
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     CascadeConfig,
     ContingencyAnalysisConfig,
+    PandapowerContingency,
     ParallelConfig,
+    SingleOutageSppsContext,
+    SppsActionsPandapowerSchema,
+    SppsConditionsPandapowerSchema,
 )
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
-from toop_engine_interfaces.nminus1_definition import Contingency, GridElement, MonitoredElement, Nminus1Definition
+from toop_engine_interfaces.interface_helpers import get_empty_dataframe_from_model
+from toop_engine_interfaces.loadflow_results import BranchResultSchema, SwitchResultsSchema
+from toop_engine_interfaces.nminus1_definition import (
+    Contingency,
+    GridElement,
+    MonitoredElement,
+    Nminus1Definition,
+    SwitchMonitoringScope,
+)
 
 
 def build_cascade_test_net():
@@ -369,3 +384,111 @@ class TestCascades(unittest.TestCase):
             "element_mrid": "line:l2",
             "element_name": "l2",
         }
+
+
+# ---------------------------------------------------------------------------
+# CascadeSimulator.simulate — switch_results_df filtered to monitored_breakers
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
+    """switch_results_df passed to _detect_triggers_from_results only contains PROTECTION-scoped switches."""
+    protection_uid = get_globally_unique_id(0, "switch")
+    flow_only_uid = get_globally_unique_id(1, "switch")
+
+    monitored_elements = pd.DataFrame(
+        [
+            {
+                "unique_id": protection_uid,
+                "table": "switch",
+                "table_id": 0,
+                "kind": "switch",
+                "name": "",
+                "monitoring_scope": frozenset({SwitchMonitoringScope.PROTECTION}),
+            },
+            {
+                "unique_id": flow_only_uid,
+                "table": "switch",
+                "table_id": 1,
+                "kind": "switch",
+                "name": "",
+                "monitoring_scope": frozenset({SwitchMonitoringScope.FLOW}),
+            },
+        ]
+    ).set_index("unique_id")
+
+    switch_results_df = pd.DataFrame(
+        [
+            {
+                "timestep": 0,
+                "contingency": "c1",
+                "element": protection_uid,
+                "p": 1.0,
+                "q": 0.5,
+                "vm": 110.0,
+                "i": 5.0,
+                "s": 1.1,
+                "element_name": "",
+                "contingency_name": "c1",
+                "side": None,
+            },
+            {
+                "timestep": 0,
+                "contingency": "c1",
+                "element": flow_only_uid,
+                "p": 2.0,
+                "q": 0.5,
+                "vm": 110.0,
+                "i": 5.0,
+                "s": 2.1,
+                "element_name": "",
+                "contingency_name": "c1",
+                "side": None,
+            },
+        ]
+    ).set_index(["timestep", "contingency", "element"])
+
+    empty_conditions = pa.typing.DataFrame[SppsConditionsPandapowerSchema](
+        pd.DataFrame(columns=list(SppsConditionsPandapowerSchema.to_schema().columns.keys()))
+    )
+    empty_actions = pa.typing.DataFrame[SppsActionsPandapowerSchema](
+        pd.DataFrame(columns=list(SppsActionsPandapowerSchema.to_schema().columns.keys()))
+    )
+    spps = SingleOutageSppsContext(conditions=empty_conditions, actions=empty_actions)
+    simulator = CascadeSimulator(
+        cfg=CascadeConfig(
+            depth_limit=1,
+            current_loading_threshold=1.0,
+            min_island_size=1,
+            cascade_log_elements=[],
+            basecase_distance_protection_factor=1.0,
+        ),
+        spps=spps,
+    )
+
+    net = build_cascade_test_net()
+    pp.runpp(net, lightsim2grid=False)
+
+    captured: list[pd.DataFrame] = []
+
+    def _fake_detect(net, branch_results, switch_results):
+        captured.append(switch_results)
+        return CascadeTriggers(
+            tripped_switches=get_empty_dataframe_from_model(SwitchResultsSchema),
+            current_overloaded_elements=get_empty_dataframe_from_model(BranchResultSchema),
+        )
+
+    with mock.patch.object(simulator, "_detect_triggers_from_results", side_effect=_fake_detect):
+        simulator.simulate(
+            net=net,
+            branch_results_df=get_empty_dataframe_from_model(BranchResultSchema),
+            switch_results_df=switch_results_df,
+            initial_contingency=PandapowerContingency(unique_id="c1", name="c1", elements=[]),
+            basecase_net=net.copy(),
+            monitored_elements=monitored_elements,
+        )
+
+    assert len(captured) == 1
+    received_elements = set(captured[0].index.get_level_values("element"))
+    assert protection_uid in received_elements
+    assert flow_only_uid not in received_elements

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -6,6 +6,7 @@
 # Mozilla Public License, version 2.0
 
 import unittest
+from copy import deepcopy
 from unittest import mock
 
 import numpy as np
@@ -484,7 +485,7 @@ def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
             branch_results_df=get_empty_dataframe_from_model(BranchResultSchema),
             switch_results_df=switch_results_df,
             initial_contingency=PandapowerContingency(unique_id="c1", name="c1", elements=[]),
-            basecase_net=net.copy(),
+            basecase_net=deepcopy(net),
             monitored_elements=monitored_elements,
         )
 

--- a/packages/contingency_analysis_pkg/tests/pandapower/spps/test_engine.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/spps/test_engine.py
@@ -360,13 +360,107 @@ def test_run_spps_no_activation_when_condition_false(pandapower_net: pp.pandapow
     assert result.activated_schemes_per_iter == []
 
 
-def test_run_spps_raises_on_initial_pf_failure() -> None:
-    net = pp.create_empty_network()
-    basecase_net = pp.create_empty_network()
-    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=0)]))
+def test_run_spps_raises_on_initial_pf_failure(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    basecase_net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=lid)]))
     actions = _validate_actions(pd.DataFrame([_act_row()]))
-    with pytest.raises(Exception):
-        run_spps(net, conditions, actions, set(), basecase_net, method="dc", max_iterations=2, runpp_kwargs={})
+
+    with mock.patch(
+        "toop_engine_contingency_analysis.pandapower.spps.engine._run_power_flow",
+        side_effect=pp.LoadflowNotConverged,
+    ):
+        with pytest.raises(SppsPowerFlowError, match="Initial power flow failed"):
+            run_spps(
+                net,
+                conditions,
+                actions,
+                set(),
+                basecase_net,
+                method="dc",
+                max_iterations=2,
+                runpp_kwargs={},
+                on_power_flow_error=SppsPowerFlowFailurePolicy.RAISE,
+            )
+
+
+def test_run_spps_initial_pf_failure_keep_previous_returns_failed_result(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    basecase_net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=lid)]))
+    actions = _validate_actions(pd.DataFrame([_act_row()]))
+
+    with mock.patch(
+        "toop_engine_contingency_analysis.pandapower.spps.engine._run_power_flow",
+        side_effect=pp.LoadflowNotConverged,
+    ):
+        result = run_spps(
+            net,
+            conditions,
+            actions,
+            set(),
+            basecase_net,
+            method="dc",
+            max_iterations=2,
+            runpp_kwargs={},
+            on_power_flow_error=SppsPowerFlowFailurePolicy.KEEP_PREVIOUS,
+        )
+    assert result.power_flow_failed is True
+    assert result.iterations == 0
+    assert result.activated_schemes_per_iter == []
+
+
+def test_run_spps_initial_pf_controller_not_converged_raises_with_raise_policy(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    basecase_net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=lid)]))
+    actions = _validate_actions(pd.DataFrame([_act_row()]))
+
+    with mock.patch(
+        "toop_engine_contingency_analysis.pandapower.spps.engine._run_power_flow",
+        side_effect=pp.ControllerNotConverged,
+    ):
+        with pytest.raises(SppsPowerFlowError, match="Initial power flow failed"):
+            run_spps(
+                net,
+                conditions,
+                actions,
+                set(),
+                basecase_net,
+                method="dc",
+                max_iterations=2,
+                runpp_kwargs={},
+                on_power_flow_error=SppsPowerFlowFailurePolicy.RAISE,
+            )
+
+
+def test_run_spps_initial_pf_controller_not_converged_returns_failed_result(pandapower_net: pp.pandapowerNet) -> None:
+    net = deepcopy(pandapower_net)
+    basecase_net = deepcopy(pandapower_net)
+    lid = int(net.line.index[0])
+    conditions = _validate_conditions(pd.DataFrame([_cond_row(table_id=lid)]))
+    actions = _validate_actions(pd.DataFrame([_act_row()]))
+
+    with mock.patch(
+        "toop_engine_contingency_analysis.pandapower.spps.engine._run_power_flow",
+        side_effect=pp.ControllerNotConverged,
+    ):
+        result = run_spps(
+            net,
+            conditions,
+            actions,
+            set(),
+            basecase_net,
+            method="dc",
+            max_iterations=2,
+            runpp_kwargs={},
+            on_power_flow_error=SppsPowerFlowFailurePolicy.KEEP_PREVIOUS,
+        )
+    assert result.power_flow_failed is True
+    assert result.iterations == 0
 
 
 def test_run_spps_max_iterations_exhausted_raises(pandapower_net: pp.pandapowerNet) -> None:


### PR DESCRIPTION
fix: handle station controller and load-flow errors correctly

Three related fixes for silent or incorrect error handling in power flow execution:

run_spps: the initial power flow had no error handling — any convergence failure would propagate uncaught. Now LoadflowNotConverged and ControllerNotConverged are caught and handled according to the on_power_flow_error policy.

_run_base_case_loadflow: ControllerNotConverged was not caught at all and would crash the analysis; LoadflowNotConverged was swallowed silently. Both are now caught and logged as warnings.

CascadeSimulator.simulate: switch results were passed to trigger detection without filtering by monitoring scope, meaning non-protection switches could incorrectly influence cascade trigger decisions.