### PR TITLE
fix: resolve wheel build collisions by refining package paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,12 @@ source = "uv-dynamic-versioning"
 
 [tool.hatch.build.targets.wheel]
 packages = [
-    "packages/interfaces_pkg/src",
-    "packages/contingency_analysis_pkg/src",
-    "packages/dc_solver_pkg/src",
-    "packages/grid_helpers_pkg/src",
-    "packages/importer_pkg/src",
-    "packages/topology_optimizer_pkg/src",
+    "packages/interfaces_pkg/src/toop_engine_interfaces",
+    "packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis",
+    "packages/dc_solver_pkg/src/toop_engine_dc_solver",
+    "packages/grid_helpers_pkg/src/toop_engine_grid_helpers",
+    "packages/importer_pkg/src/toop_engine_importer",
+    "packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [ ] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

No

## What is the new behavior (if this is a feature change)?

This PR corrects the pyproject.toml configuration to prevent build failures during wheel creation. It explicitly maps each sub-package to its specific source directory instead of the generic src parent folders.

Changes:
- Fixed Build Failure: Resolved a ValueError where multiple src/__init__.py files were colliding in the wheel archive.
- Improved Distribution: Restricted the bundled files to only the intended toop_engine_* packages, automatically excluding auxiliary scripts (like compile_proto.sh) and boilerplate files located in the src roots.
- Backend Optimization: Standardized the Hatch build target configuration to ensure reliable installations across all modules.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
