### PR TITLE
chore: add container setup for running ToOp on Windows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,18 @@
 {
    "build": {
-      "dockerfile": "../Dockerfile"
+      "dockerfile": "../docker/Dockerfile",
+      "context": "..",
+      "args": {
+         "DEV_TOOLS": "true"
+      }
    },
    "features": {
       "ghcr.io/devcontainers/features/docker-in-docker": "latest",
       "ghcr.io/devcontainers/features/azure-cli": "latest"
+   },
+   "containerEnv": {
+      "UV_PROJECT_ENVIRONMENT": "/opt/venv",
+      "TOOP_SKIP_SYNC": "1"
    },
    "customizations": {
       "vscode": {
@@ -27,13 +35,14 @@
             "ms-toolsai.vscode-jupyter-cell-tags",
             "ms-toolsai.vscode-jupyter-slideshow",
             "astral-sh.ty"
-         ]
+         ],
+         "settings": {
+            "python.defaultInterpreterPath": "/opt/venv/bin/python"
+         }
       }
    },
    "remoteUser": "root",
+   "overrideCommand": true,
    "onCreateCommand": "./.devcontainer/onCreateCommand.sh",
-   "postStartCommand": "./.devcontainer/postStartCommand.sh",
-   "mounts": [
-      "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh"
-   ]
+   "postStartCommand": "./.devcontainer/postStartCommand.sh"
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+# Files consumed by Linux containers must keep LF endings regardless of the
+# contributor's core.autocrlf setting. A CRLF entrypoint script fails at runtime
+# with a misleading "exec format error" / "no such file or directory".
+*.sh            text eol=lf
+Dockerfile      text eol=lf
+Dockerfile.*    text eol=lf
+*.yaml          text eol=lf
+*.yml           text eol=lf

--- a/.nwa-config.yaml
+++ b/.nwa-config.yaml
@@ -8,6 +8,8 @@
 nwa:
   # Used to upate license headers in source files. Run the following command
   # docker run -it -v ${PWD}:/src ghcr.io/b1nary-gr0up/nwa:latest config
+  # On Windows in Git Bash, MSYS rewrites /src into a Windows path; use instead:
+  # MSYS_NO_PATHCONV=1 docker run -it -v "$(pwd -W):/src" ghcr.io/b1nary-gr0up/nwa:latest config
   # basic
   cmd: "update"                        # Default: "add"; Can be overwritten by --command (-c) flag; Optional: "add", "check", "remove", "update"
   holder: "50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV"          # Default: "<COPYRIGHT HOLDER>"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,82 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+# Local ToOp stack for a laptop. See docker/README.md.
