### PR TITLE
feat: per-type and per-case cascade loading thresholds

### DIFF
--- a/docs/contingency_analysis/cascade.md
+++ b/docs/contingency_analysis/cascade.md
@@ -119,8 +119,28 @@ flowchart TD
 
 | Type | Detection | Threshold |
 |---|---|---|
-| **Current overload** | Branch loading exceeds `current_loading_threshold` | Configurable per `CascadeConfig` |
+| **Current overload** | Branch loading exceeds the threshold resolved for its element type and case | Configurable per `CascadeConfig` |
 | **Distance protection** | Relay impedance falls inside warning or danger polygon zone | Defined per relay in `sw_characteristics` |
+
+### Current overload thresholds
+
+`loading` is the per-unit ratio `i / i_max`, so `1.5` means 150 %. The comparison is
+strict: a branch loaded at exactly its threshold does **not** trip.
+
+Each branch result row gets its own threshold, resolved from the element type
+(`line`, transformer, or anything else) and from whether the row belongs to the base
+case or to a contingency:
+
+| Row | Threshold | Falls back to |
+|---|---|---|
+| `line`, base case | `basecase_line_loading_threshold` | `current_loading_threshold` |
+| `line`, contingency | `contingency_line_loading_threshold` | `basecase_line_loading_threshold`, then `current_loading_threshold` |
+| `trafo` / `trafo3w`, base case | `basecase_transformer_loading_threshold` | `current_loading_threshold` |
+| `trafo` / `trafo3w`, contingency | `contingency_transformer_loading_threshold` | `basecase_transformer_loading_threshold`, then `current_loading_threshold` |
+| any other table (e.g. `impedance`) | `current_loading_threshold` | — |
+
+All four overrides are optional. When none of them are set, every branch is compared
+against `current_loading_threshold`, exactly as before they existed.
 
 ## Configuration
 
