### PR TITLE
fix: allow the empty topology when PSTs are mutated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,9 @@
     "packages/contingency_analysis_pkg/src",
     "packages/importer_pkg/src",
     "packages/topology_optimizer_pkg/src"
-  ]
+  ],
+  "sonarlint.connectedMode.project": {
+    "connectionId": "https-sonarqube-consumercentricity-io-",
+    "projectKey": "gras-gridanalysis-toop-engine"
+  }
 }

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate.py
@@ -17,7 +17,10 @@ from toop_engine_topology_optimizer.dc.genetic_functions.mutation.config import 
     MutationConfig,
 )
 from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate_disconnections import mutate_disconnections
-from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate_nodal_inj import mutate_nodal_injections
+from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate_nodal_inj import (
+    has_mutable_psts,
+    mutate_nodal_injections,
+)
 from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate_substations import mutate_sub_splits
 
 
@@ -28,6 +31,7 @@ def mutate_topology(
     action: Int[Array, " max_num_splits"],
     mutate_config: MutationConfig,
     action_set: ActionSet,
+    allow_empty_topology: bool = False,
 ) -> tuple[
     Int[Array, " max_num_splits"], Int[Array, " max_num_splits"], Int[Array, " max_num_disconnections"], PRNGKeyArray
 ]:
