### PR TITLE
ci: Isolate QA into separate workflow

### DIFF
--- a/.github/actions/run-package-tests/action.yaml
+++ b/.github/actions/run-package-tests/action.yaml
@@ -33,10 +33,10 @@ runs:
           --dist loadgroup \
           --cov=packages/${{ inputs.package }}/src \
           --cov-config=.coveragerc \
-          --cov-report term-missing \
-          --cov-report xml:coverage-${{ inputs.package }}.xml
+          --cov-report term-missing 
       env:
         CLEANUP_RAY_AFTER_TESTS: true
+        COVERAGE_FILE: coverage-data-${{ inputs.package }}
         RAY_ENABLE_UV_RUN_RUNTIME_ENV: "0"
         UV_PROJECT: packages/${{ inputs.package }}
 
@@ -44,5 +44,5 @@ runs:
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: coverage-${{ inputs.package }}
-        path: coverage-${{ inputs.package }}.xml
+        path: coverage-data-${{ inputs.package }}
         retention-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,11 @@
 
 name: Continuous Integration
 
-on: 
+# Rename workflow run name to include the triggering event and branch/commit.
+run-name: >-
+  CI (${{ github.event_name }}) on ${{ github.head_ref || github.ref_name }} ${{ github.sha }}
+
+on:
   push:
     branches:
       - main
@@ -70,42 +74,6 @@ jobs:
           package: ${{ matrix.package }}
           workers: auto
 
-  sonarqube:
-    needs: [test-packages-toop-runner, test-packages-github-runner]
-    if: success()
-    permissions:
-      contents: read
-      pull-requests: read
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-        with:
-          fetch-depth: 0
-
-      - name: Download all coverage reports
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: coverage-*
-          merge-multiple: true
-          path: .
-
-      - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-      # Check the Quality Gate status.
-      - name: SonarQube Quality Gate check
-        id: sonarqube-quality-gate-check
-        uses: sonarsource/sonarqube-quality-gate-action@8e9b0ca0a7273d6f16986388d98393efdfcf56fd
-        with:
-          pollingTimeoutSec: 600
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
   code-quality-checks:
     permissions:
       contents: read
@@ -147,46 +115,6 @@ jobs:
           cmd: check # (optional) command to execute; options: `check`, `add`, `update`, `remove`; default: check
           path: .nwa-config.yaml # (optional) configuration file path; default: .nwa-config.yaml
 
-  fossa-scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      FOSSA_BRANCH: ${{ github.head_ref || github.ref_name }}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - uses: ./.github/actions/install-uv
-
-      - name: Export requirements.txt for FOSSA
-        shell: bash
-        run: |
-          rm -rf .fossa-ci
-          mkdir -p .fossa-ci
-          cp .fossa.yml .fossa-ci/.fossa.yml
-          uv export \
-            --no-hashes \
-            --frozen \
-            --format=requirements.txt \
-            --output-file .fossa-ci/requirements.txt \
-            --quiet
-
-      - id: fossa-analyze
-        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # Use a specific version if locking is preferred
-        with:
-          api-key: ${{secrets.FOSSA_API_KEY}}
-          branch: ${{ env.FOSSA_BRANCH }}
-          working-directory: .fossa-ci
-          run-tests: false # Add another run with run-tests: true if ci should fail on issues
-
-      - id: fossa-test
-        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # Use a specific version if locking is preferred
-        with:
-          api-key: ${{secrets.FOSSA_API_KEY}}
-          working-directory: .fossa-ci
-          run-tests: true # Add another run with run-tests: true if ci should fail on issues
-
   test-docs-build:
     permissions:
       contents: read
@@ -224,13 +152,58 @@ jobs:
       - name: Test example notebooks
         run: uv run pytest -n auto --dist loadgroup notebooks/tests
 
