### PR TITLE
fix: tie line reduction

### DIFF
--- a/packages/grid_helpers_pkg/src/toop_engine_grid_helpers/powsybl/example_grids.py
+++ b/packages/grid_helpers_pkg/src/toop_engine_grid_helpers/powsybl/example_grids.py
@@ -1010,6 +1010,12 @@ def create_complex_grid_battery_hvdc_svc_3w_trafo(
     - two busbar with no coupler
     -> is used in propagation tests -> test removes the breaker for the lines
 
+    Dangling_NL_BE_1_NL, Dangling_NL_BE_1_BE and others:
+    - the boundary nodes have different p0 and q0 settings than the actual flow over the tie line
+    -> if reduced via the powsybl net.reduce_by_ids_and_depths() function, the loadflow will not match
+    -> solution: set first the p0 and q0 of the boundary nodes to match the actual flow over the tie line,
+       then reduce the network
+
     Parameters
     ----------
     linear_pst : np.ndarray | None

--- a/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_analysis.py
+++ b/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_analysis.py
@@ -277,8 +277,10 @@ def set_tie_line_boundary_equivalents(net: Network) -> None:
     net : Network
         The network to modify.
     """
-    boundary_lines = net.get_boundary_lines(attributes=["boundary_p", "boundary_q"])
+    boundary_lines = net.get_boundary_lines(attributes=["boundary_p", "boundary_q", "paired"])
+    boundary_lines = boundary_lines[boundary_lines["paired"]]
     boundary_lines.rename(columns={"boundary_p": "p0", "boundary_q": "q0"}, inplace=True)
+    boundary_lines = boundary_lines[["p0", "q0"]]
     boundary_lines["p0"] = boundary_lines["p0"].fillna(0.0) * -1
     boundary_lines["q0"] = boundary_lines["q0"].fillna(0.0) * -1
     net.update_boundary_lines(boundary_lines)

--- a/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_analysis.py
+++ b/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_analysis.py
@@ -258,3 +258,27 @@ def remove_branches_with_same_bus(network: Network) -> None:
             f"Removed {len(same_bus_branches)} branches with the same bus id. Please check the network for inconsistencies.",
             removed_branch_ids=same_bus_branches.tolist(),
         )
+
+
+def set_tie_line_boundary_equivalents(net: Network) -> None:
+    """Set every tie-line boundary component to its loadflow equivalent.
+
+    When a reduction removes one endpoint of a tie line, PowSyBl retains the
+    other endpoint as a boundary line. Keeping its solved setpoint beforehand
+    preserves the original active exchange after that reduction.
+
+    Notes
+    -----
+    - This function modifies the network in place.
+    - Expects a network with a solved loadflow.
+
+    Parameters
+    ----------
+    net : Network
+        The network to modify.
+    """
+    boundary_lines = net.get_boundary_lines(attributes=["boundary_p", "boundary_q"])
+    boundary_lines.rename(columns={"boundary_p": "p0", "boundary_q": "q0"}, inplace=True)
+    boundary_lines["p0"] = boundary_lines["p0"].fillna(0.0) * -1
+    boundary_lines["q0"] = boundary_lines["q0"].fillna(0.0) * -1
+    net.update_boundary_lines(boundary_lines)

--- a/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_reduction.py
+++ b/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_reduction.py
@@ -60,4 +60,16 @@ def reduce_network_based_on_area_settings(
 
     # get vl_depths with importer setting
     vl_depths = [(vl_id, importer_parameters.network_reduction_voltage_level_range) for vl_id in voltage_level_ids]
-    net.reduce_by_ids_and_depths(vl_depths=vl_depths, with_boundary_lines=True)
+    # Keep PowSyBl's load equivalents for ordinary lines crossing the
+    # reduction boundary.  A generated boundary line contains half of the
+    # original line impedance, but PowSyBl initializes its p0/q0 with the
+    # retained terminal flow.  That is not an AC-equivalent setpoint: on the
+    # next loadflow, losses and shunt consumption of the half-line change the
+    # retained-area flows.
+    #
+    # Tie-line endpoints are already BoundaryLines and remain in the network
+    # after their TieLine is removed.  Their p0/q0 values are corrected before
+    # reduction by set_tie_line_boundary_equivalents, so enabling creation of
+    # additional boundary lines here is neither needed nor flow preserving.
+    # set with_boundary_lines=False
+    net.reduce_by_ids_and_depths(vl_depths=vl_depths, with_boundary_lines=False)

--- a/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_reduction.py
+++ b/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/network_reduction.py
@@ -60,4 +60,4 @@ def reduce_network_based_on_area_settings(
 
     # get vl_depths with importer setting
     vl_depths = [(vl_id, importer_parameters.network_reduction_voltage_level_range) for vl_id in voltage_level_ids]
-    net.reduce_by_ids_and_depths(vl_depths=vl_depths, with_boundary_lines=False)
+    net.reduce_by_ids_and_depths(vl_depths=vl_depths, with_boundary_lines=True)

--- a/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/preprocessing.py
+++ b/packages/importer_pkg/src/toop_engine_importer/pypowsybl_import/preprocessing.py
@@ -371,8 +371,22 @@ def convert_file(
         import_parameter=importer_parameters,
     )
 
-    # Note: must be greater than 0
-    if importer_parameters.network_reduction_voltage_level_range >= 1:
+    # a loadflow is needed for the network set_tie_line_boundary_equivalents and later for the reduction
+    if importer_parameters.loadflow_parameters_file:
+        lf_params = load_lf_params_from_fs(
+            filesystem=unprocessed_gridfile_fs,
+            file_path=importer_parameters.loadflow_parameters_file,
+        )
+        main_result, *_ = pypowsybl.loadflow.run_ac(network, parameters=lf_params)
+    else:
+        lf_params, main_result = find_converging_loadflow_params(importer_parameters, network)
+
+    # set_tie_line_boundary_equivalents
+    # sets the p0 and q0 of the boundary lines to match the actual flow over the tie line
+    # This is needed if the grid is reduced and a tie line is removed -> wrong loadflow if the p0 and q0 is not set
+    network_analysis.set_tie_line_boundary_equivalents(net=network)
+
+    if importer_parameters.network_reduction_voltage_level_range >= 0:
         status_update_fn("reduce_network_to_view_area", "Reducing network to view area")
         reduce_network_based_on_area_settings(net=network, importer_parameters=importer_parameters)
 
@@ -427,6 +441,7 @@ def convert_file(
         filesystem=processed_gridfile_fs,
         file_path=importer_parameters.data_folder / PREPROCESSING_PATHS["loadflow_parameters_file_path"],
     )
+
     # get N-1 masks
     status_update_fn("get_masks", "Creating Network Masks")
     network_masks = compute_network_masks_and_n_1_definition(

--- a/packages/importer_pkg/tests/pypowsybl_import/test_preprocessing.py
+++ b/packages/importer_pkg/tests/pypowsybl_import/test_preprocessing.py
@@ -22,6 +22,7 @@ from fsspec.implementations.local import LocalFileSystem
 from pypowsybl.network import Network
 from toop_engine_dc_solver.preprocess.convert_to_jax import load_grid
 from toop_engine_grid_helpers.powsybl.loadflow_parameters import SINGLE_SLACK
+from toop_engine_grid_helpers.powsybl.powsybl_helpers import load_lf_params_from_fs
 from toop_engine_importer.pandapower_import.preprocessing import modify_constan_z_load
 from toop_engine_importer.pypowsybl_import import powsybl_masks, preprocessing
 from toop_engine_importer.pypowsybl_import.data_classes import PreProcessingStatistics
@@ -261,7 +262,7 @@ def test_reduce_network_to_view_area_preserves_dc_branch_flows_tie_lines_edge_ca
     loadflow_parameters.provider_parameters["maxNewtonRaphsonIterations"] = "20"
     if run_ac:
         columns = ["p1", "p2", "q1", "q2"]
-        atol = 1e-6
+        atol = 1e-7
     else:
         columns = ["p1", "p2"]
         atol = 1e-9
@@ -360,11 +361,10 @@ def test_convert_file_complex_grid_with_network_reduction(
 def test_convert_file_reduced_network_preserves_ac_branch_flows(
     complex_grid_network: Network, cgmes_importer_parameters: CgmesImporterParameters, tmp_path: Path
 ) -> None:
-    pypowsybl.loadflow.run_ac(complex_grid_network)
-    original_branches = complex_grid_network.get_lines()
-
+    """Tests that a reduced network is has the same loadflow with tie line reductions"""
+    complex_grid_network_org = deepcopy(complex_grid_network)
     input_grid_path = tmp_path / "complex_grid.xiidm"
-    complex_grid_network.save(input_grid_path)
+    complex_grid_network_org.save(input_grid_path)
     importer_parameters = cgmes_importer_parameters.model_copy(
         update={
             "grid_model_file": input_grid_path,
@@ -383,20 +383,36 @@ def test_convert_file_reduced_network_preserves_ac_branch_flows(
     )
 
     import_result = preprocessing.convert_file(importer_parameters=importer_parameters)
+    loadflow_parameters = load_lf_params_from_fs(
+        filesystem=LocalFileSystem(),
+        file_path=import_result.data_folder / PREPROCESSING_PATHS["loadflow_parameters_file_path"],
+    )
+    pypowsybl.loadflow.run_ac(complex_grid_network_org, loadflow_parameters)
+    original_branches = complex_grid_network_org.get_lines()
+
     converted_network = pypowsybl.network.load(import_result.data_folder / PREPROCESSING_PATHS["grid_file_path_powsybl"])
-    pypowsybl.loadflow.run_ac(converted_network)
+    pypowsybl.loadflow.run_ac(converted_network, loadflow_parameters)
     converted_branches = converted_network.get_lines()
+
+    # check that the reduction happened
+    voltage_levels_org = complex_grid_network_org.get_voltage_levels()
+    voltage_levels_converted = converted_network.get_voltage_levels()
+    assert len(voltage_levels_converted) < len(voltage_levels_org)
 
     common_branch_ids = original_branches.index.intersection(converted_branches.index)
     assert len(common_branch_ids) > 0
-    for column in ["p1", "p2"]:
+    for column in ["p1", "p2", "q1", "q2"]:
+        # Note: the other tests use 1e-7
+        # because of loadflow_parameters.provider_parameters["newtonRaphsonConvEpsPerEq"] = "1e-9"
+        # this loadflow runs with the standard settings of newtonRaphsonConvEpsPerEq = "1e-6"
+        # hence the reduced accuracy of the loadflow results here
         pd.testing.assert_series_equal(
             original_branches.loc[common_branch_ids, column],
             converted_branches.loc[common_branch_ids, column],
             check_names=False,
             check_exact=False,
             rtol=0.0,
-            atol=1e-9,
+            atol=1e-5,
         )
 
 

--- a/packages/importer_pkg/tests/pypowsybl_import/test_preprocessing.py
+++ b/packages/importer_pkg/tests/pypowsybl_import/test_preprocessing.py
@@ -6,6 +6,7 @@
 # Mozilla Public License, version 2.0
 
 import time
+from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -20,9 +21,11 @@ from fsspec.implementations.dirfs import DirFileSystem
 from fsspec.implementations.local import LocalFileSystem
 from pypowsybl.network import Network
 from toop_engine_dc_solver.preprocess.convert_to_jax import load_grid
+from toop_engine_grid_helpers.powsybl.loadflow_parameters import SINGLE_SLACK
 from toop_engine_importer.pandapower_import.preprocessing import modify_constan_z_load
 from toop_engine_importer.pypowsybl_import import powsybl_masks, preprocessing
 from toop_engine_importer.pypowsybl_import.data_classes import PreProcessingStatistics
+from toop_engine_importer.pypowsybl_import.network_analysis import set_tie_line_boundary_equivalents
 from toop_engine_importer.pypowsybl_import.network_reduction import reduce_network_based_on_area_settings
 from toop_engine_importer.pypowsybl_import.preprocessing import create_nminus1_definition_from_masks
 from toop_engine_interfaces.folder_structure import (
@@ -243,6 +246,96 @@ def test_reduce_network_to_view_area_preserves_dc_branch_flows(
         )
 
 
+@pytest.mark.parametrize("run_ac", [True, False])
+def test_reduce_network_to_view_area_preserves_dc_branch_flows_tie_lines_edge_case(
+    complex_grid_network: Network, cgmes_importer_parameters: CgmesImporterParameters, run_ac: bool
+) -> None:
+    """Tests Tieline reduction.
+
+    It can happen, that a Tieline is exactly on the border of the view area.
+    If the boundary node has a different setting for p0 and q0, the resulting load flow will be different after the reduction.
+    This test checks that the reduction does not change the load flow of the remaining branches, even in this edge case.
+    """
+    loadflow_parameters = deepcopy(SINGLE_SLACK)
+    loadflow_parameters.provider_parameters["newtonRaphsonConvEpsPerEq"] = "1e-9"
+    loadflow_parameters.provider_parameters["maxNewtonRaphsonIterations"] = "20"
+    if run_ac:
+        columns = ["p1", "p2", "q1", "q2"]
+        atol = 1e-6
+    else:
+        columns = ["p1", "p2"]
+        atol = 1e-9
+
+    reduction_range = 0
+    net = complex_grid_network
+    importer_parameters = cgmes_importer_parameters.model_copy(
+        update={"network_reduction_voltage_level_range": reduction_range}
+    )
+
+    # VL_NL_TIE_REDUCTION_REMOTE_380 is a tie line that is exactly on the border of the view area.
+    # it is set to p0=0.0 and q0=0.0, but the tie line has a flow due to load_NL_tie_reduction_remote
+    importer_parameters.area_settings = AreaSettings(
+        cutoff_voltage=220,
+        control_area=["BE"],
+        view_area=[
+            "BE",
+        ],
+        nminus1_area=[
+            "BE",
+        ],
+        dso_trafo_factors=None,
+        border_line_factors=None,
+    )
+    if run_ac:
+        pypowsybl.loadflow.run_ac(net, loadflow_parameters)
+    else:
+        pypowsybl.loadflow.run_dc(net, loadflow_parameters)
+    net_success = deepcopy(net)
+    original_branches = net.get_lines()
+    reduce_network_based_on_area_settings(net=net, importer_parameters=importer_parameters)
+
+    if run_ac:
+        pypowsybl.loadflow.run_ac(net, loadflow_parameters)
+    else:
+        pypowsybl.loadflow.run_dc(net, loadflow_parameters)
+    reduced_branches = net.get_lines()
+
+    common_branch_ids = original_branches.index.intersection(reduced_branches.index)
+    assert len(common_branch_ids) > 0
+    for column in columns:
+        with pytest.raises(AssertionError):
+            pd.testing.assert_series_equal(
+                original_branches.loc[common_branch_ids, column],
+                reduced_branches.loc[common_branch_ids, column],
+                check_names=False,
+                check_exact=False,
+                rtol=0.0,
+                atol=atol,
+            )
+
+    # Set boundary lines to their solved tie-line flow before reducing the successful variant.
+    set_tie_line_boundary_equivalents(net=net_success)
+    reduce_network_based_on_area_settings(net=net_success, importer_parameters=importer_parameters)
+
+    if run_ac:
+        pypowsybl.loadflow.run_ac(net_success, loadflow_parameters)
+    else:
+        pypowsybl.loadflow.run_dc(net_success, loadflow_parameters)
+    reduced_branches = net_success.get_lines()
+
+    common_branch_ids = original_branches.index.intersection(reduced_branches.index)
+    assert len(common_branch_ids) > 0
+    for column in columns:
+        pd.testing.assert_series_equal(
+            original_branches.loc[common_branch_ids, column],
+            reduced_branches.loc[common_branch_ids, column],
+            check_names=False,
+            check_exact=False,
+            rtol=0.0,
+            atol=atol,
+        )
+
+
 def test_convert_file_complex_grid_with_network_reduction(
     complex_grid_network: Network, cgmes_importer_parameters: CgmesImporterParameters, tmp_path: Path
 ) -> None:
@@ -262,6 +355,49 @@ def test_convert_file_complex_grid_with_network_reduction(
     assert isinstance(import_result, ImportResult)
     assert (import_result.data_folder / PREPROCESSING_PATHS["grid_file_path_powsybl"]).exists()
     assert (import_result.data_folder / PREPROCESSING_PATHS["nminus1_definition_file_path"]).exists()
+
+
+def test_convert_file_reduced_network_preserves_ac_branch_flows(
+    complex_grid_network: Network, cgmes_importer_parameters: CgmesImporterParameters, tmp_path: Path
+) -> None:
+    pypowsybl.loadflow.run_ac(complex_grid_network)
+    original_branches = complex_grid_network.get_lines()
+
+    input_grid_path = tmp_path / "complex_grid.xiidm"
+    complex_grid_network.save(input_grid_path)
+    importer_parameters = cgmes_importer_parameters.model_copy(
+        update={
+            "grid_model_file": input_grid_path,
+            "data_folder": tmp_path / "processed",
+            "fail_on_non_convergence": False,
+            "network_reduction_voltage_level_range": 0,
+            "area_settings": AreaSettings(
+                cutoff_voltage=220,
+                control_area=["BE"],
+                view_area=["BE"],
+                nminus1_area=["BE"],
+                dso_trafo_factors=None,
+                border_line_factors=None,
+            ),
+        }
+    )
+
+    import_result = preprocessing.convert_file(importer_parameters=importer_parameters)
+    converted_network = pypowsybl.network.load(import_result.data_folder / PREPROCESSING_PATHS["grid_file_path_powsybl"])
+    pypowsybl.loadflow.run_ac(converted_network)
+    converted_branches = converted_network.get_lines()
+
+    common_branch_ids = original_branches.index.intersection(converted_branches.index)
+    assert len(common_branch_ids) > 0
+    for column in ["p1", "p2"]:
+        pd.testing.assert_series_equal(
+            original_branches.loc[common_branch_ids, column],
+            converted_branches.loc[common_branch_ids, column],
+            check_names=False,
+            check_exact=False,
+            rtol=0.0,
+            atol=1e-9,
+        )
 
 
 def test_convert_file_node_breaker_with_svc(basic_node_breaker_network_powsybl_grid: Network):


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes network reduction when a tie line is reduced to its boundary node, but this boundary node has still an out of data p0 and q0.
p0 and q0 are updated in the convert_file() before the network reduction is called

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
