### PR TITLE
test: complex grid save and load powsybl

### DIFF
--- a/packages/grid_helpers_pkg/src/toop_engine_grid_helpers/powsybl/example_grids.py
+++ b/packages/grid_helpers_pkg/src/toop_engine_grid_helpers/powsybl/example_grids.py
@@ -1870,7 +1870,10 @@ def create_complex_grid_battery_hvdc_svc_3w_trafo(
     if connect_line_out_of_service:
         n.connect("LINE_out_of_service")
 
-    pypowsybl.loadflow.run_ac(n)
+    # Bound the residual slack-bus imbalance well below the ~0.1 MW threshold above which the
+    # CGMES SV export emits an SvInjection. Such an SvInjection cannot be re-imported into a
+    # node/breaker voltage level (powsybl attaches the fictitious load by bus, not by node).
+    pypowsybl.loadflow.run_ac(n, pypowsybl.loadflow.Parameters(provider_parameters={"slackBusPMaxMismatch": "1e-6"}))
 
     return n
 

--- a/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
+++ b/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
@@ -251,38 +251,37 @@ def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.Te
 
     assert isinstance(loaded_net, pypowsybl.network.Network)
 
-    # Element types that CGMES round trips one to one, ids included.
-    for getter in [
-        "get_loads",
-        "get_2_windings_transformers",
-        "get_3_windings_transformers",
-        "get_shunt_compensators",
-        "get_static_var_compensators",
-        "get_hvdc_lines",
-        "get_vsc_converter_stations",
-        "get_lcc_converter_stations",
-        "get_busbar_sections",
-    ]:
-        before = getattr(net, getter)()
-        after = getattr(loaded_net, getter)()
-        assert len(before) == len(after), f"{getter} changed during the CGMES round trip"
-        assert set(before.index) <= set(after.index), f"{getter} lost ids during the CGMES round trip"
-
     n_boundary_lines = len(net.get_boundary_lines())
     n_tie_lines = len(net.get_tie_lines())
     n_batteries = len(net.get_batteries())
-
     # CGMES models a boundary line as a full AC line ending in a fictitious substation/voltage level/bus.
     # Two boundary lines coupled by a tie line share a single boundary point.
-    assert len(loaded_net.get_lines()) == len(net.get_lines()) + n_boundary_lines
-    assert set(net.get_lines().index) <= set(loaded_net.get_lines().index)
-    assert len(loaded_net.get_boundary_lines()) == 0
-    assert len(loaded_net.get_tie_lines()) == 0
-    for getter in ["get_substations", "get_voltage_levels", "get_buses"]:
+    n_boundary_points = n_boundary_lines - n_tie_lines
+
+    # Element counts that CGMES round trips, ids included, either one to one or up to the fictitious
+    # elements added per boundary point.
+    for getter, extra in [
+        ("get_loads", 0),
+        ("get_2_windings_transformers", 0),
+        ("get_3_windings_transformers", 0),
+        ("get_shunt_compensators", 0),
+        ("get_static_var_compensators", 0),
+        ("get_hvdc_lines", 0),
+        ("get_vsc_converter_stations", 0),
+        ("get_lcc_converter_stations", 0),
+        ("get_busbar_sections", 0),
+        ("get_substations", n_boundary_points),
+        ("get_voltage_levels", n_boundary_points),
+        ("get_buses", n_boundary_points),
+        ("get_lines", n_boundary_lines),
+    ]:
         before = getattr(net, getter)()
         after = getattr(loaded_net, getter)()
-        assert len(after) == len(before) + n_boundary_lines - n_tie_lines, f"unexpected {getter} count"
+        assert len(after) == len(before) + extra, f"unexpected {getter} count after the CGMES round trip"
         assert set(before.index) <= set(after.index), f"{getter} lost ids during the CGMES round trip"
+
+    assert len(loaded_net.get_boundary_lines()) == 0
+    assert len(loaded_net.get_tie_lines()) == 0
 
     # CGMES has no battery class, so batteries come back as generators, and every boundary line adds an
     # equivalent injection generator.
@@ -310,11 +309,31 @@ def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.Te
         before = getattr(net, getter)()
         after = getattr(loaded_net, getter)()
         common = sorted(set(before.index) & set(after.index))
+        # initial=0.0 keeps element types the grid does not have (empty frames) a no-op.
         return float(
-            np.nanmax(np.abs(before.loc[common, column].to_numpy(float) - after.loc[common, column].to_numpy(float)))
+            np.nanmax(
+                np.abs(before.loc[common, column].to_numpy(float) - after.loc[common, column].to_numpy(float)),
+                initial=0.0,
+            )
         )
 
-    # The state variables of the exported load flow are restored on import.
+    # Tap changers keep their position and their full step table. Note that target_deadband is not part of
+    # the comparison, CGMES does not carry it.
+    tap_columns = {
+        "get_phase_tap_changers": ["tap", "low_tap", "high_tap", "step_count"],
+        "get_ratio_tap_changers": ["tap", "low_tap", "high_tap", "step_count"],
+        "get_phase_tap_changer_steps": ["rho", "alpha", "r", "x", "g", "b"],
+        "get_ratio_tap_changer_steps": ["rho", "r", "x", "g", "b"],
+    }
+    for getter, columns in tap_columns.items():
+        before = getattr(net, getter)()
+        assert before.index.equals(getattr(loaded_net, getter)().index), f"{getter} changed during the round trip"
+        for column in columns:
+            assert max_abs_diff(getter, column) < 1e-6, f"{getter}.{column} changed during the CGMES round trip"
+
+    # The state variables of the exported load flow are restored on import. The first assertion guards
+    # against an all NaN comparison, which max_abs_diff would report as no difference.
+    assert net.get_lines()["p1"].notna().any(), "the fixture is expected to leave a converged load flow"
     for getter, columns in result_columns.items():
         for column in columns:
             assert max_abs_diff(getter, column) < 1e-6, f"{getter}.{column} changed during the CGMES round trip"

--- a/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
+++ b/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
@@ -240,7 +240,9 @@ def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.Te
     net = create_complex_grid_battery_hvdc_svc_3w_trafo()
     cgmes_file = tmp_path / "cgmes.zip"
 
-    # Export the CGMES files
+    # Export the CGMES files. Note that no load flow is run here on purpose: the fixture already leaves a
+    # converged state on the network, and a default-parameter run would leave a slack bus residual large
+    # enough for the SV export to emit an SvInjection, which cannot be imported into a node/breaker grid.
     net.save(
         cgmes_file,
         format="CGMES",
@@ -248,8 +250,92 @@ def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.Te
     loaded_net = pypowsybl.network.load(cgmes_file)
 
     assert isinstance(loaded_net, pypowsybl.network.Network)
-    assert len(loaded_net.get_buses()) > 0
-    assert len(loaded_net.get_branches()) > 0
+
+    # Element types that CGMES round trips one to one, ids included.
+    for getter in [
+        "get_loads",
+        "get_2_windings_transformers",
+        "get_3_windings_transformers",
+        "get_shunt_compensators",
+        "get_static_var_compensators",
+        "get_hvdc_lines",
+        "get_vsc_converter_stations",
+        "get_lcc_converter_stations",
+        "get_busbar_sections",
+    ]:
+        before = getattr(net, getter)()
+        after = getattr(loaded_net, getter)()
+        assert len(before) == len(after), f"{getter} changed during the CGMES round trip"
+        assert set(before.index) <= set(after.index), f"{getter} lost ids during the CGMES round trip"
+
+    n_boundary_lines = len(net.get_boundary_lines())
+    n_tie_lines = len(net.get_tie_lines())
+    n_batteries = len(net.get_batteries())
+
+    # CGMES models a boundary line as a full AC line ending in a fictitious substation/voltage level/bus.
+    # Two boundary lines coupled by a tie line share a single boundary point.
+    assert len(loaded_net.get_lines()) == len(net.get_lines()) + n_boundary_lines
+    assert set(net.get_lines().index) <= set(loaded_net.get_lines().index)
+    assert len(loaded_net.get_boundary_lines()) == 0
+    assert len(loaded_net.get_tie_lines()) == 0
+    for getter in ["get_substations", "get_voltage_levels", "get_buses"]:
+        before = getattr(net, getter)()
+        after = getattr(loaded_net, getter)()
+        assert len(after) == len(before) + n_boundary_lines - n_tie_lines, f"unexpected {getter} count"
+        assert set(before.index) <= set(after.index), f"{getter} lost ids during the CGMES round trip"
+
+    # CGMES has no battery class, so batteries come back as generators, and every boundary line adds an
+    # equivalent injection generator.
+    assert len(loaded_net.get_batteries()) == 0
+    assert len(loaded_net.get_generators()) == len(net.get_generators()) + n_batteries + n_boundary_lines
+    assert set(net.get_generators().index) | set(net.get_batteries().index) <= set(loaded_net.get_generators().index)
+
+    # The injection count is preserved, but the boundary line ids are renamed to their equivalent injections.
+    assert len(loaded_net.get_injections()) == len(net.get_injections())
+
+    # Fictitious switches are added for the open terminals of LINE_out_of_service.
+    assert set(net.get_switches().index) <= set(loaded_net.get_switches().index)
+
+    result_columns = {
+        "get_lines": ["p1", "q1", "p2", "q2", "i1", "i2"],
+        "get_2_windings_transformers": ["p1", "q1", "i1"],
+        "get_3_windings_transformers": ["p1", "p2", "p3"],
+        "get_loads": ["p", "q"],
+        "get_generators": ["p", "q"],
+        "get_shunt_compensators": ["q"],
+        "get_static_var_compensators": ["q"],
+    }
+
+    def max_abs_diff(getter: str, column: str) -> float:
+        before = getattr(net, getter)()
+        after = getattr(loaded_net, getter)()
+        common = sorted(set(before.index) & set(after.index))
+        return float(
+            np.nanmax(np.abs(before.loc[common, column].to_numpy(float) - after.loc[common, column].to_numpy(float)))
+        )
+
+    # The state variables of the exported load flow are restored on import.
+    for getter, columns in result_columns.items():
+        for column in columns:
+            assert max_abs_diff(getter, column) < 1e-6, f"{getter}.{column} changed during the CGMES round trip"
+    for column in ["v_mag", "v_angle"]:
+        assert max_abs_diff("get_buses", column) < 1e-6, f"bus {column} changed during the CGMES round trip"
+
+    # The imported grid still solves and reproduces the same operating point.
+    lf_result = pypowsybl.loadflow.run_ac(loaded_net)
+    assert lf_result[0].status == pypowsybl._pypowsybl.LoadFlowComponentStatus.CONVERGED
+    for getter, columns in result_columns.items():
+        for column in columns:
+            assert max_abs_diff(getter, column) < 0.5, f"{getter}.{column} differs after solving the imported grid"
+    assert max_abs_diff("get_buses", "v_mag") < 1e-2
+
+    # CGMES does not carry the slackTerminal extension, so the rerun picks another reference bus and the bus
+    # angles only match up to a global offset.
+    common_buses = sorted(set(net.get_buses().index) & set(loaded_net.get_buses().index))
+    angles_before = net.get_buses().loc[common_buses, "v_angle"].to_numpy(float)
+    angles_after = loaded_net.get_buses().loc[common_buses, "v_angle"].to_numpy(float)
+    # Disconnected buses have no angle at all, they are skipped by comparing with nanmax.
+    assert np.nanmax(np.abs((angles_before - angles_before[0]) - (angles_after - angles_after[0]))) < 1e-2
 
 
 def test_load_pandapower_net_for_powsybl_with_convert_from_pandapower():

--- a/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
+++ b/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
@@ -11,7 +11,10 @@ import pandas as pd
 import pypowsybl
 import pytest
 from fsspec.implementations.local import LocalFileSystem
-from toop_engine_grid_helpers.powsybl.example_grids import basic_node_breaker_network_powsybl
+from toop_engine_grid_helpers.powsybl.example_grids import (
+    basic_node_breaker_network_powsybl,
+    create_complex_grid_battery_hvdc_svc_3w_trafo,
+)
 from toop_engine_grid_helpers.powsybl.powsybl_helpers import (
     change_dangling_to_tie,
     check_powsybl_import,
@@ -230,6 +233,20 @@ def test_save_powsybl_to_fs_cgmes(tmp_path_factory: pytest.TempPathFactory, euro
     assert net_original.get_buses().equals(net_loaded.get_buses())
     assert net_original.get_branches().equals(net_loaded.get_branches())
     assert net_original.get_injections().equals(net_loaded.get_injections())
+
+
+def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.TempPathFactory) -> None:
+    tmp_path = tmp_path_factory.mktemp("powsybl_save_load")
+    net = create_complex_grid_battery_hvdc_svc_3w_trafo()
+    cgmes_file = tmp_path / "cgmes.zip"
+
+    # Export the CGMES files
+    net.save(cgmes_file, format="CGMES")
+    loaded_net = pypowsybl.network.load(cgmes_file)
+
+    assert isinstance(loaded_net, pypowsybl.network.Network)
+    assert len(loaded_net.get_buses()) > 0
+    assert len(loaded_net.get_branches()) > 0
 
 
 def test_load_pandapower_net_for_powsybl_with_convert_from_pandapower():

--- a/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
+++ b/packages/grid_helpers_pkg/tests/powsybl/test_powsybl_helpers_grid_helper.py
@@ -241,7 +241,10 @@ def test_save_and_load_complex_example_grid_as_cgmes(tmp_path_factory: pytest.Te
     cgmes_file = tmp_path / "cgmes.zip"
 
     # Export the CGMES files
-    net.save(cgmes_file, format="CGMES")
+    net.save(
+        cgmes_file,
+        format="CGMES",
+    )
     loaded_net = pypowsybl.network.load(cgmes_file)
 
     assert isinstance(loaded_net, pypowsybl.network.Network)


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes #

## What is the new behavior (if this is a feature change)?

Adds a regression test in grid_helpers_pkg to ensure a more complex PyPowsybl example network can be exported to CGMES and loaded back successfully, extending existing save/load coverage beyond the Eurostag tutorial grid.

Changes:

- Extend PyPowsybl test imports to include `create_complex_grid_battery_hvdc_svc_3w_trafo`.
- Add a new test that saves the complex example grid as CGMES (zip) and reloads it.
- Test also checks for correct assets and AC loadflows.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