+  ci-summary:
+    needs: [test-packages-toop-runner, test-packages-github-runner]
+    if: success()
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download coverage reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-*
+          path: .
+          merge-multiple: true
+
+      - name: Setup Python and install dependencies
+        uses: ./.github/actions/setup-python
+        with:
+          sync-args: "--only-group ci --frozen"
+
+      - name: Merge coverage reports
+        run: |
+          uv run --no-sync coverage combine coverage-data-*
+          uv run --no-sync coverage report --format=markdown > coverage.md
+          uv run --no-sync coverage xml -o coverage.xml
+
+      - name: Publish CI summary
+        run: |
+          {
+            echo "## CI"
+            echo
+            echo "[Open commit ${GITHUB_SHA}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
+            echo
+            echo "## Combined test coverage"
+            echo
+            cat coverage.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload combined coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-combined
+          path: coverage.xml
+          retention-days: 7
+
   ci-success-check:
     needs:
       [
         code-quality-checks,
-        fossa-scan,
+        ci-summary,
         license-headers,
-        sonarqube,
         test-docs-build,
         test-example-notebooks,
         test-packages-github-runner,
@@ -244,18 +217,16 @@ jobs:
       - name: Check all job results
         run: |
           echo "Code Quality: ${{ needs.code-quality-checks.result }}"
-          echo "FOSSA Scan: ${{ needs.fossa-scan.result }}"
+          echo "CI Summary: ${{ needs.ci-summary.result }}"
           echo "License Headers: ${{ needs.license-headers.result }}"
-          echo "SonarQube: ${{ needs.sonarqube.result }}"
           echo "Test Docs Build: ${{ needs.test-docs-build.result }}"
           echo "Test Example Notebooks: ${{ needs.test-example-notebooks.result }}"
           echo "Test Packages (GitHub Runner): ${{ needs.test-packages-github-runner.result }}"
           echo "Test Packages (ToOp Runner): ${{ needs.test-packages-toop-runner.result }}"
 
           if [[ "${{ needs.code-quality-checks.result }}" != "success" ]] || \
-             [[ "${{ needs.fossa-scan.result }}" != "success" ]] || \
+             [[ "${{ needs.ci-summary.result }}" != "success" ]] || \
              [[ "${{ needs.license-headers.result }}" != "success" ]] || \
-             [[ "${{ needs.sonarqube.result }}" != "success" ]] || \
              [[ "${{ needs.test-docs-build.result }}" != "success" ]] || \
              [[ "${{ needs.test-example-notebooks.result }}" != "success" ]] || \
              [[ "${{ needs.test-packages-github-runner.result }}" != "success" ]] || \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: coverage-*
           path: .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,8 +211,7 @@ jobs:
         test-packages-toop-runner,
       ]
     if: always()
-    permissions:
-      contents: read
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: Check all job results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,8 @@ name: Continuous Integration
 
 # Rename workflow run name to include the triggering event and branch/commit.
 run-name: >-
-  CI (${{ github.event_name }}) on ${{ github.head_ref || github.ref_name }} ${{ github.sha }}
+  CI (${{ github.event_name }}) on
+  ${{ github.head_ref || github.ref_name }} ${{ github.sha }}
 
 on:
   push:
@@ -159,7 +160,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Download coverage reports
         uses: actions/download-artifact@v8

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,13 +23,13 @@ on:
 permissions: {}
 
 jobs:
+
   # Preparatory job for the QA workflow run.
   # This job extracts all the necessary information from the triggering CI
   # workflow run such as the triggering event, the triggering branch, the
   # triggering commit SHA.
   # It also updates the QA workflow run summary with a link to the triggering CI
   # workflow run and optionally a link to the triggering pull request.
-
   pre-qa:
     name: Pre QA
     if: >
@@ -145,7 +145,13 @@ jobs:
           echo "[Open pull request #${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})" \
             >> "$GITHUB_STEP_SUMMARY"
 
-  sonar-scan:
+  # SonarQube analysis and quality gate check.
+  # This job runs SonarQube analysis and checks the quality gate status.
+  # It pulls the combined coverage report from the triggering CI workflow run
+  # and uses it for the analysis.
+  # It pulls sonar-project.properties from the main branch and updates it with
+  # additional information about the source context.
+  sonar:
     name: SonarQube
     needs: pre-qa
     runs-on: ubuntu-latest
@@ -237,7 +243,13 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-  fossa-scan:
+  # Fossa analysis and quality gate check.
+  # This job runs FOSSA analysis and checks the quality gate status.
+  # It uses a temporary for the analysis. Contents:
+  # - Fossa configuration file pulled from the main branch and updated with the
+  #   triggering commit SHA.
+  # - requirements.txt
+  fossa:
     name: FOSSA
     needs: pre-qa
     runs-on: ubuntu-latest
@@ -255,7 +267,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           enable-cache: true
 
@@ -299,7 +311,6 @@ jobs:
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          project: ci-workflow-test
           branch: ${{ needs.pre-qa.outputs.analysis_branch }}
           working-directory: ${{ env.FOSSA_WORKING_DIRECTORY }}
           run-tests: false
@@ -308,15 +319,17 @@ jobs:
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          project: ci-workflow-test
           working-directory: ${{ env.FOSSA_WORKING_DIRECTORY }}
           run-tests: true
 
+  # QA Gate job that checks the results of the SonarQube and FOSSA quality gates
+  # and reports the status back to GitHub. This status is used to block merging
+  # of pull requests if the quality gates fail.
   qa-gate:
     needs:
       - pre-qa
-      - sonar-scan
-      - fossa-scan
+      - sonar
+      - fossa
 
     # We require pre-qa to succeed so we can determine the correct SHA to
     # report the status against.

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -183,7 +183,7 @@ jobs:
           git fetch upstream "$BASE_REF"
 
       - name: Download coverage
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: coverage-combined
           path: .

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -54,9 +54,8 @@ jobs:
       pr_number: ${{ steps.metadata.outputs.pr_number }}
 
     steps:
-      # Add a summary to the QA workflow run with a link to the triggering CI
-      # workflow run.
-      - name: Publish QA summary
+      # Update workflow summary with a link to the triggering CI workflow
+      - name: Link CI trigger
         env:
           CI_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
@@ -136,7 +135,7 @@ jobs:
             exit 1
           fi
 
-      # Add a link to the triggering pull request in the QA workflow run summary if
+      # Update workflow summary with a link to the triggering pull request if
       # the triggering event was a pull request.
       - name: Link pull request
         if: steps.metadata.outputs.analysis_type == 'pull_request'

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -67,7 +67,7 @@ jobs:
 
       # Resolve metadata from the triggering CI workflow run.
       # This is preferable over extracting metadata from the triggering workflow
-      # artifacts because they might originate from untrusted forks.
+      # artifacts because they might originate from untrusted sources.
       - name: Resolve metadata
         id: metadata
         env:
@@ -266,10 +266,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
-        with:
-          enable-cache: true
+      - uses: ./.github/actions/install-uv
 
       - name: Set FOSSA working directory
         run: echo "FOSSA_WORKING_DIRECTORY=$RUNNER_TEMP/fossa-ci" >> "$GITHUB_ENV"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,359 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+name: Quality Assurance
+
+# Rename workflow run name to include the triggering event and branch/commit.
+run-name: >-
+  QA (${{ github.event.workflow_run.event }}) on
+  ${{ github.event.workflow_run.head_branch }}
+  ${{ github.event.workflow_run.head_sha }}
+
+# Triggered by a successful completion of the CI workflow run.
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  # Preparatory job for the QA workflow run.
+  # This job extracts all the necessary information from the triggering CI
+  # workflow run such as the triggering event, the triggering branch, the
+  # triggering commit SHA.
+  # It also updates the QA workflow run summary with a link to the triggering CI
+  # workflow run and optionally a link to the triggering pull request.
+
+  pre-qa:
+    name: Pre QA
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        github.event.workflow_run.event == 'pull_request' ||
+        (
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      analysis_type: ${{ steps.metadata.outputs.analysis_type }}
+      checkout_repository: ${{ steps.metadata.outputs.checkout_repository }}
+      checkout_sha: ${{ steps.metadata.outputs.checkout_sha }}
+      status_sha: ${{ steps.metadata.outputs.status_sha }}
+      analysis_branch: ${{ steps.metadata.outputs.analysis_branch }}
+      base_ref: ${{ steps.metadata.outputs.base_ref }}
+      pr_number: ${{ steps.metadata.outputs.pr_number }}
+
+    steps:
+      # Add a summary to the QA workflow run with a link to the triggering CI
+      # workflow run.
+      - name: Publish QA summary
+        env:
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          {
+            echo "## QA"
+            echo
+            echo "[Open triggering CI run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${CI_RUN_ID})"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Resolve metadata from the triggering CI workflow run.
+      # This is preferable over extracting metadata from the triggering workflow
+      # artifacts because they might originate from untrusted forks.
+      - name: Resolve metadata
+        id: metadata
+        env:
+          EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "pull_request" ]; then
+            PR_JSON="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${WORKFLOW_SHA}/pulls" \
+              --jq '[.[] | select(.state == "open")][0]')"
+
+            if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+              echo "No open PR found for ${WORKFLOW_SHA}"
+              exit 1
+            fi
+
+            PR_NUMBER="$(echo "$PR_JSON" | jq -r '.number')"
+            PR_HEAD_SHA="$(echo "$PR_JSON" | jq -r '.head.sha')"
+            HEAD_REF="$(echo "$PR_JSON" | jq -r '.head.ref')"
+            HEAD_REPO="$(echo "$PR_JSON" | jq -r '.head.repo.full_name')"
+            HEAD_OWNER="$(echo "$PR_JSON" | jq -r '.head.repo.owner.login')"
+            BASE_REF="$(echo "$PR_JSON" | jq -r '.base.ref')"
+
+            if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+              ANALYSIS_BRANCH="${HEAD_OWNER}:${HEAD_REF}"
+            else
+              ANALYSIS_BRANCH="$HEAD_REF"
+            fi
+
+            {
+              echo "analysis_type=pull_request"
+              echo "checkout_repository=$HEAD_REPO"
+              echo "checkout_sha=$PR_HEAD_SHA"
+              echo "status_sha=$PR_HEAD_SHA"
+              echo "analysis_branch=$ANALYSIS_BRANCH"
+              echo "base_ref=$BASE_REF"
+              echo "pr_number=$PR_NUMBER"
+            } >> "$GITHUB_OUTPUT"
+
+            echo "PR #${PR_NUMBER}"
+            echo "Repository: ${HEAD_REPO}"
+            echo "Branch: ${ANALYSIS_BRANCH}"
+            echo "Base: ${BASE_REF}"
+            echo "SHA: ${PR_HEAD_SHA}"
+
+          elif [ "$EVENT" = "push" ]; then
+            {
+              echo "analysis_type=branch"
+              echo "checkout_repository=$GITHUB_REPOSITORY"
+              echo "checkout_sha=$WORKFLOW_SHA"
+              echo "status_sha=$WORKFLOW_SHA"
+              echo "analysis_branch=$WORKFLOW_BRANCH"
+              echo "base_ref="
+              echo "pr_number="
+            } >> "$GITHUB_OUTPUT"
+
+            echo "Branch: ${WORKFLOW_BRANCH}"
+            echo "SHA: ${WORKFLOW_SHA}"
+
+          else
+            echo "Unsupported event: ${EVENT}"
+            exit 1
+          fi
+
+      # Add a link to the triggering pull request in the QA workflow run summary if
+      # the triggering event was a pull request.
+      - name: Link pull request
+        if: steps.metadata.outputs.analysis_type == 'pull_request'
+        env:
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+        run: |
+          echo "[Open pull request #${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  sonar-scan:
+    name: SonarQube
+    needs: pre-qa
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.pre-qa.outputs.checkout_repository }}
+          ref: ${{ needs.pre-qa.outputs.checkout_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Sonar requires the target branch to be present for PR analysis.
+      - name: Fetch PR base branch
+        if: needs.pre-qa.outputs.analysis_type == 'pull_request'
+        env:
+          BASE_REF: ${{ needs.pre-qa.outputs.base_ref }}
+        run: |
+          set -euo pipefail
+
+          git remote add upstream \
+            "https://github.com/${GITHUB_REPOSITORY}.git"
+
+          git fetch upstream "$BASE_REF"
+
+      - name: Download coverage
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-combined
+          path: .
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Prepare trusted SonarQube configuration
+        env:
+          ANALYSIS_TYPE: ${{ needs.pre-qa.outputs.analysis_type }}
+          PR_NUMBER: ${{ needs.pre-qa.outputs.pr_number }}
+          ANALYSIS_BRANCH: ${{ needs.pre-qa.outputs.analysis_branch }}
+          BASE_REF: ${{ needs.pre-qa.outputs.base_ref }}
+          CHECKOUT_SHA: ${{ needs.pre-qa.outputs.checkout_sha }}
+        run: |
+          set -euo pipefail
+
+          SONAR_PROPERTIES_FILE="sonar-project.properties"
+          rm -f "$SONAR_PROPERTIES_FILE"
+
+          gh api "repos/${GITHUB_REPOSITORY}/contents/sonar-project.properties?ref=main" \
+            --jq '.content' \
+            | base64 --decode \
+            > "$SONAR_PROPERTIES_FILE"
+
+          cat >> "$SONAR_PROPERTIES_FILE" <<EOF
+
+          sonar.scm.revision=${CHECKOUT_SHA}
+          EOF
+
+          if [ "$ANALYSIS_TYPE" = "pull_request" ]; then
+            cat >> "$SONAR_PROPERTIES_FILE" <<EOF
+          sonar.pullrequest.key=${PR_NUMBER}
+          sonar.pullrequest.branch=${ANALYSIS_BRANCH}
+          sonar.pullrequest.base=${BASE_REF}
+          EOF
+
+          else
+            cat >> "$SONAR_PROPERTIES_FILE" <<EOF
+          sonar.branch.name=${ANALYSIS_BRANCH}
+          EOF
+
+          fi
+
+          cat "$SONAR_PROPERTIES_FILE"
+
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      - name: SonarQube Quality Gate
+        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b
+        with:
+          pollingTimeoutSec: 600
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+  fossa-scan:
+    name: FOSSA
+    needs: pre-qa
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.pre-qa.outputs.checkout_repository }}
+          ref: ${{ needs.pre-qa.outputs.checkout_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Set FOSSA working directory
+        run: echo "FOSSA_WORKING_DIRECTORY=$RUNNER_TEMP/fossa-ci" >> "$GITHUB_ENV"
+
+      - name: Prepare trusted FOSSA configuration
+        env:
+          CHECKOUT_SHA: ${{ needs.pre-qa.outputs.checkout_sha }}
+          FOSSA_CONFIG_FILE: ${{ env.FOSSA_WORKING_DIRECTORY }}/.fossa.yml
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$FOSSA_WORKING_DIRECTORY"
+
+          gh api "repos/${GITHUB_REPOSITORY}/contents/.fossa.yml?ref=main" \
+            --jq '.content' \
+            | base64 --decode \
+            > "$FOSSA_CONFIG_FILE"
+
+          cat >> "$FOSSA_CONFIG_FILE" <<EOF
+
+          revision:
+            commit: ${CHECKOUT_SHA}
+          EOF
+
+          cat "$FOSSA_CONFIG_FILE"
+
+      - name: Export requirements.txt for FOSSA
+        run: |
+          set -euo pipefail
+
+          uv export \
+            --no-hashes \
+            --frozen \
+            --format=requirements.txt \
+            --output-file "$FOSSA_WORKING_DIRECTORY/requirements.txt" \
+            --quiet
+
+      - name: FOSSA analyze
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: ci-workflow-test
+          branch: ${{ needs.pre-qa.outputs.analysis_branch }}
+          working-directory: ${{ env.FOSSA_WORKING_DIRECTORY }}
+          run-tests: false
+
+      - name: FOSSA test
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          project: ci-workflow-test
+          working-directory: ${{ env.FOSSA_WORKING_DIRECTORY }}
+          run-tests: true
+
+  qa-gate:
+    needs:
+      - pre-qa
+      - sonar-scan
+      - fossa-scan
+
+    # We require pre-qa to succeed so we can determine the correct SHA to
+    # report the status against.
+    if: always() && needs.pre-qa.result == 'success'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      statuses: write
+
+    steps:
+      - name: Publish QA Gate status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ needs.pre-qa.outputs.status_sha }}
+          SONAR_RESULT: ${{ needs.sonar.result }}
+          FOSSA_RESULT: ${{ needs.fossa.result }}
+        run: |
+          set -euo pipefail
+
+          echo "SonarQube: $SONAR_RESULT"
+          echo "FOSSA: $FOSSA_RESULT"
+
+          if [ "$SONAR_RESULT" = "success" ] &&
+             [ "$FOSSA_RESULT" = "success" ]; then
+            STATE="success"
+            DESCRIPTION="SonarQube and FOSSA quality gates passed"
+          else
+            STATE="failure"
+            DESCRIPTION="Quality gate failed."
+          fi
+
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${SHA}" \
+            -f state="$STATE" \
+            -f context="QA Gate" \
+            -f description="$DESCRIPTION" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -44,6 +44,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: read
+
     outputs:
       analysis_type: ${{ steps.metadata.outputs.analysis_type }}
       checkout_repository: ${{ steps.metadata.outputs.checkout_repository }}
