### PR TITLE
fix: failsave/hotfix for case where backend filters out a branch that is expected by the busbar outage

### DIFF
--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess_bb_outage.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess_bb_outage.py
@@ -151,8 +151,9 @@ def extract_outage_index_injection_from_asset(
             # Branch is a line or a trafo
             try:
                 branch_index = network.branch_ids.index(asset.grid_model_id)
-            except ValueError as e:
-                raise ValueError(f"Branch {asset.grid_model_id} not found in network data.") from e
+            except ValueError:
+                logger.warning(f"Branch {asset.grid_model_id} is not a valid branch. Might have been removed.")
+                return branch_index_to_outage, nodal_injection_to_outage
             if not network.bridging_branch_mask[branch_index]:
                 branch_index_to_outage = branch_index
             else:

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess_bb_outage.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess_bb_outage.py
@@ -177,6 +177,27 @@ def test_extract_outage_index_injection_from_asset(network_data: NetworkData):
     )
     assert connected_branches_to_outage == [], f"Expected [], but got {connected_branches_to_outage}"
 
+    # Test case 5: Process an in-service branch that is no longer present in network.branch_ids
+    # (e.g. filtered out as disconnected during backend preprocessing).
+    missing_branch_asset = SwitchableAsset(
+        grid_model_id="branch_missing",
+        in_service=True,
+        branch_end="from",
+        type="line",
+    )
+    nodal_injection_to_outage = np.zeros(network_data_dummy.nodal_injection.shape[0], float)
+    connected_branches_to_outage = []
+    branch_index, injection = extract_outage_index_injection_from_asset(missing_branch_asset, network_data_dummy, 0, {})
+    if branch_index is not None:
+        connected_branches_to_outage.append(branch_index)
+    nodal_injection_to_outage += injection
+
+    expected_busbar_nodal_injection_removal = np.zeros(network_data_dummy.nodal_injection.shape[0], float)
+    assert np.allclose(nodal_injection_to_outage, expected_busbar_nodal_injection_removal), (
+        f"Expected {expected_busbar_nodal_injection_removal}, but got {nodal_injection_to_outage}"
+    )
+    assert connected_branches_to_outage == [], f"Expected [], but got {connected_branches_to_outage}"
+
 
 def test_extract_busbar_outage_data(network_data_preprocessed: NetworkData):
     # Create mock SwitchableAsset objects


### PR DESCRIPTION
Signed-off-by: Benjamin Petrick <170433522+BenjPetr@users.noreply.github.com>

## Checklist

Please check if the PR fulfills these requirements:

- [ ] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

fix: failsave/hotfix for case where backend filters out a branch that is expected by the busbar outage

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