@@ -136,6 +156,22 @@ cascade_cfg = CascadeConfig(
     min_island_size=10,
     basecase_distance_protection_factor=0.9,
     contingency_distance_protection_factor=0.95,  # falls back to basecase factor if None
+    cascade_log_elements=["line", "trafo", "trafo3w"],
+)
+```
+
+To trip lines at 150 % and transformers at 180 % instead, add the per-type overrides
+(see [Current overload thresholds](#current-overload-thresholds)):
+
+```python
+cascade_cfg = CascadeConfig(
+    depth_limit=5,
+    current_loading_threshold=1.0,      # still used for e.g. impedances
+    basecase_line_loading_threshold=1.5,
+    basecase_transformer_loading_threshold=1.8,
+    min_island_size=10,
+    basecase_distance_protection_factor=0.9,
+    contingency_distance_protection_factor=0.95,
     cascade_log_elements=["line", "trafo", "trafo3w"],
 )
 ```

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
@@ -15,6 +15,7 @@ from .overload import (
     evaluate_overload_triggers,
     pick_highest_loading_row,
     prepare_branch_results_for_overload,
+    resolve_loading_thresholds,
 )
 from .switch_preparation import (
     get_complex_impedance,
@@ -33,4 +34,5 @@ __all__ = [
     "prepare_branch_results_for_overload",
     "prepare_cascade_run_constants",
     "prepare_switch_results_for_protection",
+    "resolve_loading_thresholds",
 ]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/overload.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/overload.py
@@ -10,11 +10,18 @@
 import logging
 from typing import Optional
 
+import numpy as np
 import pandas as pd
 import pandera.typing as pat
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import TRANSFORMER_TABLES
+from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR
 from toop_engine_interfaces.loadflow_results import BranchResultSchema
 
 _logger = logging.getLogger(__name__)
+
+#: Contingency id used for the N-0 results.
+BASECASE_CONTINGENCY_ID = "BASECASE"
 
 
 def prepare_branch_results_for_overload(current_res: Optional[pat.DataFrame[BranchResultSchema]]) -> pd.DataFrame:
@@ -35,23 +42,84 @@ def prepare_branch_results_for_overload(current_res: Optional[pat.DataFrame[Bran
     return current_res.reset_index()
 
 
+def resolve_loading_thresholds(
+    current_res: pd.DataFrame,
+    cascade_configuration: CascadeConfig,
+) -> tuple[np.ndarray, dict[str, float]]:
+    """Resolve the loading threshold that applies to each branch result row.
+
+    The threshold of a row follows from the element type (line, transformer, or
+    anything else) encoded in its globally unique ``element`` id, and from whether
+    the row belongs to the base case or to a contingency.
+
+    Parameters
+    ----------
+    current_res : pd.DataFrame
+        Branch result table with ``element`` and ``contingency`` columns, as
+        produced by :func:`prepare_branch_results_for_overload`.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the scalar and the per-type/per-case thresholds.
+
+    Returns
+    -------
+    tuple[np.ndarray, dict[str, float]]
+        Per-row thresholds aligned to ``current_res``, and the same thresholds keyed
+        by ``"<element type>/<case>"`` for logging.
+    """
+    # Globally unique ids are ``f"{table_id}{SEPARATOR}{table}"``; ids without a separator
+    # (or missing ones) resolve to no known table and therefore to the scalar threshold.
+    element_tables = current_res["element"].astype(str).str.rsplit(SEPARATOR, n=1).str[-1].to_numpy()
+    is_basecase = (current_res["contingency"] == BASECASE_CONTINGENCY_ID).to_numpy()
+
+    is_line = element_tables == "line"
+    # Both transformer tables resolve to the same threshold, so "trafo" stands for both.
+    is_transformer = np.isin(element_tables, list(TRANSFORMER_TABLES))
+
+    line_basecase = cascade_configuration.loading_threshold("line", basecase=True)
+    line_contingency = cascade_configuration.loading_threshold("line", basecase=False)
+    transformer_basecase = cascade_configuration.loading_threshold("trafo", basecase=True)
+    transformer_contingency = cascade_configuration.loading_threshold("trafo", basecase=False)
+    other = cascade_configuration.current_loading_threshold
+
+    # Every row starts at the scalar threshold; lines and transformers overwrite it.
+    thresholds = np.full(len(current_res), other, dtype=float)
+    thresholds[is_line & is_basecase] = line_basecase
+    thresholds[is_line & ~is_basecase] = line_contingency
+    thresholds[is_transformer & is_basecase] = transformer_basecase
+    thresholds[is_transformer & ~is_basecase] = transformer_contingency
+
+    thresholds_by_category = {
+        "line/basecase": line_basecase,
+        "line/contingency": line_contingency,
+        "transformer/basecase": transformer_basecase,
+        "transformer/contingency": transformer_contingency,
+        "other": other,
+    }
+    return thresholds, thresholds_by_category
+
+
 def evaluate_overload_triggers(
     current_res: Optional[pat.DataFrame[BranchResultSchema]],
-    threshold: float,
+    cascade_configuration: CascadeConfig,
 ) -> pd.DataFrame:
-    """Find branches whose loading is above the configured threshold.
+    """Find branches whose loading is above the threshold configured for them.
+
+    Each row is compared against the threshold resolved for its element type and
+    case by :func:`resolve_loading_thresholds`. The comparison is strict, so a
+    branch loaded exactly at its threshold does not trigger a cascade.
 
     Parameters
     ----------
     current_res : pat.DataFrame[BranchResultSchema] or None
-        Branch result table with a loading column.
-    threshold : float
-        Loading value above which a branch is treated as overloaded.
+        Branch result table with a loading column, where ``loading`` is the
+        per-unit ratio ``i / i_max`` rather than a percentage.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the loading thresholds.
 
     Returns
     -------
     pd.DataFrame
-        Rows from current_res whose loading is greater than threshold.
+        Rows from current_res whose loading is greater than their threshold.
     """
     if current_res is None or current_res.empty:
         return pd.DataFrame()
@@ -59,11 +127,12 @@ def evaluate_overload_triggers(
     max_loading = float(current_res["loading"].max())
     _logger.info("Maximum calculated loading: %s", max_loading)
 
-    overloaded = current_res[current_res["loading"] > threshold]
+    thresholds, applied_thresholds = resolve_loading_thresholds(current_res, cascade_configuration)
+    overloaded = current_res[current_res["loading"].to_numpy() > thresholds]
     if overloaded.empty:
-        _logger.info("cascading: No cascade records found with %s threshold", threshold)
+        _logger.info("cascading: No cascade records found with thresholds %s", applied_thresholds)
     else:
-        _logger.info("cascading: %s cascade records found", len(overloaded))
+        _logger.info("cascading: %s cascade records found with thresholds %s", len(overloaded), applied_thresholds)
     return overloaded
 
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
@@ -275,7 +275,7 @@ class CascadeSimulator:
             ),
             current_overloaded_elements=evaluate_overload_triggers(
                 current_res=branch_for_overload,
-                threshold=self._cfg.current_loading_threshold,
+                cascade_configuration=self._cfg,
             ),
         )
 

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -33,6 +33,9 @@ from toop_engine_interfaces.spps_parameters import (
     SppsPowerFlowFailurePolicy,
 )
 
+#: Pandapower tables whose branches are treated as transformers when resolving loading thresholds.
+TRANSFORMER_TABLES = frozenset({"trafo", "trafo3w"})
+
 
 class CascadeConfig(BaseModel):
     """Configuration for cascading protection screening after contingency load flow."""
@@ -43,7 +46,32 @@ class CascadeConfig(BaseModel):
     """Maximum number of cascade iterations to run before stopping."""
 
     current_loading_threshold: float
-    """Loading factor above which a branch is considered overloaded and triggers a cascade."""
+    """Loading factor above which a branch is considered overloaded and triggers a cascade.
+
+    This is a per-unit ratio (``i / i_max``), not a percentage: ``1.5`` means 150 %.
+    It applies to every branch for which no more specific threshold below is set,
+    and is the only threshold used when none of them are set.
+    """
+
+    basecase_line_loading_threshold: Optional[float] = None
+    """Loading factor for lines in the base case.
+    If not set, current_loading_threshold is used.
+    """
+
+    contingency_line_loading_threshold: Optional[float] = None
+    """Loading factor for lines after a contingency.
+    If not set, basecase_line_loading_threshold is used, then current_loading_threshold.
+    """
+
+    basecase_transformer_loading_threshold: Optional[float] = None
+    """Loading factor for transformers (``trafo`` and ``trafo3w``) in the base case.
+    If not set, current_loading_threshold is used.
+    """
+
+    contingency_transformer_loading_threshold: Optional[float] = None
+    """Loading factor for transformers (``trafo`` and ``trafo3w``) after a contingency.
+    If not set, basecase_transformer_loading_threshold is used, then current_loading_threshold.
+    """
 
     min_island_size: int
     """Minimum number of buses in an island for it to be kept; smaller islands are dropped."""
@@ -58,6 +86,42 @@ class CascadeConfig(BaseModel):
 
     cascade_log_elements: list[str]
     """MRIDs of elements whose cascade events should be written to the log (e.g. line, trafo, trafo3w)."""
+
+    def loading_threshold(self, element_table: str, *, basecase: bool) -> float:
+        """Resolve the loading threshold that applies to one branch.
+
+        Parameters
+        ----------
+        element_table : str
+            Pandapower table the branch lives in, e.g. ``"line"``, ``"trafo"``,
+            ``"trafo3w"`` or ``"impedance"``. Tables without a dedicated threshold
+            (such as ``"impedance"``) always use :attr:`current_loading_threshold`.
+        basecase : bool
+            Whether the branch result belongs to the base case rather than to a
+            contingency.
+
+        Returns
+        -------
+        float
+            Loading factor above which the branch is treated as overloaded, as a
+            per-unit ratio (``i / i_max``).
+        """
+        # Pick the pair of overrides for this element type; other tables have none.
+        if element_table == "line":
+            basecase_threshold = self.basecase_line_loading_threshold
+            contingency_threshold = self.contingency_line_loading_threshold
+        elif element_table in TRANSFORMER_TABLES:
+            basecase_threshold = self.basecase_transformer_loading_threshold
+            contingency_threshold = self.contingency_transformer_loading_threshold
+        else:
+            return self.current_loading_threshold
+
+        # Contingency rows prefer their own value and fall back to the base-case one.
+        if not basecase and contingency_threshold is not None:
+            return contingency_threshold
+        if basecase_threshold is not None:
+            return basecase_threshold
+        return self.current_loading_threshold
 
 
 @dataclasses.dataclass

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -14,6 +14,7 @@ import pandapower as pp
 import pandas as pd
 import pandera as pa
 import polars as pl
+import pytest
 from toop_engine_contingency_analysis.pandapower import run_contingency_analysis_pandapower
 from toop_engine_contingency_analysis.pandapower.cascade.detection import prepare_cascade_run_constants
 from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeReasonType, CascadeTriggers
@@ -153,6 +154,111 @@ def build_cascade_test_net():
 
     net.bus["Busbar_id"] = ""
     return net
+
+
+def build_line_and_transformer_net():
+    """Radial net whose line (~171 %) and transformer (~166 %) are both overloaded.
+
+    HV slack --trafo--> MV --switch--> MV2 --line--> load. Ratings are picked so that
+    both branches sit between 150 % and 180 %, which lets a per-element-type threshold
+    pick exactly one of them.
+    """
+    net = pp.create_empty_network(sn_mva=100.0)
+    for tbl in ("bus", "line", "trafo", "load", "gen", "switch"):
+        if "origin_id" not in net[tbl].columns:
+            net[tbl]["origin_id"] = None
+
+    hv = pp.create_bus(net, vn_kv=110.0, name="HV", origin_id="bus:hv")
+    mv = pp.create_bus(net, vn_kv=20.0, name="MV", origin_id="bus:mv")
+    mv2 = pp.create_bus(net, vn_kv=20.0, name="MV2", origin_id="bus:mv2")
+    load_bus = pp.create_bus(net, vn_kv=20.0, name="LOAD", origin_id="bus:load")
+
+    slack = pp.create_gen(net, bus=hv, p_mw=0.0, vm_pu=1.02, name="Slack", origin_id="gen:slack")
+    if "slack" not in net.gen.columns:
+        net.gen["slack"] = False
+    net.gen.at[slack, "slack"] = True
+
+    pp.create_transformer_from_parameters(
+        net,
+        hv_bus=hv,
+        lv_bus=mv,
+        sn_mva=12.5,
+        vn_hv_kv=110.0,
+        vn_lv_kv=20.0,
+        vkr_percent=0.4,
+        vk_percent=12.0,
+        pfe_kw=0.0,
+        i0_percent=0.0,
+        name="t1",
+        origin_id="trafo:t1",
+    )
+    pp.create_switch(net, bus=mv, element=mv2, et="b", closed=True, type="CB", name="sw1", origin_id="sw:mv_mv2")
+    pp.create_line_from_parameters(
+        net,
+        from_bus=mv2,
+        to_bus=load_bus,
+        length_km=1.0,
+        r_ohm_per_km=0.1,
+        x_ohm_per_km=0.1,
+        c_nf_per_km=0.0,
+        max_i_ka=0.35,
+        name="l1",
+        origin_id="line:l1",
+    )
+    pp.create_load(net, load_bus, p_mw=20.0, q_mvar=2.0, name="Load", origin_id="load:load")
+
+    # A relay with a near-zero protection zone: distance protection must never fire here,
+    # so every cascade event in these tests comes from the current-overload check.
+    net["sw_characteristics"] = pd.DataFrame(
+        index=net.switch.index,
+        data={
+            "breaker_uuid": list(net.switch.origin_id),
+            "r_i": [1e-6],
+            "r_v": [1e-6],
+            "x_v": [1e-6],
+            "angle": [30.0],
+            "relay_side": ["element"],
+            "protection_side": ["element"],
+            "custom_warning_distance_protection": [np.nan],
+        },
+    )
+    net.bus["Busbar_id"] = ""
+    return net
+
+
+def _run_basecase_cascade(net, cascade_cfg: CascadeConfig) -> pd.DataFrame:
+    """Run a base-case-only contingency analysis and return its cascade results."""
+    for table in ("line", "trafo", "bus", "switch"):
+        net[table]["global_id"] = net[table].index.map(lambda idx, tbl=table: get_globally_unique_id(idx, tbl))
+
+    monitored_elements = (
+        [MonitoredElement(id=row.global_id, type="line", kind="branch", name=row.name) for row in net.line.itertuples()]
+        + [MonitoredElement(id=row.global_id, type="trafo", kind="branch", name=row.name) for row in net.trafo.itertuples()]
+        + [MonitoredElement(id=row.global_id, type="bus", kind="bus", name=row.name) for row in net.bus.itertuples()]
+        + [
+            MonitoredElement(id=row.global_id, type="switch", kind="switch", name=row.name)
+            for row in net.switch.itertuples()
+        ]
+    )
+    nminus1_def = Nminus1Definition(
+        monitored_elements=monitored_elements,
+        contingencies=[Contingency(id="BASECASE", name="BASECASE", elements=[])],
+    )
+    cfg = ContingencyAnalysisConfig(
+        method="ac",
+        min_island_size=1,
+        cascade=cascade_cfg,
+        parallel=ParallelConfig(n_processes=1, batch_size=None),
+        runpp_kwargs={"lightsim2grid": False, "enforce_q_lims": True},
+    )
+    lf_results = run_contingency_analysis_pandapower(
+        net=net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test",
+        timestep=0,
+        cfg=cfg,
+    )
+    return lf_results.cascade_results
 
 
 def _cascade_results_to_events(cascade_results: pd.DataFrame) -> list[dict]:
@@ -498,3 +604,153 @@ def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
     received_elements = set(captured[0].index.get_level_values("element"))
     assert protection_uid in received_elements
     assert flow_only_uid not in received_elements
+
+
+# ---------------------------------------------------------------------------
+# Per-element-type and per-case current loading thresholds
+# ---------------------------------------------------------------------------
+
+
+def _current_violation_mrids(cascade_results: pd.DataFrame) -> list[str]:
+    """External ids of the elements that tripped on current overload, sorted."""
+    overloaded = cascade_results[cascade_results["cascade_reason"] == CascadeReasonType.CASCADE_REASON_CURRENT]
+    return sorted(overloaded.index.get_level_values("element_mrid"))
+
+
+@pytest.mark.parametrize(
+    ("line_threshold", "transformer_threshold", "expected_mrids"),
+    [
+        # Both branches are loaded to ~165 %: the threshold decides which one trips.
+        (1.5, 1.8, ["line:l1"]),
+        (1.8, 1.5, ["trafo:t1"]),
+        (1.5, 1.5, ["line:l1", "trafo:t1"]),
+        (1.8, 1.8, []),
+    ],
+)
+def test_cascade_trips_the_element_types_above_their_own_threshold(
+    line_threshold: float,
+    transformer_threshold: float,
+    expected_mrids: list[str],
+) -> None:
+    net = build_line_and_transformer_net()
+    cascade_cfg = CascadeConfig(
+        depth_limit=2,
+        # Deliberately unreachable: every trip below must come from a type-specific threshold.
+        current_loading_threshold=99.0,
+        basecase_line_loading_threshold=line_threshold,
+        basecase_transformer_loading_threshold=transformer_threshold,
+        min_island_size=1,
+        cascade_log_elements=["line", "trafo"],
+        basecase_distance_protection_factor=0.01,
+        contingency_distance_protection_factor=0.01,
+    )
+
+    cascade_results = _run_basecase_cascade(net, cascade_cfg)
+
+    assert _current_violation_mrids(cascade_results) == expected_mrids
+    # The relay zone is near zero, so nothing here may be attributed to distance protection.
+    reasons = set(cascade_results["cascade_reason"])
+    assert CascadeReasonType.CASCADE_REASON_DISTANCE not in reasons
+
+
+def _run_l1_cascade(cascade_cfg: CascadeConfig) -> list[dict]:
+    """Run the multi-step fixture with *cascade_cfg* and return the l1-contingency events."""
+    net = build_cascade_test_net()
+    net.line.loc[0, "max_i_ka"] = 0.3
+    net.line.loc[1, "max_i_ka"] = 0.3
+    net.line.loc[2, "max_i_ka"] = 0.6
+    net.line.loc[3, "max_i_ka"] = 0.4
+    net.line.loc[4, "max_i_ka"] = 0.6
+
+    net.line["global_id"] = net.line.index.map(lambda imp_id: get_globally_unique_id(imp_id, "line"))
+    net.bus["global_id"] = net.bus.index.map(lambda imp_id: get_globally_unique_id(imp_id, "bus"))
+    net.switch["global_id"] = net.switch.index.map(lambda imp_id: get_globally_unique_id(imp_id, "switch"))
+
+    monitored_elements = (
+        [MonitoredElement(id=row.global_id, type="line", kind="branch", name=row.name) for row in net.line.itertuples()]
+        + [MonitoredElement(id=row.global_id, type="bus", kind="bus", name=row.name) for row in net.bus.itertuples()]
+        + [
+            MonitoredElement(id=row.global_id, type="switch", kind="switch", name=row.name)
+            for row in net.switch.itertuples()
+        ]
+    )
+    nminus1_def = Nminus1Definition(
+        monitored_elements=monitored_elements,
+        contingencies=[
+            Contingency(id="BASECASE", name="BASECASE", elements=[]),
+            Contingency(id="line:l1", name="l1", elements=[GridElement(id="0%%line", type="line", kind="branch")]),
+        ],
+    )
+    cfg = ContingencyAnalysisConfig(
+        method="ac",
+        min_island_size=2,
+        cascade=cascade_cfg,
+        parallel=ParallelConfig(n_processes=1, batch_size=None),
+        runpp_kwargs={"lightsim2grid": False, "enforce_q_lims": True},
+    )
+    lf_results = run_contingency_analysis_pandapower(
+        net=net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test",
+        timestep=0,
+        cfg=cfg,
+    )
+    all_events = _cascade_results_to_events(lf_results.cascade_results)
+    return [event for event in all_events if event["contingency_name"] == "l1"]
+
+
+def _l1_cascade_config(**threshold_fields: float) -> CascadeConfig:
+    return CascadeConfig(
+        depth_limit=3,
+        min_island_size=2,
+        cascade_log_elements=["line", "switch"],
+        basecase_distance_protection_factor=2,
+        contingency_distance_protection_factor=2,
+        **threshold_fields,
+    )
+
+
+def test_line_threshold_replaces_the_scalar_threshold_for_lines() -> None:
+    """A line override reproduces the scalar-threshold cascade, and reaches contingency rows.
+
+    Only the base-case line threshold is set, so the l1 contingency rows exercise the
+    contingency -> base-case fallback. The scalar threshold is unreachable, which proves
+    the lines are compared against the override rather than against it.
+    """
+    scalar_events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=1.5))
+    override_events = _run_l1_cascade(
+        _l1_cascade_config(current_loading_threshold=99.0, basecase_line_loading_threshold=1.5)
+    )
+
+    assert [event["element_mrid"] for event in scalar_events] == ["line:l2", "line:l4", "line:l7"]
+    assert override_events == scalar_events
+
+
+def test_transformer_threshold_does_not_apply_to_lines() -> None:
+    events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=99.0, basecase_transformer_loading_threshold=1.5))
+
+    assert events == []
+
+
+@pytest.mark.parametrize(
+    ("basecase_threshold", "contingency_threshold", "expect_events"),
+    [
+        # The l1 rows are contingency rows, so only the contingency threshold can trip them.
+        (99.0, 1.5, True),
+        (1.5, 99.0, False),
+    ],
+)
+def test_basecase_and_contingency_thresholds_are_applied_per_case(
+    basecase_threshold: float,
+    contingency_threshold: float,
+    expect_events: bool,
+) -> None:
+    events = _run_l1_cascade(
+        _l1_cascade_config(
+            current_loading_threshold=99.0,
+            basecase_line_loading_threshold=basecase_threshold,
+            contingency_line_loading_threshold=contingency_threshold,
+        )
+    )
+
+    assert bool(events) == expect_events


### PR DESCRIPTION
Signed-off-by: siarhei <Siarhei.Matsiushonak_ext@50hertz.com>
## What

Cascade current-overload detection used one threshold for every branch. It now resolves a threshold per branch row from the element type (line vs transformer) and the case (base case vs contingency).

## Why

Lines and transformers tolerate overload differently, and what is acceptable after a contingency is not acceptable in normal operation. One number could not express that.

## Configuring it

Four new optional fields on CascadeConfig, all defaulting to None:

- basecase_line_loading_threshold, contingency_line_loading_threshold
- basecase_transformer_loading_threshold, contingency_transformer_loading_threshold

Resolution order for a row:

1. the value for its own type and case
2. for contingency rows, the base-case value of the same type
3. current_loading_threshold