+#
+#   docker compose up -d                 -> Jupyter Lab on http://localhost:8888
+#   docker compose exec toop bash        -> interactive shell, use `uv run ...`
+#   docker compose --profile gpu up -d   -> NVIDIA GPU variant (see docker/README.md)
+#
+# This file is unrelated to dev-deployment/docker-compose.yaml, which brings up the Kafka broker
+# used by the worker-based deployment. That one still works standalone and is left untouched.
+
+x-toop-base: &toop-base
+  build:
+    context: .
+    dockerfile: docker/Dockerfile
+  working_dir: /app
+  volumes:
+    # The repository itself. Source edits on the Windows side take effect immediately because the
+    # six packages are installed editable, pointing into /app/packages/*/src.
+    # This also means grid files dropped into .\data\<iteration_name>\ from Explorer are visible
+    # here, and results written by the pipeline appear back in Explorer.
+    - .:/app
+    # The uv-managed environment. Deliberately a named volume rather than /app/.venv -- see the
+    # UV_PROJECT_ENVIRONMENT comment in docker/Dockerfile. Docker seeds it from the image on first
+    # use, so the environment baked at build time is the starting point.
+    - toop-venv:/opt/venv
+    # uv download cache, matplotlib/fontconfig caches, and the JAX persistent compilation cache if
+    # enabled. Keeping it off the bind mount avoids re-downloading wheels on every rebuild.
+    - toop-cache:/root/.cache
+  # Ray and JAX allocate through /dev/shm; Docker's 64MB default surfaces as opaque crashes.
+  shm_size: "2gb"
+  stdin_open: true
+  tty: true
+
+services:
+  toop:
+    <<: *toop-base
+    # Bound to loopback only: Jupyter runs without a token (see the CMD in docker/Dockerfile), so it
+    # must not be reachable from the local network.
+    ports:
+      - "127.0.0.1:8888:8888"
+      - "127.0.0.1:6006:6006"
+    environment:
+      # Pin JAX to CPU. Without this, JAX probes for accelerators on every import and emits noisy
+      # warnings on a machine with no CUDA runtime.
+      JAX_PLATFORMS: cpu
+
+  # NVIDIA GPU variant. Two things are required, and the profile alone is not enough:
+  #   1. build with CUDA:  INSTALL_CUDA=true docker compose --profile gpu build
+  #   2. run:              docker compose --profile gpu up -d toop-gpu
+  # Written out in full rather than via `extends` so the build args and JAX_PLATFORMS override are
+  # visible in one place.
+  toop-gpu:
+    <<: *toop-base
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        INSTALL_CUDA: "true"
+    ports:
+      - "127.0.0.1:8889:8888"
+      - "127.0.0.1:6007:6006"
+    environment:
+      # Empty means "let JAX pick", i.e. GPU when visible, CPU otherwise.
+      JAX_PLATFORMS: ""
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+volumes:
+  toop-venv:
+  toop-cache:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,93 @@
+# syntax=docker/dockerfile:1
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+# Runnable ToOp image, intended for a laptop (Jupyter / interactive shell / VS Code dev container).
+#
+# This is NOT the image used by the root ./Dockerfile. That one is a bare dev container base: it
+# layers uv + protoc onto python:3.13 and copies no project files, leaving dependency installation
+# to .devcontainer/onCreateCommand.sh. This image installs the project instead.
+#
+# The `uv` release is pinned by digest, matching the style of the root Dockerfile.
+FROM ghcr.io/astral-sh/uv:0.11.19@sha256:b46b03ddfcfbf8f547af7e9eaefdf8a39c8cebcba7c98858d3162bd28cf536f6 AS uv
+
+# Python 3.11 because every pyproject.toml in this repo declares requires-python ">=3.11,<3.12".
+# Deliberately tag-pinned rather than digest-pinned: a digest must be verified against the registry,
+# and inventing one would be worse than none. To harden, run
+#   docker buildx imagetools inspect python:3.11-slim-bookworm
+# and append the reported @sha256:... here.
+FROM python:3.11-slim-bookworm
+
+COPY --from=uv /uv /usr/local/bin/uv
+
+# git is required at build time: uv-dynamic-versioning derives each package version from git tags.
+# ca-certificates is required for any HTTPS the packages perform (e.g. CGMES boundary downloads).
+RUN apt-get -qq update \
+ && apt-get -qq -y install --no-install-recommends git ca-certificates \
+ && apt-get -qq -y autoremove \
+ && apt-get autoclean \
+ && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+# Extra conveniences for interactive/dev-container use. Off by default to keep the runtime slim.
+# Note: protoc is intentionally NOT installed here. packages/interfaces_pkg/src/compile_proto.sh
+# needs the exact protoc 33.1 pinned by the root ./Dockerfile, and Debian ships a different version.
+# The generated *_pb2.py files are committed, so regeneration is a rare, deliberate task -- use the
+# root Dockerfile for it.
+ARG DEV_TOOLS=false
+RUN if [ "$DEV_TOOLS" = "true" ]; then \
+      apt-get -qq update \
+   && apt-get -qq -y install --no-install-recommends vim htop zip unzip curl less procps \
+   && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log; \
+    fi
+
+# The project environment lives OUTSIDE /app on purpose.
+#
+# /app is bind-mounted from the Windows host at runtime. Creating the venv at /app/.venv would put a
+# Linux virtualenv on the Windows filesystem: it would collide with any natively-created .venv, and
+# every import would drag thousands of small files across the WSL2 9p/virtiofs bridge. Relocating it
+# keeps `uv sync` / `uv run` as the only interface while the environment sits on Linux-native
+# storage. UV_PROJECT_ENVIRONMENT is uv's supported way to do this.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
+    UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_PREFERENCE=system \
+    PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# The whole context is copied (including .git, ~9MB) so that uv-dynamic-versioning can resolve
+# versions and so the six editable path-dependencies under packages/ resolve at build time. At
+# runtime the host repo is bind-mounted over /app; because the editable install records
+# /app/packages/*/src, source edits on the host take effect with no rebuild.
+COPY . /app
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --all-groups
+
+# Bytecode is compiled once, above, and ships in the image (and therefore in the toop-venv volume,
+# which Docker seeds from it). Turning the flag off from here on keeps the entrypoint's re-sync from
+# recompiling all ~38k files on every container start, which costs ~6s each time. Placed after the
+# sync so it does not invalidate that layer.
+ENV UV_COMPILE_BYTECODE=0
+
+# Optional NVIDIA GPU support. Requires an NVIDIA GPU, a Windows driver with WSL2 CUDA support, and
+# `docker compose --profile gpu`. Roughly doubles the image size, hence opt-in.
+ARG INSTALL_CUDA=false
+RUN --mount=type=cache,target=/root/.cache/uv \
+    if [ "$INSTALL_CUDA" = "true" ]; then uv pip install "jax[cuda12]"; fi
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8888 6006
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["uv", "run", "jupyter", "lab", \
+     "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", \
+     "--ServerApp.token=", "--ServerApp.password=", \
+     "--ServerApp.root_dir=/app"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,38 @@
+# Build context filter for docker/Dockerfile.
+#
+# BuildKit prefers "<dockerfile-path>.dockerignore" over the root .dockerignore when it exists.
+# That root file is a single "**" (ignore everything), which is correct for the root ./Dockerfile
+# -- a dev container base that copies nothing -- but would leave this image with no source at all.
+# Keeping the override here means the root file stays untouched.
+
+# NOTE: .git is deliberately NOT ignored. uv-dynamic-versioning derives every package version from
+# git tags; without it, `uv sync` cannot build the six editable path dependencies. It is ~9MB.
+
+# Python / uv artifacts that must not leak in from a host-side checkout
+.venv/
+**/__pycache__/
+**/*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+**/.ipynb_checkpoints/
+
+# Grid data and results: bind-mounted at runtime, and potentially large or confidential.
+# See .pre-commit-hooks/check-sensitive-files.sh for why these formats are treated carefully.
+data/
+tensorboard/
+stats/
+
+# Build/test outputs
+site/
+dist/
+build/
+*.egg-info/
+coverage*.xml
+test-report.xml
+.coverage
+
+# Host tooling
+.vscode/
+.devcontainer/
+.github/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,248 @@
+# Running ToOp on a Windows laptop with Docker
+
+This directory contains a runnable ToOp image and a `docker-compose.yaml` (at the repository root)
+for driving it from a Windows 11 machine — via Jupyter, an interactive shell, or the VS Code dev
+container. The Python environment is created and executed entirely through `uv`.
+
+> This is separate from `dev-deployment/docker-compose.yaml`, which starts the Kafka broker used by
+> the worker-based deployment. That file is unchanged and still works standalone.
+
+## Prerequisites
+
+- **Docker Desktop** with the **WSL2** backend (not Hyper-V). Start it before any command below.
+  Verify with `docker version` — it must report a Linux server engine.
+- ~15 GB free disk. The CPU image holds about **4.5 GB** of content, 3.0 GB of which is the Python
+  environment (jaxlib 383M, pypowsybl 223M, ray 220M, polars 204M, plotly 188M). The CUDA variant is
+  substantially larger, and BuildKit's layer cache needs headroom beyond the image itself.
+
+  Docker's own size reporting is unreliable here: under the containerd image store both
+  `docker images` and `docker image inspect --format '{{.Size}}'` report ~1.0 GB — the *compressed*
+  total — immediately after a build, and `docker images` was observed switching to 4.49 GB only
+  after a daemon restart. To measure for real, look inside (prefix with `MSYS_NO_PATHCONV=1` in Git
+  Bash, see below):
+  `docker run --rm --entrypoint sh toop-toop:latest -c "du -sh /opt/venv"`.
+- No local Python needed — everything runs inside the container.
+
+## Quick start
+
+```powershell
+cd C:\Users\<you>\...\ToOp
+docker compose build toop        # ~9 min cold (6.5 min of it is `uv sync`)
+docker compose up -d
+```
+
+Subsequent container starts take ~2 s: the entrypoint's `uv sync` is a no-op check
+(`Checked 312 packages in 62ms`) unless `uv.lock` actually changed.
+
+Open `http://localhost:8888` and run `notebooks/example1_dc_loadflow_example.ipynb`.
+
+For a shell instead:
+
+```powershell
+docker compose exec toop bash
+# then, inside:
+uv run python -c "import jax; print(jax.devices())"
+uv run pytest packages/interfaces_pkg/tests -q
+uv run python -m toop_engine_topology_optimizer.dc.main --help
+```
+
+Stop with `docker compose down`. Add `-v` to also discard the environment and cache volumes.
+
+### If you use Git Bash instead of PowerShell
+
+Git Bash (MSYS2) rewrites arguments that look like absolute POSIX paths into Windows paths before
+`docker.exe` ever sees them, so a container path such as `/app` silently becomes
+`C:/Program Files/Git/app`:
+
+```
+docker: Error response from daemon: the working directory 'C:/Program Files/Git/app'
+is invalid, it needs to be an absolute path
+```
+
+Prefix the command with `MSYS_NO_PATHCONV=1` whenever it contains a container-absolute path
+(`-w /app`, `-v <host>:/app`, or a bare `/opt/...` argument):
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/app" -w /app toop-toop:latest uv run pytest -q
+```
+
+The plain `docker compose` commands in this file are unaffected — their paths are relative — so
+PowerShell users and anyone staying on `docker compose` can ignore this. Doubling the leading slash
+(`//app`) works too, but is easier to forget.
+
+## Running tests
+
+```powershell
+docker compose run --rm toop uv run pytest packages/interfaces_pkg/tests -q
+docker compose run --rm toop uv run pytest packages/dc_solver_pkg/tests -q -n 4 --dist loadgroup
+```
+
+**Prefer an explicit `-n <N>` over `-n auto` here.** CI uses `-n auto` on a dedicated runner; inside
+WSL2 on a laptop it starts one worker per core, each loading its own JAX runtime, which can easily
+outgrow the VM's memory allowance. During this setup's first run the Docker engine became
+unresponsive about four minutes into an `-n auto` invocation of this suite — memory pressure is the
+plausible explanation, though a concurrent Docker Desktop self-update muddied the evidence and the
+cause was never conclusively pinned down. Either way, `-n 4` is a safer starting point on a laptop,
+and raising the WSL2 memory limit (below) is worthwhile.
+
+`--dist loadgroup` is mandatory whenever `-n` is used: Kafka, Ray and performance tests are
+serialized through `@pytest.mark.xdist_group` and will interfere with each other otherwise.
+
+Measured result of the command above on a 13.58 GB VM: **491 passed, 1 failed, 8 skipped, 2 xfailed
+in 13:41**. The one failure is `jax/benchmarks/test_bench_postprocessing.py::test_main`, which dies
+with `ray.exceptions.OutOfMemoryError` — Ray sees the node at 95 % and kills a worker. It passes
+when the file is run on its own:
+
+```powershell
+docker compose run --rm toop uv run pytest packages/dc_solver_pkg/tests/jax/benchmarks/test_bench_postprocessing.py -q
+# 3 passed in 211.42s
+```
+
+So it is a VM memory-ceiling artefact, not a defect in the image. Raise the WSL2 memory limit
+(below) or run the Ray benchmarks separately from the rest of the suite.
+
+## Where to put your grid data
+
+The repository is bind-mounted at `/app`, so the `data/` folder you see in Explorer is the same one
+the pipeline reads and writes.
+
+1. Create `data\<iteration_name>\` in Explorer.
+2. Drop your grid file in it — `.xiidm`, `.json` (pandapower), or `.zip` (CGMES).
+3. Set `iteration_name` and `file_name` in the notebook config cell.
+
+The pipeline then creates `data\<iteration_name>\<timestamp>\` and fills it with the processed grid
+folder: `grid.xiidm`/`grid.json`, `masks\`, `loadflow_parameters.json`, `initial_topology\`,
+`static_information.hdf5`, `action_set.json`, `action_set_diffs.hdf5`, `nminus1_definition.json`,
+and `optimizer_snapshots\` with the DC and AC results. Filenames come from
+`packages/interfaces_pkg/src/toop_engine_interfaces/folder_structure.py`.
+
+Everything appears in Explorer as it is written, so you can inspect results without entering the
+container.
+
+> Grid data may be confidential. A pre-commit hook blocks committing `.uct`, `.xml`, `.zip`,
+> `.json`, `.xiidm`, `.veragrid` and `.hdf5` files unless whitelisted in
+> `.pre-commit-hooks/sensitive-files-whitelist.txt`.
+
+## Why the virtualenv is not in the repository folder
+
+`uv` creates the environment at **`/opt/venv`**, not `/app/.venv`, via `UV_PROJECT_ENVIRONMENT`.
+`/app` is a bind mount from the Windows filesystem; a Linux virtualenv there would collide with any
+natively-created `.venv` and would push thousands of small files across the WSL2 filesystem bridge
+on every import.
+
+`uv sync` and `uv run` behave exactly as documented — only the environment's location moves. The six
+`packages/*` are installed **editable**, so editing a `.py` file in Windows takes effect on the next
+import with no rebuild.
+
+The environment lives on the `toop-venv` named volume, so it survives `docker compose down`. If it
+ever gets into a bad state: `docker compose down -v && docker compose up -d`.
+
+## Enabling the NVIDIA GPU
+
+Requires an NVIDIA GPU, a current Windows driver with WSL2 CUDA support, and Docker Desktop's GPU
+support enabled. AMD and Intel integrated GPUs are not usable — JAX has no backend for them here.
+
+```powershell
+docker compose --profile gpu build toop-gpu
+docker compose --profile gpu up -d toop-gpu
+docker compose exec toop-gpu uv run python -c "import jax; print(jax.devices())"
+```
+
+Jupyter for the GPU service is on `http://localhost:8889` so it can coexist with the CPU one. If
+`jax.devices()` still reports CPU, the container is not seeing the GPU — check
+`docker compose exec toop-gpu nvidia-smi` first.
+
+## Performance notes for Windows
+
+**Bind-mount speed.** `C:\...\ToOp` → `/app` crosses the WSL2 9p/virtiofs bridge. Imports are
+unaffected (the environment is on a Linux-native volume), but random access into
+`static_information.hdf5` and `action_set_diffs.hdf5` is measurably slower than native. If a large
+grid becomes I/O-bound, move the checkout into the WSL2 filesystem
+(`\\wsl$\<distro>\home\<you>\ToOp`) and run the same compose file from there — no changes needed.
+
+**Memory.** JAX and pypowsybl's native runtime are memory-hungry, and with no explicit setting WSL2
+takes about half the host's RAM — measured here, a 27.9 GB host produced a 13.58 GB VM. That is not
+enough for the whole `dc_solver_pkg` suite at `-n 4`: Ray killed a worker at 95 % utilisation
+(12.91 GB of 13.58 GB) in `test_bench_postprocessing.py::test_main`, a test that passes when run on
+its own. A plain container OOM instead shows up as exit code 137.
+
+Raise it in `%UserProfile%\.wslconfig` (create the `[wsl2]` section if absent):
+
+```ini
+[wsl2]
+memory=16GB      # on a 32GB host; leave the OS several GB
+processors=8
+swap=4GB
+```
+
+then `wsl --shutdown` followed by restarting Docker Desktop. Ray's own kill threshold can be moved
+with `RAY_memory_usage_threshold`, but raising the VM's memory is the better fix.
+
+**Shared memory.** The compose file sets `shm_size: 2gb`; Ray and JAX allocate through `/dev/shm`
+and Docker's 64 MB default produces confusing crashes.
+
+## VS Code dev container
+
+`.devcontainer/devcontainer.json` builds this same image (with `DEV_TOOLS=true`, adding `vim`,
+`htop`, `less` and friends). Open the folder and choose **Reopen in Container**.
+
+Two details differ from the compose flow:
+
+- VS Code mounts the workspace at `/workspaces/ToOp` rather than `/app`, so `TOOP_SKIP_SYNC=1` is
+  set and `.devcontainer/onCreateCommand.sh` performs the `uv sync` from the correct directory.
+- The interpreter is `/opt/venv/bin/python`, preconfigured in `python.defaultInterpreterPath`.
+
+The `${localEnv:HOME}/.ssh` bind mount was removed from `devcontainer.json`: `HOME` is not set on
+Windows hosts, so that mount failed there.
+
+## Regenerating protobuf schemas
+
+Works here, and everywhere else. `protoc` comes from the `grpcio-tools` wheel rather than a system
+binary, so the compiler version is pinned by `uv.lock` and needs no image-specific tooling:
+
+```powershell
+docker compose run --rm toop uv run bash packages/interfaces_pkg/src/compile_proto.sh
+```
+
+Regeneration is rare — the `*_pb2.py` / `.pyi` files are committed, and there is exactly one schema
+(`message_wrapper.proto`, a single-field envelope marked temporary in its own comment).
+
+**Two things to know before you regenerate.**
+
+*The output is equivalent but not identical.* Comparing generated code across `grpcio-tools`
+1.66–1.83 by AST shows **all 13 top-level statements identical** except the
+`ValidateProtobufRuntimeVersion(...)` call, which merely embeds the generator's own version. The
+serialized descriptor, field numbers and wire format never change. The committed file declares
+gencode 5.29.3 (standalone `protoc` v29.3); the current toolchain emits 7.35.1. Older gencode loads
+fine on a newer runtime, so the committed file works as-is — but the reverse does not, so
+regenerating raises the effective minimum protobuf runtime to 7.x while the packages still declare
+`protobuf>=5,<8`. Tighten that constraint in the same change if you commit regenerated output.
+
+*Do not try to pin `grpcio-tools` low to reproduce the 5.29.x gencode.* Releases before 1.72 cap
+protobuf at `<6`, which drags the entire environment's runtime down to 5.29.x — and `mypy-protobuf`
+ships gencode built against 6.32.1, so `--mypy_out` then fails with
+`Runtime version cannot be older than the linked gencode version`. Hence the `>=1.72` floor.
+
+`protoc` does not emit the MPL header, so re-add it after regenerating; CI's `nwa` check enforces it.
+
+## What is not included
+
+Kafka worker services. `docs/usage.md` describes running
+`packages/topology_optimizer_pkg/.../dc/worker/worker.py` directly, but that file (and the AC
+equivalent) has no `__main__` block and no CLI: its `main()` takes already-constructed Kafka
+producers, consumers and `fsspec` filesystems. Containerizing that path requires writing launcher
+shims first. The directly runnable CLIs are
+`toop_engine_topology_optimizer.dc.main` and
+`toop_engine_contingency_analysis.ac_loadflow_service.lf_worker`.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `exec /usr/local/bin/entrypoint.sh: no such file or directory` | `entrypoint.sh` was checked out with CRLF endings. `.gitattributes` forces LF; re-clone or run `git add --renormalize .`. |
+| `the working directory 'C:/Program Files/Git/app' is invalid` (or any container path prefixed with a Git install dir) | Git Bash rewrote a POSIX path. Prefix the command with `MSYS_NO_PATHCONV=1`, or run it from PowerShell. |
+| Container exits with code 137 | Out of memory — see the `.wslconfig` section above. |
+| `docker version` returns `500 Internal Server Error` for *every* call, while `wsl -l -v` shows `docker-desktop` Running and `docker desktop status` says `running` | The Desktop backend is wedged; the "check if the server supports the requested API version" wording is boilerplate appended to any 500, not a real version problem (pinning `DOCKER_API_VERSION` does not help). Confirm by checking whether `%LOCALAPPDATA%\Docker\log\vm\init.log` has stopped growing, and whether `docker desktop status` still reports the *same* `SessionID` after a restart — an unchanged SessionID means the backend never actually restarted. Fix: quit Docker Desktop fully from the tray, `wsl --shutdown`, then relaunch and let any pending update finish. |
+| `detected dubious ownership in repository at '/app'` | The entrypoint sets `safe.directory`; this means it was bypassed. Run `git config --global --add safe.directory /app` inside the container. |
+| `uv sync` fails offline at startup | `docker compose run -e TOOP_SKIP_SYNC=1 toop bash`. |
+| Rebuild does not pick up dependency changes | `docker compose build --no-cache toop`, then `docker compose down -v` to reset the environment volume. |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+set -euo pipefail
+
+# The repository is bind-mounted from the host, so its ownership does not match the container user.
+# Without this, every git call (including the one uv-dynamic-versioning makes to resolve versions)
+# fails with "detected dubious ownership".
+git config --global --add safe.directory /app
+
+# Reconcile the baked-in environment with whatever uv.lock is actually mounted. This is a ~1s no-op
+# when nothing changed, and self-heals after a `git pull` that moved dependencies. Mirrors what
+# .devcontainer/onCreateCommand.sh does. Set TOOP_SKIP_SYNC=1 to skip (e.g. when offline).
+if [ "${TOOP_SKIP_SYNC:-0}" != "1" ]; then
+    echo "entrypoint: syncing uv environment at ${UV_PROJECT_ENVIRONMENT:-/opt/venv}"
+    uv sync --frozen --all-groups
+fi
+
+exec "$@"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,15 @@ To see the whole repo in action, check out the **[notebooks/example3_e2e_pipelin
 If you want to use Kafka workers instead, read on.
 <!-- markdown-link-check-enable -->
 
+## Running on Windows
+
+<!-- markdown-link-check-disable -->
+If you are on Windows, the supported route is a container: see
+**[docker/README.md](https://github.com/EliaGroup/ToOp/blob/main/docker/README.md)**.
+`docker compose up` gives you Jupyter with the repository and its `data/` folder bind-mounted, so
+grid files you drop in from Explorer are picked up directly and results are written back there.
+<!-- markdown-link-check-enable -->
+
 ## Kafka messaging
 
 !!! Work-in-progress
@@ -65,6 +74,15 @@ python3 worker.py --processed_gridfile_folder=/path/to/your/import/
 cd packages/topology_optimizer_pkg/ac/
 python3 worker.py --processed_gridfile_folder=/path/to/your/import/
 ```
+
+!!! warning "These invocations are out of date"
+
+    Both `worker.py` files currently expose only a `main()` that takes already-constructed Kafka
+    `Producer` / consumer objects and `fsspec` filesystems — there is no `__main__` block and no
+    `--processed_gridfile_folder` flag, so the two commands above cannot be run as written. Until
+    launcher entry points are added, the directly runnable CLIs are
+    `toop_engine_topology_optimizer.dc.main` (DC optimization, `tyro`-based) and
+    `toop_engine_contingency_analysis.ac_loadflow_service.lf_worker` (AC loadflow worker).
 
 They should connect to the kafka that was spun up earlier on their own, you should see new consumers in the kafka logs.
 

--- a/packages/interfaces_pkg/pyproject.toml
+++ b/packages/interfaces_pkg/pyproject.toml
@@ -79,6 +79,12 @@ dev = [
     "pypowsybl-jupyter>=1.0.0",
     "docker>=7.1.0",
     "ray>=2.55.0,<3.0.0",
+    # Supplies protoc as a wheel (python -m grpc_tools.protoc) for src/compile_proto.sh, so the
+    # compiler version is pinned by uv.lock instead of being a system binary installed per image.
+    # Do not pin below 1.72 to make the generated code match the committed gencode version: those
+    # releases cap protobuf at <6, and mypy-protobuf's own gencode needs a >=6 runtime, so
+    # --mypy_out then fails outright.
+    "grpcio-tools>=1.72",
 ]
 
 [tool.pytest_env]

--- a/packages/interfaces_pkg/src/compile_proto.sh
+++ b/packages/interfaces_pkg/src/compile_proto.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
 #
 # This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -5,7 +6,24 @@
 # you can obtain one at https://mozilla.org/MPL/2.0/.
 # Mozilla Public License, version 2.0
 
-protoc \
+# Regenerate the *_pb2.py / *_pb2.pyi files from the .proto schemas.
+#
+# The generated files are committed, so this only needs running after editing a .proto.
+#
+# protoc comes from the grpcio-tools wheel rather than a system binary, so the compiler version is
+# pinned by uv.lock and this runs anywhere the project environment does -- host, container or dev
+# container -- with no image-specific tooling. --mypy_out is provided by mypy-protobuf, a declared
+# dependency of this package.
+#
+# Run from the repository root:
+#     uv run bash packages/interfaces_pkg/src/compile_proto.sh
+
+set -euo pipefail
+
+# -I=. and the find below are relative to this directory, so anchor to it regardless of the caller.
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+python -m grpc_tools.protoc \
   -I=. \
   --python_out=. \
   --mypy_out=. \

--- a/packages/interfaces_pkg/uv.lock
+++ b/packages/interfaces_pkg/uv.lock
@@ -536,6 +536,50 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/f6/3b781cd07a715ea5f5125ae264226e7fc4d87603d6d3955022cabfdc5da2/grpcio-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:8ff0b8767ddd62704e0d9571c1890af08d84a3a689ebba1807e62519d0b3277f", size = 6338720, upload-time = "2026-07-23T15:19:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/d14833d15d5984e366f1b027fa78bd038c9b028c66880bffb0f5a4d25ee2/grpcio-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4772402f43517b4824980be4b3b2274a81eec0004a70009473c31b340d43e223", size = 12178773, upload-time = "2026-07-23T15:19:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/8acbb416544e7871132d8e42a07ed70c802d70e6a16c6009e505a34d32a4/grpcio-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f4cee5fc86e84a0cf7ad1574b454c3320e087c07f55b7df5dc0ac6a873fb90c0", size = 6921203, upload-time = "2026-07-23T15:19:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/0fdbfaf4fc54e5c88f6bce4008a065092fe7fbc4460eb5617ae8b20fd505/grpcio-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f5e822a7e7d03282f6ad225e710493c48b9057a353358344a5f7c42b2b37618d", size = 7648508, upload-time = "2026-07-23T15:19:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ea/107b9dbb2ed3ad14dd774fd3dde7d29ff9938a6c198654becb2c3a0e9a6a/grpcio-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5f410d7c2903eabb34789dfd6342eef04af1ad459943936b7e09a9f5bd417b9", size = 7079466, upload-time = "2026-07-23T15:19:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/9fa9941089e6fae83b060b6ce61c1e81053e52decae43197245f45e07d36/grpcio-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee94a4016fdf8699fb1fd8a38652475ff677f1c72074cee44deeeb9a7e95e745", size = 7605583, upload-time = "2026-07-23T15:19:23.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/f10fb56062dc2771c630827a82d9ad0ecd05cad572ea3b08d49f6631680a/grpcio-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6444666317338e903093c7c756e6cc88eee59f798cb8dd41e87725bf54e1617", size = 8637810, upload-time = "2026-07-23T15:19:25.536Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/f84927258f6a1b6ea6dea661fdc6de859b35e560c96f3012d15ccd39f85e/grpcio-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aa074041231f03959cb097dd5517b0677b8ea49215bae01d5710a7b69dd59969", size = 8008021, upload-time = "2026-07-23T15:19:27.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/cdf72161397ccd29d4ca2192f641524536c9cf54ad948c9dd0e0e01138fa/grpcio-1.83.0-cp311-cp311-win32.whl", hash = "sha256:cb056f6e171c42639a50460b2929c82241fda51f71cf3dcdd68090fe45095a45", size = 4404376, upload-time = "2026-07-23T15:19:30.137Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ed/e0ffeb4c848699c194dc9fb6a29ab29bcb2b6aac8c416bf18c51bfe8242c/grpcio-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:7416952ca770477990257206276999056f8316d79196f2f25942393e58a20b49", size = 5164469, upload-time = "2026-07-23T15:19:31.941Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/b1/50b17b3a2ba8970dbb00b2035a4df218bc6ec88d2d77fc7da4e42e1c7b19/grpcio_tools-1.83.0.tar.gz", hash = "sha256:515907265d14fa9975d0c7723f95a9da01463d7ac607546a03f8741f86a1bb07", size = 6400437, upload-time = "2026-07-23T15:22:18.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/f0/d55c59b3af39d2ca975a2bafc5be1a60e0460a1b507bdbcf7bb8a17567db/grpcio_tools-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:72471a4a46909f1d798836c0a0aa2f568e10f6404585d7b22ac7330dd6a7bc74", size = 2652835, upload-time = "2026-07-23T15:21:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/82/97/59bdf27c5f99848087b3b268c90b3fcc557d400c8d0224cf49c7ac573e60/grpcio_tools-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:7da547dd1e0b1fe3d6d5677e9c1848969ecdbd51a92c342cf82d885c5935de7d", size = 5967887, upload-time = "2026-07-23T15:21:08.19Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c4/117d6688c4cb40240ce48da1ffac005e8da8bf63785634bdbb9143ca367e/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33350bd94c4913f8eaf6ca79ce69cc673bb46ca5f800e6474b1d6899ed321dad", size = 2704869, upload-time = "2026-07-23T15:21:09.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/51/e4d1a89f69072bb93b975548c40fe9524219ab5777cce113c1e2183b1f2d/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0f27da6dc58c910f31dcee4fcbfd05659c10c14b9e132f4f17da48d867e75eb4", size = 3032318, upload-time = "2026-07-23T15:21:11.55Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/26/f9a082b79ae7f7dac7050047614000721dcf3d1c6d14bffa881b1f7a9774/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b3a5000e8540efb80f74d9c760f36ed9408294d76edb0fa4b87fd287b0a8a258", size = 2774113, upload-time = "2026-07-23T15:21:13.037Z" },
+    { url = "https://files.pythonhosted.org/packages/de/59/b715d431218f0e8382490db7b1d01b3d32392c359c1886eee7e2551edaa8/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f710032264ed114c9d3b52f4c5cf71d68ccf70f25c4cb5776fe60388374bc01b", size = 3226715, upload-time = "2026-07-23T15:21:14.88Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/99/c4e91a2116062f7b42ab99459eeda15ec59a07daad01f4f38753fb1584ac/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ad00de87334154901e9af50a7f3f95261a0133502c6c0cea1f4e6107245154c3", size = 3799000, upload-time = "2026-07-23T15:21:16.352Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f7/0bb5e45a1f51822c0bcf5a355a06132c43b9dbe5c283edc8d0b63bec7626/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:de2b0c645363f7c4b005f145e06e790870dfb21bb7e162dec6fee2f054de9291", size = 3457774, upload-time = "2026-07-23T15:21:17.953Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/51/52aec42a3059bad4263a7a82c715a0fc08220f7533be41f0b9177b05468a/grpcio_tools-1.83.0-cp311-cp311-win32.whl", hash = "sha256:6d1a1c9e62689d04b63b227558b759a55dce8fb81a3934d3b5f95d1ee26a2b45", size = 1022798, upload-time = "2026-07-23T15:21:19.854Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/034d6daa5b2fae4e4c1718111c1b791589c3743d7d8fb07984e0b59c7f2c/grpcio_tools-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:a6ac3cc2c2d77f869a96dfaf2b1315852878babddfe2dc49b9fd47afbf502865", size = 1192474, upload-time = "2026-07-23T15:21:21.467Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2239,6 +2283,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2356,6 +2409,7 @@ pypowsybl = [
 [package.dev-dependencies]
 dev = [
     { name = "docker" },
+    { name = "grpcio-tools" },
     { name = "ipykernel" },
     { name = "jupyter" },
     { name = "openpyxl" },
@@ -2402,6 +2456,7 @@ provides-extras = ["pandapower", "pypowsybl"]
 [package.metadata.requires-dev]
 dev = [
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "grpcio-tools", specifier = ">=1.72" },
     { name = "ipykernel", specifier = ">=6.25.2" },
     { name = "jupyter", specifier = ">=1.0.0" },
     { name = "openpyxl", specifier = ">=3.1.2" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,11 @@ dev = [
     "types-confluent-kafka>=1.3.3",
     "pypowsybl-jupyter>=1.0.0",
     "docker>=7.1.0",
-    "ipympl>=0.9.8"
+    "ipympl>=0.9.8",
+    # Supplies protoc as a wheel for packages/interfaces_pkg/src/compile_proto.sh. Declared here too
+    # because that script is run through the root project environment. Must stay >=1.72: older
+    # releases cap protobuf at <6, which breaks mypy-protobuf's --mypy_out plugin.
+    "grpcio-tools>=1.72"
 ]
 doc = [
     "mkdocs>=1.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -988,9 +988,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
     { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
     { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
-    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
     { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
     { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
     { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
@@ -1004,6 +1002,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/f6/3b781cd07a715ea5f5125ae264226e7fc4d87603d6d3955022cabfdc5da2/grpcio-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:8ff0b8767ddd62704e0d9571c1890af08d84a3a689ebba1807e62519d0b3277f", size = 6338720, upload-time = "2026-07-23T15:19:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/d14833d15d5984e366f1b027fa78bd038c9b028c66880bffb0f5a4d25ee2/grpcio-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4772402f43517b4824980be4b3b2274a81eec0004a70009473c31b340d43e223", size = 12178773, upload-time = "2026-07-23T15:19:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/8acbb416544e7871132d8e42a07ed70c802d70e6a16c6009e505a34d32a4/grpcio-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f4cee5fc86e84a0cf7ad1574b454c3320e087c07f55b7df5dc0ac6a873fb90c0", size = 6921203, upload-time = "2026-07-23T15:19:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/0fdbfaf4fc54e5c88f6bce4008a065092fe7fbc4460eb5617ae8b20fd505/grpcio-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f5e822a7e7d03282f6ad225e710493c48b9057a353358344a5f7c42b2b37618d", size = 7648508, upload-time = "2026-07-23T15:19:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ea/107b9dbb2ed3ad14dd774fd3dde7d29ff9938a6c198654becb2c3a0e9a6a/grpcio-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5f410d7c2903eabb34789dfd6342eef04af1ad459943936b7e09a9f5bd417b9", size = 7079466, upload-time = "2026-07-23T15:19:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/9fa9941089e6fae83b060b6ce61c1e81053e52decae43197245f45e07d36/grpcio-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee94a4016fdf8699fb1fd8a38652475ff677f1c72074cee44deeeb9a7e95e745", size = 7605583, upload-time = "2026-07-23T15:19:23.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/f10fb56062dc2771c630827a82d9ad0ecd05cad572ea3b08d49f6631680a/grpcio-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6444666317338e903093c7c756e6cc88eee59f798cb8dd41e87725bf54e1617", size = 8637810, upload-time = "2026-07-23T15:19:25.536Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/f84927258f6a1b6ea6dea661fdc6de859b35e560c96f3012d15ccd39f85e/grpcio-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aa074041231f03959cb097dd5517b0677b8ea49215bae01d5710a7b69dd59969", size = 8008021, upload-time = "2026-07-23T15:19:27.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/cdf72161397ccd29d4ca2192f641524536c9cf54ad948c9dd0e0e01138fa/grpcio-1.83.0-cp311-cp311-win32.whl", hash = "sha256:cb056f6e171c42639a50460b2929c82241fda51f71cf3dcdd68090fe45095a45", size = 4404376, upload-time = "2026-07-23T15:19:30.137Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ed/e0ffeb4c848699c194dc9fb6a29ab29bcb2b6aac8c416bf18c51bfe8242c/grpcio-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:7416952ca770477990257206276999056f8316d79196f2f25942393e58a20b49", size = 5164469, upload-time = "2026-07-23T15:19:31.941Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/b1/50b17b3a2ba8970dbb00b2035a4df218bc6ec88d2d77fc7da4e42e1c7b19/grpcio_tools-1.83.0.tar.gz", hash = "sha256:515907265d14fa9975d0c7723f95a9da01463d7ac607546a03f8741f86a1bb07", size = 6400437, upload-time = "2026-07-23T15:22:18.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/f0/d55c59b3af39d2ca975a2bafc5be1a60e0460a1b507bdbcf7bb8a17567db/grpcio_tools-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:72471a4a46909f1d798836c0a0aa2f568e10f6404585d7b22ac7330dd6a7bc74", size = 2652835, upload-time = "2026-07-23T15:21:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/82/97/59bdf27c5f99848087b3b268c90b3fcc557d400c8d0224cf49c7ac573e60/grpcio_tools-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:7da547dd1e0b1fe3d6d5677e9c1848969ecdbd51a92c342cf82d885c5935de7d", size = 5967887, upload-time = "2026-07-23T15:21:08.19Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c4/117d6688c4cb40240ce48da1ffac005e8da8bf63785634bdbb9143ca367e/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:33350bd94c4913f8eaf6ca79ce69cc673bb46ca5f800e6474b1d6899ed321dad", size = 2704869, upload-time = "2026-07-23T15:21:09.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/51/e4d1a89f69072bb93b975548c40fe9524219ab5777cce113c1e2183b1f2d/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0f27da6dc58c910f31dcee4fcbfd05659c10c14b9e132f4f17da48d867e75eb4", size = 3032318, upload-time = "2026-07-23T15:21:11.55Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/26/f9a082b79ae7f7dac7050047614000721dcf3d1c6d14bffa881b1f7a9774/grpcio_tools-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b3a5000e8540efb80f74d9c760f36ed9408294d76edb0fa4b87fd287b0a8a258", size = 2774113, upload-time = "2026-07-23T15:21:13.037Z" },
+    { url = "https://files.pythonhosted.org/packages/de/59/b715d431218f0e8382490db7b1d01b3d32392c359c1886eee7e2551edaa8/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f710032264ed114c9d3b52f4c5cf71d68ccf70f25c4cb5776fe60388374bc01b", size = 3226715, upload-time = "2026-07-23T15:21:14.88Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/99/c4e91a2116062f7b42ab99459eeda15ec59a07daad01f4f38753fb1584ac/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ad00de87334154901e9af50a7f3f95261a0133502c6c0cea1f4e6107245154c3", size = 3799000, upload-time = "2026-07-23T15:21:16.352Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f7/0bb5e45a1f51822c0bcf5a355a06132c43b9dbe5c283edc8d0b63bec7626/grpcio_tools-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:de2b0c645363f7c4b005f145e06e790870dfb21bb7e162dec6fee2f054de9291", size = 3457774, upload-time = "2026-07-23T15:21:17.953Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/51/52aec42a3059bad4263a7a82c715a0fc08220f7533be41f0b9177b05468a/grpcio_tools-1.83.0-cp311-cp311-win32.whl", hash = "sha256:6d1a1c9e62689d04b63b227558b759a55dce8fb81a3934d3b5f95d1ee26a2b45", size = 1022798, upload-time = "2026-07-23T15:21:19.854Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/034d6daa5b2fae4e4c1718111c1b791589c3743d7d8fb07984e0b59c7f2c/grpcio_tools-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:a6ac3cc2c2d77f869a96dfaf2b1315852878babddfe2dc49b9fd47afbf502865", size = 1192474, upload-time = "2026-07-23T15:21:21.467Z" },
 ]
 
 [[package]]
@@ -3658,6 +3700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
 name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4279,6 +4330,7 @@ provides-extras = ["pandapower", "pypowsybl"]
 [package.metadata.requires-dev]
 dev = [
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "grpcio-tools", specifier = ">=1.72" },
     { name = "ipykernel", specifier = ">=6.25.2" },
     { name = "jupyter", specifier = ">=1.0.0" },
     { name = "openpyxl", specifier = ">=3.1.2" },
@@ -4398,6 +4450,7 @@ ci = [
 dev = [
     { name = "defusedxml" },
     { name = "docker" },
+    { name = "grpcio-tools" },
     { name = "ipykernel" },
     { name = "ipympl" },
     { name = "jupyter" },
@@ -4444,6 +4497,7 @@ ci = [{ name = "commitizen", specifier = ">=4.16.2" }]
 dev = [
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "grpcio-tools", specifier = ">=1.72" },
     { name = "ipykernel", specifier = ">=6.25.2" },
     { name = "ipympl", specifier = ">=0.9.8" },
     { name = "jupyter", specifier = ">=1.0.0" },


### PR DESCRIPTION
chore/Add a runnable image and compose stack so the engine can be used on a MS Windows laptop through Docker Desktop.

The uv environment is placed at /opt/venv via UV_PROJECT_ENVIRONMENT rather than /app/.venv, because /app is a bind mount from the Windows filesystem: a Linux virtualenv there would collide with a natively created .venv and push thousands of small files across the WSL2 bridge on every import. The six packages remain editable installs, so host-side source edits take effect without a rebuild.

The root .dockerignore stays "**" for the dev container base; a per-Dockerfile docker/Dockerfile.dockerignore scopes the build context for this image. .gitattributes pins LF on files consumed by Linux containers, so a CRLF checkout cannot break the entrypoint.

devcontainer.json now builds this image, points the interpreter at /opt/venv, and drops the ${localEnv:HOME}/.ssh mount, which fails on Windows hosts where HOME is unset.

Take protoc from the grpcio-tools wheel rather than a system binary, so compile_proto.sh runs anywhere the project environment does instead of only inside the root Dockerfile, and the compiler version is pinned by uv.lock. The >=1.72 floor is deliberate: older releases cap protobuf at <6, which drags the environment's runtime down to 5.29.x, and mypy-protobuf ships gencode built against 6.32.1, so --mypy_out then fails. The committed *_pb2.py files are left untouched; across grpcio-tools 1.66-1.83 the generated code is identical except the ValidateProtobufRuntimeVersion call, which only embeds the generator's version.

Document MSYS_NO_PATHCONV=1 where container-absolute paths appear: Git Bash rewrites "-w /app" into "C:/Program Files/Git/app" and the daemon rejects it.

docs/usage.md gains a pointer to docker/README.md and a warning that the documented worker.py invocations no longer match the code: both worker modules expose only a main() taking pre-built Kafka clients and fsspec filesystems, with no __main__ block and no CLI flags. Kafka worker services are deliberately not containerised here for that reason; dev-deployment/docker-compose.yaml is unchanged.

Verified on Windows 11: interfaces_pkg 143 passed, dc_solver_pkg 491 passed at -n 4, all three example notebooks execute end to end, and Jupyter serves the bind-mounted repository.

## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes: no

## What is the new behavior (if this is a feature change)?

Add a runnable image and compose stack so the engine can be used on a MS Windows laptop through Docker Desktop, driven by Jupyter, an interactive shell, or the VS Code dev container.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