@@ -71,6 +74,7 @@ jobs:
       - name: Resolve metadata
         id: metadata
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event.workflow_run.event }}
           WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           repository: ${{ needs.pre-qa.outputs.checkout_repository }}
           ref: ${{ needs.pre-qa.outputs.checkout_sha }}
@@ -259,7 +259,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           repository: ${{ needs.pre-qa.outputs.checkout_repository }}
           ref: ${{ needs.pre-qa.outputs.checkout_sha }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -266,7 +266,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: ./.github/actions/install-uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@0098a7571ce5c86752e28c0868b41650866a8f4c
+        with:
+          version: "0.11.14"
 
       - name: Set FOSSA working directory
         run: echo "FOSSA_WORKING_DIRECTORY=$RUNNER_TEMP/fossa-ci" >> "$GITHUB_ENV"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ toop_engine_topology_optimizer = { path = "packages/topology_optimizer_pkg", edi
 [dependency-groups]
 ci = [
     "commitizen>=4.16.2",
+    "coverage>=7.14.3",
 ]
 dev = [
     "pep8-naming",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.11.*"
 
 [[package]]
@@ -4111,8 +4111,10 @@ name = "toop-engine-grid-helpers"
 source = { editable = "packages/grid_helpers_pkg" }
 dependencies = [
     { name = "beartype" },
+    { name = "fsspec" },
     { name = "jaxtyping" },
     { name = "kafka" },
+    { name = "networkx" },
     { name = "numpy" },
     { name = "orjson" },
     { name = "pandas", extra = ["hdf5"] },
@@ -4125,8 +4127,10 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beartype", specifier = ">=0.22.0,<0.23.0" },
+    { name = "fsspec", specifier = ">=2024.0.0" },
     { name = "jaxtyping", specifier = ">=0.2.22,<0.3.0" },
     { name = "kafka", specifier = ">=1.3.5,<2.0.0" },
+    { name = "networkx", specifier = ">=2.5.0" },
     { name = "numpy", specifier = ">=1.26.0,<2.0.0" },
     { name = "orjson", specifier = ">=3.11.3" },
     { name = "pandapower", marker = "extra == 'pandapower'", specifier = ">=3.0.0" },
@@ -4241,7 +4245,6 @@ dependencies = [
     { name = "h5py" },
     { name = "jaxtyping" },
     { name = "mypy-protobuf" },
-    { name = "networkx" },
     { name = "numpy" },
     { name = "numpydantic" },
     { name = "pandas" },
@@ -4261,7 +4264,6 @@ requires-dist = [
     { name = "h5py", specifier = ">=3.0.0" },
     { name = "jaxtyping", specifier = ">=0.2.22,<0.3.0" },
     { name = "mypy-protobuf", specifier = ">=3.7.0" },
-    { name = "networkx", specifier = ">=2.5.0" },
     { name = "numpy", specifier = ">=1.26.0,<2.0.0" },
     { name = "numpydantic", specifier = ">=1.6.4,<2.0.0" },
     { name = "pandapower", marker = "extra == 'pandapower'", specifier = ">=3.0.0" },
@@ -4394,6 +4396,7 @@ dependencies = [
 [package.dev-dependencies]
 ci = [
     { name = "commitizen" },
+    { name = "coverage" },
 ]
 dev = [
     { name = "defusedxml" },
@@ -4440,7 +4443,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-ci = [{ name = "commitizen", specifier = ">=4.16.2" }]
+ci = [
+    { name = "commitizen", specifier = ">=4.16.2" },
+    { name = "coverage", specifier = ">=7.14.3" },
+]
 dev = [
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "docker", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary

Moves CI jobs that require secrets into a QA (quality assurance) workflow. This enables setting up the entire CI logic that also covers PRs from forks, as definition of the QA workflow always comes from the trusted main branch.

This is achieved by configuring the QA workflow to run on `workflow_run` - triggered by other workflows, in this case the CI workflow. Workflows triggered by `workflow_run` always take the definition of the workflow from the default branch, therefore allow usage of secrets.

Without this change secrets cannot be loaded into workflows when PRs come from forks.

### Security

Both SonarQube and Fossa scanning jobs pull configuration files from the main branch to execute the analysis. Changing these files in the source branch has no effect on the analysis.

### QA gate 

- QA workflow reports `QA Gate` status check back to GitHub that can be enabled as a PR status check
- Status check includes a hyperlink to the respective QA workflow run:
  <img width="849" height="450" alt="Screenshot 2026-08-18 at 10 07 42" src="https://github.com/user-attachments/assets/93ba7b58-6749-450b-a8aa-84916b4e709f" />

### Coverage Report

- Coverage report generation in the CI workflow has been refactored to upload an artifact with a single combined coverage report. The latter is also used for displaying results in the UI (see below CI workflow summary update).
- Added `coverage` as an explicit CI dependency (it was already a transitive dependency via pytest-cov) to be able to combine coverage reports into a single file.

### Workflow Run Names

QA and CI workflow runs are renamed to include information about the trigger: event type, branch, SHA 
 
<img width="569" height="224" alt="Screenshot 2026-08-18 at 10 01 31" src="https://github.com/user-attachments/assets/fbe00890-a852-477e-b619-c0ab16e08125" />

### Workflow Summaries

Workflows now update respective summaries to provide more information.

#### CI

- Test coverage
- Link to triggering SHA

<img width="1149" height="801" alt="Screenshot 2026-08-18 at 10 20 06" src="https://github.com/user-attachments/assets/fe72a3da-2214-463f-a7e7-7d2801d8a6bc" />


#### QA

- Link to the triggering CI workflow run
- Link to the triggering PR (if triggered by PR)

<img width="1158" height="623" alt="Screenshot 2026-08-18 at 10 05 49" src="https://github.com/user-attachments/assets/9dd1879f-cb9e-41b6-a480-9260fb906050" />

## Reconfiguration

This logic has been developed and extensively tested on a private repository. Therefore it remains a possibility that the permission model might require updating. 

The QA workflow will only be become trigger-able after this PR is merged into the main branch. After the merge, CI workflow will run first and afterwards trigger the QA workflow. When QA workflow completes, it will generate the first `QA Gate` status check, which can afterwards be configured in the main branch ruleset.

### Proposed Steps:

1. Remove `SonarQube Code Analysis` status check in the main branch ruleset
2. Merge PR
3. Wait for CI and QA workflows to complete in the main branch
4. Add `QA Gate` status check in the main branch ruleset
5. Update feature branches

## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

221962 on ADO board.

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