@@ -47,6 +51,10 @@ def mutate_topology(
         The mutation configuration
     action_set : ActionSet
         The set of possible actions
+    allow_empty_topology : bool
+        Whether a topology without splits and without disconnections is a meaningful individual.
+        This is the case if another part of the genome is mutated as well, e.g. the PST taps.
+        See mutate_disconnections for details.
 
     Returns
     -------
@@ -94,6 +102,7 @@ def mutate_topology(
             sub_ids=sub_ids,
             disconnections=disconnections_topo,
             disconnection_mutation_config=mutate_config.disconnection_mutation_config,
+            allow_empty_topology=allow_empty_topology,
         )
     return sub_ids, action, disconnections_topo, random_key
 
@@ -210,6 +219,12 @@ def mutate(
     )
     n_random_topologies = round(mutation_config.random_topo_prob * n_mutations)
 
+    # If the PST taps are mutated as well, a topology without splits and disconnections is not
+    # necessarily the unchanged base topology, so the disconnection mutation may produce it.
+    allow_empty_topology = has_mutable_psts(
+        repeated_topologies.nodal_injections_optimized, mutation_config.nodal_injection_mutation_config
+    )
+
     # Setup batch functions for mutation and random topology creation
     mutate_topologies_batch = jax.vmap(
         lambda sub_id, action_single, disconnection_single, key: mutate_topology(
@@ -219,6 +234,7 @@ def mutate(
             action=action_single,
             mutate_config=mutation_config,
             action_set=action_set,
+            allow_empty_topology=allow_empty_topology,
         )
     )
 

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_disconnections.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_disconnections.py
@@ -117,6 +117,7 @@ def mutate_disconnections(
     sub_ids: Int[Array, " max_num_splits"],
     disconnections: Int[Array, " max_num_disconnections"],
     disconnection_mutation_config: DisconnectionMutationConfig,
+    allow_empty_topology: bool = False,
 ) -> Int[Array, " max_num_disconnections"]:
     """Mutate the disconnections of a single topology.
 
@@ -138,6 +139,12 @@ def mutate_disconnections(
         containing the probabilities for the different mutation types and the
         number of disconnectable branches in the grid,
         which is needed to determine the valid range of branch ids for mutation.
+    allow_empty_topology : bool
+        Whether a topology without splits and without disconnections is a meaningful individual.
+        This is the case if some other part of the genome is mutated as well, e.g. the PST taps.
+        If it is not (the default), we avoid ending up with the unchanged base topology by never
+        reconnecting the last disconnection and by always adding a disconnection to an empty topology.
+        This is a static python bool, it must not be a traced value.
 
     Returns
     -------
@@ -162,10 +169,14 @@ def mutate_disconnections(
     # Check which actions are allowed.
     # We only allow to add a disconnection if there are less disconnections than the maximum number of disconnections.
     allow_add = (n_disconnections < max_num_disconnections) & (add_disconnection_prob > 0.0)
-    # We only allow to remove a disconnection if there is at least one disconnection,
-    # and we don't want to end up with zero disconnections if there are no splits in the topology,
-    # because then we would always end up with the same unsplit topology after mutation.
-    allow_remove = (has_splits & (n_disconnections == 1)) | (n_disconnections > 1)
+    # We only allow to remove a disconnection if there is at least one disconnection.
+    # Unless another part of the genome is mutated as well, we additionally don't want to end up with
+    # zero disconnections if there are no splits in the topology, because then we would always end up
+    # with the same unsplit topology after mutation.
+    if allow_empty_topology:
+        allow_remove = n_disconnections > 0
+    else:
+        allow_remove = (has_splits & (n_disconnections == 1)) | (n_disconnections > 1)
 
     # We only allow to change a disconnection if there is at least one disconnection,
     # otherwise there is nothing to change
@@ -185,14 +196,18 @@ def mutate_disconnections(
 
     # Replace all "illegal" operations with "remain unchanged".
     prob_sum = jnp.sum(probs)
-    # If there are no splits, always add a disconnection
-    # Otherwise, normalise the allowed probabilities to sum to 1
+    # Normalise the allowed probabilities to sum to 1.
     # If probs are negative, only the remain option is considered
-    probs = jnp.where(
-        (~has_splits) & allow_add & (n_disconnections == 0),
-        jnp.array([1.0, 0.0, 0.0, 0.0]),
-        probs.at[3].set(1.0 - prob_sum),
-    )
+    probs = probs.at[3].set(1.0 - prob_sum)
+    if not allow_empty_topology:
+        # An empty topology would be the unchanged base topology, so we always add a disconnection to it.
+        # If another part of the genome is mutated as well (e.g. the PST taps), the empty topology is a
+        # meaningful individual and we leave the probabilities as they are.
+        probs = jnp.where(
+            (~has_splits) & allow_add & (n_disconnections == 0),
+            jnp.array([1.0, 0.0, 0.0, 0.0]),
+            probs,
+        )
 
     # Randomly choose which operation to perform based on the probabilities
     # At least one of the operations is executed

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
@@ -100,6 +100,37 @@ def mutate_psts(
     return new_pst_taps
 
 
+def has_mutable_psts(
+    nodal_inj_info: Optional[NodalInjOptimResults],
+    nodal_mutation_config: Optional[NodalInjectionMutationConfig],
+) -> bool:
+    """Check whether the PST taps are a mutable part of the genome.
+
+    If they are, a topology without splits and without disconnections is still a meaningful
+    individual, because it can differ from other individuals in its PST taps.
+
+    Parameters
+    ----------
+    nodal_inj_info : Optional[NodalInjOptimResults]
+        The nodal injection optimization results that are part of the genome. If None,
+        the genome does not contain any PST taps.
+    nodal_mutation_config : Optional[NodalInjectionMutationConfig]
+        The configuration for the nodal injection mutation. If None, the PST taps are never mutated.
+
+    Returns
+    -------
+    bool
+        Whether at least one PST tap can be changed by the mutation.
+    """
+    if nodal_inj_info is None or nodal_mutation_config is None:
+        return False
+
+    if nodal_mutation_config.pst_mutation_sigma <= 0:
+        return False
+
+    return nodal_inj_info.pst_tap_idx.shape[-1] > 0
+
+
 def mutate_nodal_injections(
     random_key: PRNGKeyArray,
     nodal_inj_info: Optional[NodalInjOptimResults],
@@ -124,7 +155,7 @@ def mutate_nodal_injections(
     if nodal_inj_info is None:
         return None
 
-    if nodal_mutation_config is None or nodal_mutation_config.pst_mutation_sigma <= 0:
+    if not has_mutable_psts(nodal_inj_info, nodal_mutation_config):
         return nodal_inj_info
 
     batch_size = nodal_inj_info.pst_tap_idx.shape[0]

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
@@ -109,6 +109,9 @@ def has_mutable_psts(
     If they are, a topology without splits and without disconnections is still a meaningful
     individual, because it can differ from other individuals in its PST taps.
 
+    This is stricter than the early return of mutate_nodal_injections: a configuration that runs
+    the mutation but can never select a PST for it leaves the taps unchanged as well.
+
     Parameters
     ----------
     nodal_inj_info : Optional[NodalInjOptimResults]
@@ -125,7 +128,14 @@ def has_mutable_psts(
     if nodal_inj_info is None or nodal_mutation_config is None:
         return False
 
+    # A sigma of zero disables the PST mutation entirely, see mutate_nodal_injections.
     if nodal_mutation_config.pst_mutation_sigma <= 0:
+        return False
+
+    # Without a chance to either mutate or reset a PST, mutate_psts leaves all taps as they are.
+    # A reset alone is enough, because the taps can differ from the starting taps: they are written
+    # back into the genome by the nodal injection optimization during scoring.
+    if nodal_mutation_config.pst_mutation_probability <= 0 and nodal_mutation_config.pst_reset_probability <= 0:
         return False
 
     return nodal_inj_info.pst_tap_idx.shape[-1] > 0
@@ -155,7 +165,7 @@ def mutate_nodal_injections(
     if nodal_inj_info is None:
         return None
 
-    if not has_mutable_psts(nodal_inj_info, nodal_mutation_config):
+    if nodal_mutation_config is None or nodal_mutation_config.pst_mutation_sigma <= 0:
         return nodal_inj_info
 
     batch_size = nodal_inj_info.pst_tap_idx.shape[0]

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/dc/genetic_functions/mutation/mutate_nodal_inj.py
@@ -128,14 +128,10 @@ def has_mutable_psts(
     if nodal_inj_info is None or nodal_mutation_config is None:
         return False
 
-    # A sigma of zero disables the PST mutation entirely, see mutate_nodal_injections.
-    if nodal_mutation_config.pst_mutation_sigma <= 0:
-        return False
-
-    # Without a chance to either mutate or reset a PST, mutate_psts leaves all taps as they are.
-    # A reset alone is enough, because the taps can differ from the starting taps: they are written
-    # back into the genome by the nodal injection optimization during scoring.
-    if nodal_mutation_config.pst_mutation_probability <= 0 and nodal_mutation_config.pst_reset_probability <= 0:
+    # Both a sigma of zero (see the early return of mutate_nodal_injections) and a mutation
+    # probability of zero disable the PST mutation. A reset does not help either, because the taps
+    # start at their initial set point and the mutation is the only thing that moves them away.
+    if nodal_mutation_config.pst_mutation_sigma <= 0 or nodal_mutation_config.pst_mutation_probability <= 0:
         return False
 
     return nodal_inj_info.pst_tap_idx.shape[-1] > 0

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/interfaces/messages/dc_params.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/interfaces/messages/dc_params.py
@@ -11,6 +11,8 @@ This holds the parameters to start the optimization. Some parameters can not be 
 the names of the kafka streams) and are included in the command line start parameters instead.
 """
 
+import math
+
 from beartype.typing import Optional
 from pydantic import (
     BaseModel,
@@ -198,9 +200,11 @@ class BatchedMEParameters(BaseModel):
         therefore require all three parameters to be 0 as soon as one of the two disables the
         mutation, instead of silently ignoring the remaining ones.
         """
-        pst_mutation_disabled = self.pst_mutation_sigma == 0.0 or self.pst_mutation_probability == 0.0
+        pst_mutation_disabled = math.isclose(self.pst_mutation_sigma, 0.0) or math.isclose(
+            self.pst_mutation_probability, 0.0
+        )
         pst_params = (self.pst_mutation_sigma, self.pst_mutation_probability, self.pst_reset_probability)
-        if pst_mutation_disabled and any(param != 0.0 for param in pst_params):
+        if pst_mutation_disabled and any(not math.isclose(param, 0.0) for param in pst_params):
             raise ValueError(
                 "A pst_mutation_sigma or a pst_mutation_probability of 0 disables the PST mutation, which makes "
                 "the remaining PST mutation parameters ineffective. Set pst_mutation_sigma, pst_mutation_probability "

--- a/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/interfaces/messages/dc_params.py
+++ b/packages/topology_optimizer_pkg/src/toop_engine_topology_optimizer/interfaces/messages/dc_params.py
@@ -115,7 +115,7 @@ class BatchedMEParameters(BaseModel):
 
     # Parameters for the mutation of nodal injections (currently only PSTs)
 
-    pst_mutation_sigma: NonNegativeFloat = 0.0
+    pst_mutation_sigma: NonNegativeFloat = 1.0
     """The sigma to use for the normal distribution that mutates the PST taps. The mutation is applied by adding a random
     value drawn from this distribution to the current tap position. A value of 0.0 means no PST mutation."""
 
@@ -125,7 +125,8 @@ class BatchedMEParameters(BaseModel):
 
     pst_reset_probability: confloat(ge=0.0, le=1.0) = 0.0
     """The probability for an individual PST to be reverted to its initial set point. A value of 0.0 means no reset. A
-    value of 1.0 means all PSTs will be reset."""
+    value of 1.0 means all PSTs will be reset. This only has an effect if the PST mutation is enabled, because the taps
+    start at their initial set point and the mutation is the only thing that moves them away from it."""
 
     ### CROSS OVER CONFIGURATION ###
 
@@ -185,6 +186,27 @@ class BatchedMEParameters(BaseModel):
             raise ValueError("The sum of the disconnection mutation probabilities cannot be larger than 1.")
         if self.random_topo_prob > 1.0:
             raise ValueError("The random topology probability cannot be larger than 1.")
+        return self
+
+    @model_validator(mode="after")
+    def pst_mutation_enabled_consistently(self) -> "BatchedMEParameters":
+        """Check that the PST mutation is either fully enabled or fully disabled.
+
+        Both a sigma of 0 and a mutation probability of 0 disable the PST mutation completely.
+        The taps are initialized at their starting values and the mutation is the only thing that
+        moves them away from it, so a reset probability has no effect on its own either. We
+        therefore require all three parameters to be 0 as soon as one of the two disables the
+        mutation, instead of silently ignoring the remaining ones.
+        """
+        pst_mutation_disabled = self.pst_mutation_sigma == 0.0 or self.pst_mutation_probability == 0.0
+        pst_params = (self.pst_mutation_sigma, self.pst_mutation_probability, self.pst_reset_probability)
+        if pst_mutation_disabled and any(param != 0.0 for param in pst_params):
+            raise ValueError(
+                "A pst_mutation_sigma or a pst_mutation_probability of 0 disables the PST mutation, which makes "
+                "the remaining PST mutation parameters ineffective. Set pst_mutation_sigma, pst_mutation_probability "
+                "and pst_reset_probability all to 0 to disable the PST mutation, or set both pst_mutation_sigma and "
+                "pst_mutation_probability to a value larger than 0 to enable it."
+            )
         return self
 
     @model_validator(mode="after")

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate.py
@@ -70,8 +70,12 @@ def test_create_random_topology_values(synthetic_action_set):
         assert val == int_max() or (0 <= val < n_disconnectable_branches)
 
 
-def _mutation_config_without_split_mutations(n_disconnectable_branches: int, n_rel_subs: int, with_psts: bool):
-    """Build a config that keeps the substations unsplit, so only disconnections and PSTs are mutated."""
+def _mutation_config_without_split_mutations(n_disconnectable_branches: int, n_rel_subs: int, pst_mode: str):
+    """Build a config that keeps the substations unsplit, so only disconnections and PSTs are mutated.
+
+    pst_mode is one of "none" (no PSTs in the genome), "mutable" (the taps are actually mutated) and
+    "never_selected" (PSTs exist, but no PST can ever be picked for a mutation or a reset).
+    """
     return MutationConfig(
         mutation_repetition=1,
         random_topo_prob=0.0,
@@ -90,20 +94,20 @@ def _mutation_config_without_split_mutations(n_disconnectable_branches: int, n_r
         ),
         nodal_injection_mutation_config=NodalInjectionMutationConfig(
             pst_mutation_sigma=2.0,
-            pst_mutation_probability=0.5,
+            pst_mutation_probability=0.5 if pst_mode == "mutable" else 0.0,
             pst_reset_probability=0.0,
             pst_n_taps=jnp.array([10, 10]),
             pst_start_tap_idx=jnp.array([5, 5]),
         )
-        if with_psts
+        if pst_mode != "none"
         else None,
     )
 
 
-@pytest.mark.parametrize("with_psts", [False, True])
-def test_mutate_empty_topology_only_stays_empty_with_psts(synthetic_action_set, with_psts):
+@pytest.mark.parametrize("pst_mode", ["none", "mutable", "never_selected"])
+def test_mutate_empty_topology_only_stays_empty_with_mutable_psts(synthetic_action_set, pst_mode):
     # An empty topology (no splits, no disconnections) is the unchanged base topology unless the PST
-    # taps are mutated as well. Only in the latter case the mutation may keep it empty.
+    # taps are actually mutated as well. Only in that case the mutation may keep it empty.
     batch_size = 32
     n_timesteps = 1
     n_disconnectable_branches = 5
@@ -114,9 +118,9 @@ def test_mutate_empty_topology_only_stays_empty_with_psts(synthetic_action_set, 
         max_num_splits=3,
         max_num_disconnections=2,
         n_timesteps=n_timesteps,
-        starting_taps=jnp.array([5, 5]) if with_psts else None,
+        starting_taps=jnp.array([5, 5]) if pst_mode != "none" else None,
     )
-    mutation_config = _mutation_config_without_split_mutations(n_disconnectable_branches, n_rel_subs, with_psts)
+    mutation_config = _mutation_config_without_split_mutations(n_disconnectable_branches, n_rel_subs, pst_mode)
 
     mutated, _ = mutate(
         topologies=topologies,
@@ -128,7 +132,7 @@ def test_mutate_empty_topology_only_stays_empty_with_psts(synthetic_action_set, 
     # The substations are never split with this config, so an empty genome is one without disconnections
     assert jnp.all(mutated.action_index == int_max())
     is_empty = jnp.all(mutated.disconnections == int_max(), axis=1)
-    if with_psts:
-        assert jnp.any(is_empty), "With PSTs, the mutation should be able to keep the empty topology"
+    if pst_mode == "mutable":
+        assert jnp.any(is_empty), "With mutable PSTs, the mutation should be able to keep the empty topology"
     else:
-        assert not jnp.any(is_empty), "Without PSTs, the mutation should always add a disconnection"
+        assert not jnp.any(is_empty), "Without mutable PSTs, the mutation should always add a disconnection"

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate.py
@@ -7,8 +7,16 @@
 
 import jax
 import jax.numpy as jnp
+import pytest
 from toop_engine_dc_solver.jax.types import int_max
-from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate import create_random_topology
+from toop_engine_topology_optimizer.dc.genetic_functions.genotype import empty_repertoire
+from toop_engine_topology_optimizer.dc.genetic_functions.mutation.config import (
+    DisconnectionMutationConfig,
+    MutationConfig,
+    NodalInjectionMutationConfig,
+    SubstationMutationConfig,
+)
+from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate import create_random_topology, mutate
 
 
 def test_create_random_topology_shapes(synthetic_action_set):
@@ -60,3 +68,67 @@ def test_create_random_topology_values(synthetic_action_set):
     # Check that disconnections_out contains either int_max or values in [0, n_disconnectable_branches)
     for val in disconnections_out:
         assert val == int_max() or (0 <= val < n_disconnectable_branches)
+
+
+def _mutation_config_without_split_mutations(n_disconnectable_branches: int, n_rel_subs: int, with_psts: bool):
+    """Build a config that keeps the substations unsplit, so only disconnections and PSTs are mutated."""
+    return MutationConfig(
+        mutation_repetition=1,
+        random_topo_prob=0.0,
+        substation_mutation_config=SubstationMutationConfig(
+            n_subs_mutated_lambda=1.0,
+            add_split_prob=0.0,
+            change_split_prob=0.0,
+            remove_split_prob=0.0,
+            n_rel_subs=n_rel_subs,
+        ),
+        disconnection_mutation_config=DisconnectionMutationConfig(
+            add_disconnection_prob=0.1,
+            change_disconnection_prob=0.1,
+            remove_disconnection_prob=0.1,
+            n_disconnectable_branches=n_disconnectable_branches,
+        ),
+        nodal_injection_mutation_config=NodalInjectionMutationConfig(
+            pst_mutation_sigma=2.0,
+            pst_mutation_probability=0.5,
+            pst_reset_probability=0.0,
+            pst_n_taps=jnp.array([10, 10]),
+            pst_start_tap_idx=jnp.array([5, 5]),
+        )
+        if with_psts
+        else None,
+    )
+
+
+@pytest.mark.parametrize("with_psts", [False, True])
+def test_mutate_empty_topology_only_stays_empty_with_psts(synthetic_action_set, with_psts):
+    # An empty topology (no splits, no disconnections) is the unchanged base topology unless the PST
+    # taps are mutated as well. Only in the latter case the mutation may keep it empty.
+    batch_size = 32
+    n_timesteps = 1
+    n_disconnectable_branches = 5
+    n_rel_subs = synthetic_action_set.n_actions_per_sub.shape[0]
+
+    topologies = empty_repertoire(
+        batch_size,
+        max_num_splits=3,
+        max_num_disconnections=2,
+        n_timesteps=n_timesteps,
+        starting_taps=jnp.array([5, 5]) if with_psts else None,
+    )
+    mutation_config = _mutation_config_without_split_mutations(n_disconnectable_branches, n_rel_subs, with_psts)
+
+    mutated, _ = mutate(
+        topologies=topologies,
+        random_key=jax.random.PRNGKey(0),
+        mutation_config=mutation_config,
+        action_set=synthetic_action_set,
+    )
+
+    # The substations are never split with this config, so an empty genome is one without disconnections
+    assert jnp.all(mutated.action_index == int_max())
+    is_empty = jnp.all(mutated.disconnections == int_max(), axis=1)
+    if with_psts:
+        assert jnp.any(is_empty), "With PSTs, the mutation should be able to keep the empty topology"
+    else:
+        assert not jnp.any(is_empty), "Without PSTs, the mutation should always add a disconnection"

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_disconnections.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_disconnections.py
@@ -276,6 +276,62 @@ def test_mutate_disconnections_operation_selection(random_key, sub_ids, disconne
         assert jnp.any(mutated == int_max())
 
 
+def test_mutate_disconnections_empty_topology_forces_add():
+    # Without another mutable part of the genome, an empty topology is the unchanged base topology,
+    # so a disconnection is always added, even though the add probability is low.
+    sub_ids = jnp.array([int_max(), int_max()], dtype=int)
+    disconnections = jnp.array([int_max(), int_max()], dtype=int)
+    config = DisconnectionMutationConfig(
+        add_disconnection_prob=0.1,
+        change_disconnection_prob=0.1,
+        remove_disconnection_prob=0.1,
+        n_disconnectable_branches=3,
+    )
+    for i in range(20):
+        mutated = mutate_disconnections(jax.random.PRNGKey(i), sub_ids, disconnections, config)
+        assert jnp.sum(mutated != int_max()) == 1, "A disconnection should always be added to an empty topology"
+
+
+def test_mutate_disconnections_allow_empty_topology_can_remain():
+    # With PSTs, the empty topology is a meaningful individual, so it does not have to be mutated.
+    sub_ids = jnp.array([int_max(), int_max()], dtype=int)
+    disconnections = jnp.array([int_max(), int_max()], dtype=int)
+    config = DisconnectionMutationConfig(
+        add_disconnection_prob=0.1,
+        change_disconnection_prob=0.1,
+        remove_disconnection_prob=0.1,
+        n_disconnectable_branches=3,
+    )
+    results = [
+        mutate_disconnections(jax.random.PRNGKey(i), sub_ids, disconnections, config, allow_empty_topology=True)
+        for i in range(20)
+    ]
+    assert any(jnp.all(mutated == int_max()) for mutated in results), (
+        "The empty topology should be able to remain unchanged when PSTs are mutated"
+    )
+    # The add operation must still be reachable
+    assert any(jnp.any(mutated != int_max()) for mutated in results), "Disconnections should still be added sometimes"
+
+
+@pytest.mark.parametrize("allow_empty_topology", [False, True])
+def test_mutate_disconnections_remove_last_disconnection(random_key, allow_empty_topology):
+    # Removing the last disconnection of a topology without splits results in the empty topology,
+    # which is only allowed if another part of the genome is mutated as well.
+    sub_ids = jnp.array([int_max(), int_max()], dtype=int)
+    disconnections = jnp.array([1, int_max()], dtype=int)
+    config = DisconnectionMutationConfig(
+        add_disconnection_prob=0.0,
+        change_disconnection_prob=0.0,
+        remove_disconnection_prob=1.0,
+        n_disconnectable_branches=3,
+    )
+    mutated = mutate_disconnections(random_key, sub_ids, disconnections, config, allow_empty_topology=allow_empty_topology)
+    if allow_empty_topology:
+        assert jnp.all(mutated == int_max()), "The last disconnection should be removable when PSTs are mutated"
+    else:
+        assert jnp.all(mutated == disconnections), "The last disconnection must not be removed without splits"
+
+
 def test_mutate_disconnections_remain(random_key):
     sub_ids = jnp.array([int_max(), int_max()], dtype=int)
     disconnections = jnp.array([int_max(), int_max()], dtype=int)

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
@@ -310,6 +310,24 @@ def test_has_mutable_psts() -> None:
         pst_start_tap_idx=jnp.array([1, 2], dtype=int),
     )
     assert not has_mutable_psts(nodal_inj_info, no_sigma_config)
+    # No PST can ever be selected for mutation or for a reset, so the taps never change
+    never_selected_config = NodalInjectionMutationConfig(
+        pst_mutation_sigma=2.0,
+        pst_mutation_probability=0.0,
+        pst_reset_probability=0.0,
+        pst_n_taps=jnp.array([5, 5], dtype=int),
+        pst_start_tap_idx=jnp.array([1, 2], dtype=int),
+    )
+    assert not has_mutable_psts(nodal_inj_info, never_selected_config)
+    # A reset alone still changes taps that differ from the starting taps
+    reset_only_config = NodalInjectionMutationConfig(
+        pst_mutation_sigma=2.0,
+        pst_mutation_probability=0.0,
+        pst_reset_probability=0.5,
+        pst_n_taps=jnp.array([5, 5], dtype=int),
+        pst_start_tap_idx=jnp.array([1, 2], dtype=int),
+    )
+    assert has_mutable_psts(nodal_inj_info, reset_only_config)
     # No controllable PSTs
     empty_nodal_inj_info = NodalInjOptimResults(pst_tap_idx=jnp.zeros((1, 1, 0), dtype=int))
     assert not has_mutable_psts(empty_nodal_inj_info, mutation_config)

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
@@ -10,6 +10,7 @@ import jax.numpy as jnp
 from toop_engine_dc_solver.jax.types import NodalInjOptimResults
 from toop_engine_topology_optimizer.dc.genetic_functions.mutation.config import NodalInjectionMutationConfig
 from toop_engine_topology_optimizer.dc.genetic_functions.mutation.mutate_nodal_inj import (
+    has_mutable_psts,
     mutate_nodal_injections,
     mutate_psts,
 )
@@ -284,6 +285,34 @@ def test_grouped_mutate_psts_keeps_parallel_members_equal_different_order() -> N
     assert jnp.any(difference > 0)
     assert mutated_pst_taps[0] == mutated_pst_taps[2]
     assert mutated_pst_taps[1] == mutated_pst_taps[3]
+
+
+def test_has_mutable_psts() -> None:
+    nodal_inj_info = NodalInjOptimResults(pst_tap_idx=jnp.array([[[1, 2]]], dtype=int))
+    mutation_config = NodalInjectionMutationConfig(
+        pst_mutation_sigma=2.0,
+        pst_mutation_probability=1.0,
+        pst_reset_probability=0.0,
+        pst_n_taps=jnp.array([5, 5], dtype=int),
+        pst_start_tap_idx=jnp.array([1, 2], dtype=int),
+    )
+
+    assert has_mutable_psts(nodal_inj_info, mutation_config)
+    # No PST taps in the genome
+    assert not has_mutable_psts(None, mutation_config)
+    # No mutation of the PST taps
+    assert not has_mutable_psts(nodal_inj_info, None)
+    no_sigma_config = NodalInjectionMutationConfig(
+        pst_mutation_sigma=0.0,
+        pst_mutation_probability=1.0,
+        pst_reset_probability=1.0,
+        pst_n_taps=jnp.array([5, 5], dtype=int),
+        pst_start_tap_idx=jnp.array([1, 2], dtype=int),
+    )
+    assert not has_mutable_psts(nodal_inj_info, no_sigma_config)
+    # No controllable PSTs
+    empty_nodal_inj_info = NodalInjOptimResults(pst_tap_idx=jnp.zeros((1, 1, 0), dtype=int))
+    assert not has_mutable_psts(empty_nodal_inj_info, mutation_config)
 
 
 def test_mutate_nodal_injections_ignores_empty_group_mask_when_group_optim_disabled() -> None:

--- a/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
+++ b/packages/topology_optimizer_pkg/tests/dc/genetic_functions/test_mutate_nodal_inj.py
@@ -319,7 +319,7 @@ def test_has_mutable_psts() -> None:
         pst_start_tap_idx=jnp.array([1, 2], dtype=int),
     )
     assert not has_mutable_psts(nodal_inj_info, never_selected_config)
-    # A reset alone still changes taps that differ from the starting taps
+    # A reset alone changes nothing, because only the mutation moves taps off their starting value
     reset_only_config = NodalInjectionMutationConfig(
         pst_mutation_sigma=2.0,
         pst_mutation_probability=0.0,
@@ -327,7 +327,7 @@ def test_has_mutable_psts() -> None:
         pst_n_taps=jnp.array([5, 5], dtype=int),
         pst_start_tap_idx=jnp.array([1, 2], dtype=int),
     )
-    assert has_mutable_psts(nodal_inj_info, reset_only_config)
+    assert not has_mutable_psts(nodal_inj_info, reset_only_config)
     # No controllable PSTs
     empty_nodal_inj_info = NodalInjOptimResults(pst_tap_idx=jnp.zeros((1, 1, 0), dtype=int))
     assert not has_mutable_psts(empty_nodal_inj_info, mutation_config)

--- a/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
+++ b/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
@@ -130,6 +130,32 @@ def test_me_descriptors_not_empty() -> None:
         )
 
 
+def test_pst_mutation_enabled_consistently() -> None:
+    # The PST mutation is enabled by default, so it takes effect as soon as the PSTs are optimized
+    defaults = BatchedMEParameters()
+    assert defaults.pst_mutation_sigma > 0.0
+    assert defaults.pst_mutation_probability > 0.0
+
+    # Fully enabled, with and without resets
+    _ = BatchedMEParameters(pst_mutation_sigma=2.0, pst_mutation_probability=0.2)
+    _ = BatchedMEParameters(pst_mutation_sigma=2.0, pst_mutation_probability=0.2, pst_reset_probability=0.1)
+
+    # Fully disabled
+    _ = BatchedMEParameters(pst_mutation_sigma=0.0, pst_mutation_probability=0.0, pst_reset_probability=0.0)
+
+    # A sigma of 0 disables the mutation, so the other parameters must be 0 as well
+    with pytest.raises(ValueError):
+        _ = BatchedMEParameters(pst_mutation_sigma=0.0)
+    with pytest.raises(ValueError):
+        _ = BatchedMEParameters(pst_mutation_sigma=0.0, pst_mutation_probability=0.0, pst_reset_probability=0.1)
+
+    # The same holds for a mutation probability of 0
+    with pytest.raises(ValueError):
+        _ = BatchedMEParameters(pst_mutation_probability=0.0)
+    with pytest.raises(ValueError):
+        _ = BatchedMEParameters(pst_mutation_sigma=2.0, pst_mutation_probability=0.0, pst_reset_probability=0.1)
+
+
 def test_busbar_penalty_overrides_are_serialized() -> None:
     params = BatchedMEParameters(
         enable_bb_outage=True,

--- a/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
+++ b/packages/topology_optimizer_pkg/tests/interfaces/messages/test_commands.py
@@ -6,6 +6,7 @@
 # Mozilla Public License, version 2.0
 
 import json
+import math
 
 import pytest
 from toop_engine_topology_optimizer.interfaces.messages.commands import (
@@ -169,4 +170,4 @@ def test_busbar_penalty_overrides_are_serialized() -> None:
     assert payload["enable_bb_outage"] is True
     assert payload["bb_outage_as_nminus1"] is False
     assert payload["clip_bb_outage_penalty"] is True
-    assert payload["bb_outage_more_islands_penalty"] == 75.0
+    assert math.isclose(payload["bb_outage_more_islands_penalty"], 75.0)


### PR DESCRIPTION
We had a logic that would force a disconnection in case no splits are part of a topology. Before we introduced the PST feature, this logic made sense, now I added a flag that checks for optimizable pst presence and skips this forcing logic in that case.

## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?


## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
