### PR TITLE
feat(contingency-analysis): report load-flow progress through an optional on_progress callback

### DIFF
--- a/docs/contingency_analysis/progress.md
+++ b/docs/contingency_analysis/progress.md
@@ -4,7 +4,10 @@ Pass `on_progress` to [`run_contingency_analysis_pandapower`][toop_engine_contin
 and the engine will call it as outage groups finish. It is **off by default**.
 
 This hook is pandapower only. [`get_ac_loadflow_results`][toop_engine_contingency_analysis.ac_loadflow_service.ac_loadflow_service.get_ac_loadflow_results]
-and the powsybl backend does not accept it.
+and the powsybl backend do not accept it. Powsybl security analysis runs
+entirely in Java; a callback from Python into that run is not implemented
+and not planned in the pypowsybl wrapper. Progress reporting will stay
+pandapower-local.
 
 ## What it reports
 

--- a/docs/contingency_analysis/progress.md
+++ b/docs/contingency_analysis/progress.md
@@ -1,0 +1,49 @@
+# Progress reporting
+
+Pass `on_progress` to [`run_contingency_analysis_pandapower`][toop_engine_contingency_analysis.pandapower.contingency_analysis_pandapower.run_contingency_analysis_pandapower]
+and the engine will call it as outage groups finish. It is **off by default**.
+
+This hook is pandapower only. [`get_ac_loadflow_results`][toop_engine_contingency_analysis.ac_loadflow_service.ac_loadflow_service.get_ac_loadflow_results]
+and the powsybl backend does not accept it.
+
+## What it reports
+
+`on_progress(done, total)`:
+
+- **`total` is the outage-group count**, `len(grouped_contingencies)`. With
+  grouping off that is the contingency list. With `cfg.apply_outage_grouping`
+  several contingencies can share one group, so `total` can be smaller.
+- **First call is `(0, total)`**, before the first load flow.
+- **Later calls are about once a second**, then `(total, total)` if the run
+  succeeds.
+- **A failing callback does not fail the analysis.** The exception is logged
+  and ignored.
+
+## Sequential and parallel
+
+The same callback works on both paths. Sequential calls it between load flows.
+Parallel calls it on the driver process; a Python callable cannot be sent into
+a Ray worker.
+
+## Using it
+
+```python
+from toop_engine_contingency_analysis.pandapower.contingency_analysis_pandapower import (
+    run_contingency_analysis_pandapower,
+)
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
+    ContingencyAnalysisConfig,
+)
+
+def report(done: int, total: int) -> None:
+    print(f"{done}/{total} outage groups")
+
+run_contingency_analysis_pandapower(
+    net,
+    nminus1_definition,
+    job_id,
+    timestep,
+    cfg=ContingencyAnalysisConfig(method="ac", polars=True),
+    on_progress=report,
+)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
     - contingency_analysis/cascade.md
     - contingency_analysis/propagation.md
     - contingency_analysis/result_filtering.md
+    - contingency_analysis/progress.md
     - Code Reference:
       - Importer: references/reference_importer.md
       - DC Solver: references/reference_dc_solver.md

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -10,6 +10,7 @@
 import json
 import logging
 import math
+import time
 from copy import deepcopy
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
@@ -21,7 +22,8 @@ import pandera.typing as pat
 import pandera.typing.polars as patpl
 import polars as pl
 import ray
-from beartype.typing import Any, Union
+from beartype.typing import Any, Callable, Final, Optional, Union
+from ray.util.queue import Queue
 from toop_engine_contingency_analysis.pandapower.cascade.detection import (
     prepare_cascade_run_constants,
 )
@@ -95,6 +97,53 @@ from toop_engine_interfaces.loadflow_results_polars import (
 from toop_engine_interfaces.nminus1_definition import Nminus1Definition
 
 logger = logging.getLogger(__name__)
+
+# Sequential report interval and the parallel ray.wait poll timeout.
+_PROGRESS_POLL_SECONDS: Final[float] = 1.0
+
+
+def _report_progress(on_progress: Callable[[int, int], None], done: int, total: int) -> None:
+    """Call ``on_progress``. Exceptions are logged and ignored."""
+    try:
+        on_progress(done, total)
+    except Exception:
+        logger.warning("Progress callback failed for %d/%d outage groups", done, total, exc_info=True)
+
+
+class _ParallelProgress:
+    """Driver-side progress for the parallel path. No-ops when ``on_progress`` is unset."""
+
+    def __init__(self, on_progress: Optional[Callable[[int, int], None]], total: int) -> None:
+        self._on_progress = on_progress
+        self._total = total
+        self._done = 0
+        self._reported = 0
+        # num_cpus=0 so the queue actor does not take a worker slot.
+        self.queue = Queue(actor_options={"num_cpus": 0}) if on_progress is not None else None
+
+    @property
+    def wait_timeout(self) -> Optional[float]:
+        return _PROGRESS_POLL_SECONDS if self._on_progress is not None else None
+
+    def poll(self) -> None:
+        if self._on_progress is None or self.queue is None:
+            return
+        try:
+            while not self.queue.empty():
+                self._done += self.queue.get_nowait()
+        except Exception:
+            # Stop after the first failure; a dead queue would otherwise log on every poll.
+            logger.warning("Progress queue unavailable; giving up on progress reporting", exc_info=True)
+            self._on_progress = None
+            self.queue = None
+            return
+        if self._done != self._reported:
+            self._reported = self._done
+            _report_progress(self._on_progress, self._done, self._total)
+
+    def finish(self) -> None:
+        if self._on_progress is not None and self._reported != self._total:
+            _report_progress(self._on_progress, self._total, self._total)
 
 
 def _scrub_enums_for_json(obj: object) -> object:
@@ -572,6 +621,8 @@ def run_contingency_analysis_sequential(
     net: pp.pandapowerNet,
     n_minus_1_definition: PandapowerNMinus1Definition,
     ctx: SequentialContingencyAnalysisContext,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    progress_queue: Optional[Queue] = None,
 ) -> list[LoadflowResultsPolars]:
     """Compute a full N-1 analysis for the given network for a single timestep.
 
@@ -579,8 +630,16 @@ def run_contingency_analysis_sequential(
     :func:`run_single_outage`.  ``ctx.slack_allocation_config`` is forwarded to
     each outage call so that :func:`run_outage_power_flow` can handle slack-bus
     assignment (initial PF and SpPS in-loop reassignment) internally.
+
+    ``on_progress(done, total)`` reports completed outage groups at most once per
+    :data:`_PROGRESS_POLL_SECONDS`, and always after the last group. When this
+    function runs as a Ray task, leave ``on_progress`` unset and pass
+    ``progress_queue`` instead; a callable cannot be used from the worker.
     """
     results = []
+    total_groups = len(n_minus_1_definition.grouped_contingencies)
+    unreported_groups = 0
+    last_report = time.monotonic()
 
     single_outage_ctx = SingleOutageContext(
         result_filter=ctx.result_filter,
@@ -610,7 +669,7 @@ def run_contingency_analysis_sequential(
         bus_couplers_mrids=ctx.bus_couplers_mrids,
     )
 
-    for grouped_contingency in n_minus_1_definition.grouped_contingencies:
+    for done_groups, grouped_contingency in enumerate(n_minus_1_definition.grouped_contingencies, start=1):
         copy_net = deepcopy(net)
 
         single_res = run_single_outage(
@@ -622,6 +681,18 @@ def run_contingency_analysis_sequential(
 
         results.append(single_res)
 
+        # At most once per second, and always after the last group.
+        unreported_groups += 1
+        now = time.monotonic()
+        if done_groups == total_groups or now - last_report >= _PROGRESS_POLL_SECONDS:
+            last_report = now
+            if on_progress is not None:
+                _report_progress(on_progress, done_groups, total_groups)
+            if progress_queue is not None:
+                # put_nowait still hits the actor, so use the same cadence as the callback.
+                progress_queue.put_nowait(unreported_groups)
+            unreported_groups = 0
+
     return results
 
 
@@ -629,8 +700,14 @@ def run_contingency_analysis_parallel(
     net: pp.pandapowerNet,
     n_minus_1_definition: PandapowerNMinus1Definition,
     ctx: ParallelContingencyAnalysisContext,
+    on_progress: Optional[Callable[[int, int], None]] = None,
 ) -> list[LoadflowResultsPolars]:
-    """Compute the N-1 AC/DC power flow for the network in parallel."""
+    """Compute the N-1 AC/DC power flow for the network in parallel.
+
+    ``on_progress(done, total)`` is called from this process. Workers put
+    finished group counts on a :class:`ray.util.queue.Queue`; the driver
+    reads it while waiting.
+    """
     n_outages = len(n_minus_1_definition.grouped_contingencies)
     batch_size = ctx.parallel.batch_size
 
@@ -653,6 +730,8 @@ def run_contingency_analysis_parallel(
     result_lists = []
     _compute_remote = ray.remote(run_contingency_analysis_sequential)
 
+    progress = _ParallelProgress(on_progress, n_outages)
+
     sequential_ctx = SequentialContingencyAnalysisContext(
         result_filter=ctx.result_filter,
         basecase_contingency_id=ctx.basecase_contingency_id,
@@ -672,19 +751,33 @@ def run_contingency_analysis_parallel(
     )
 
     for batch in work:
+        # Pass the queue, not on_progress: a callable cannot be serialised into the worker.
         handles.append(
             _compute_remote.remote(
                 net=net,
                 n_minus_1_definition=batch,
                 ctx=sequential_ctx,
+                progress_queue=progress.queue,
             )
         )
 
-        if len(handles) >= ctx.parallel.n_processes:
-            finished, handles = ray.wait(handles, num_returns=1)
+        # ray.wait may time out with no result; keep waiting until a slot frees.
+        while handles and len(handles) >= ctx.parallel.n_processes:
+            finished, handles = ray.wait(handles, num_returns=1, timeout=progress.wait_timeout)
             result_lists.extend(ray.get(finished))
+            progress.poll()
 
-    result_lists.extend(ray.get(handles))
+    if progress.wait_timeout is None:
+        result_lists.extend(ray.get(handles))
+    else:
+        # One finished batch at a time so the driver can poll. A single ray.get on
+        # the remaining handles would block until the whole run finished.
+        while handles:
+            finished, handles = ray.wait(handles, num_returns=1, timeout=progress.wait_timeout)
+            result_lists.extend(ray.get(finished))
+            progress.poll()
+
+    progress.finish()
 
     return [result for result_list in result_lists for result in result_list]
 
@@ -778,6 +871,7 @@ def run_contingency_analysis_pandapower(
     job_id: str,
     timestep: int,
     cfg: ContingencyAnalysisConfig,
+    on_progress: Optional[Callable[[int, int], None]] = None,
 ) -> Union[LoadflowResults, LoadflowResultsPolars]:
     """Compute the N-1 AC/DC power flow for the network.
 
@@ -794,6 +888,13 @@ def run_contingency_analysis_pandapower(
     cfg : ContingencyAnalysisConfig
         Execution configuration (method, islanding/slack settings, parallelization,
         cascade screening, etc.).
+    on_progress : Optional[Callable[[int, int], None]]
+        Called as ``on_progress(done, total)`` in outage groups. ``total`` is
+        ``len(grouped_contingencies)`` and can be smaller than the contingency
+        list when ``cfg.apply_outage_grouping`` is set. First call is ``(0, total)``
+        before the first load flow; later calls are about once a second, then
+        ``(total, total)`` on success. Runs on this thread between load flows.
+        Exceptions are logged and ignored.
 
     Returns
     -------
@@ -811,6 +912,9 @@ def run_contingency_analysis_pandapower(
             PandapowerContingencyGroup(contingencies=[cont], elements=cont.elements, outage_group_id=cont.unique_id)
             for cont in pp_n1_definition.contingencies
         ]
+
+    if on_progress is not None:
+        _report_progress(on_progress, 0, len(pp_n1_definition.grouped_contingencies))
 
     slack_allocation_config = SlackAllocationConfig(
         min_island_size=cfg.min_island_size,
@@ -858,6 +962,7 @@ def run_contingency_analysis_pandapower(
                 cascade=cfg.cascade,
                 bus_couplers_mrids=bus_couplers_mrids,
             ),
+            on_progress=on_progress,
         )
     else:
         results = run_contingency_analysis_parallel(
@@ -881,6 +986,7 @@ def run_contingency_analysis_pandapower(
                 cascade=cfg.cascade,
                 bus_couplers_mrids=bus_couplers_mrids,
             ),
+            on_progress=on_progress,
         )
     # Per-outage results are polars; concatenate in polars and convert to pandas once at the
     # very end (only when the caller wants pandas).

--- a/packages/contingency_analysis_pkg/tests/pandapower/test_contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/test_contingency_analysis_pandapower.py
@@ -11,15 +11,25 @@ import pandapower as pp
 import pandera as pa
 import polars as pl
 import pytest
+import ray
+from ray.util.queue import Queue
 from toop_engine_contingency_analysis.ac_loadflow_service.ac_loadflow_service import get_ac_loadflow_results
-from toop_engine_contingency_analysis.pandapower import get_full_nminus1_definition_pandapower
+from toop_engine_contingency_analysis.pandapower import (
+    get_full_nminus1_definition_pandapower,
+    translate_nminus1_for_pandapower,
+)
 from toop_engine_contingency_analysis.pandapower.contingency_analysis_pandapower import (
     run_contingency_analysis_pandapower,
     update_results_with_names,
 )
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.contingency_outage_group import (
+    get_outage_group_for_contingency,
+)
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     ContingencyAnalysisConfig,
+    ParallelConfig,
 )
+from toop_engine_grid_helpers.pandapower.example_grids import example_multivoltage_cross_coupler
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
 from toop_engine_interfaces.loadflow_result_helpers import extract_branch_results
 from toop_engine_interfaces.loadflow_results import RegulatingElementType
@@ -486,3 +496,166 @@ def test_basecase_deviation_is_nan_when_basecase_fails_and_defined_when_basecase
     # Validate connectivity_result
     # ------------------------------------------------------------------
     assert res.connectivity_result is None
+
+
+def _progress_definition(net: pp.pandapowerNet, contingency_limit: int | None = 10) -> Nminus1Definition:
+    """Base case plus ``contingency_limit`` N-1 cases, or the full set if ``None``."""
+    full_definition = get_full_nminus1_definition_pandapower(net)
+    basecase = [contingency for contingency in full_definition.contingencies if contingency.is_basecase()]
+    nminus1_cases = [contingency for contingency in full_definition.contingencies if not contingency.is_basecase()]
+
+    return Nminus1Definition(
+        monitored_elements=full_definition.monitored_elements,
+        contingencies=basecase + nminus1_cases[:contingency_limit],
+        id_type=full_definition.id_type,
+    )
+
+
+def _dc_config(n_processes: int, apply_outage_grouping: bool = False) -> ContingencyAnalysisConfig:
+    return ContingencyAnalysisConfig(
+        method="dc",
+        apply_outage_grouping=apply_outage_grouping,
+        parallel=ParallelConfig(n_processes=n_processes, batch_size=None),
+    )
+
+
+def test_on_progress_reports_progress_sequentially(pandapower_net: pp.pandapowerNet) -> None:
+    nminus1_def = _progress_definition(pandapower_net)
+    calls: list[tuple[int, int]] = []
+
+    run_contingency_analysis_pandapower(
+        net=pandapower_net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test_job",
+        timestep=0,
+        cfg=_dc_config(n_processes=1),
+        on_progress=lambda done, total: calls.append((done, total)),
+    )
+
+    total = calls[0][1]
+    # First report is (0, total), before any load flow.
+    assert calls[0] == (0, total)
+    dones = [done for done, _ in calls]
+    assert dones == sorted(set(dones))
+    assert all(0 <= done <= total for done in dones)
+    # Last group always reports, even if the run finishes inside one poll window.
+    assert calls[-1] == (total, total)
+    assert {reported_total for _, reported_total in calls} == {total}
+
+
+def _progress_calls(
+    net: pp.pandapowerNet, nminus1_def: Nminus1Definition, apply_outage_grouping: bool
+) -> list[tuple[int, int]]:
+    calls: list[tuple[int, int]] = []
+    run_contingency_analysis_pandapower(
+        net=net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test_job",
+        timestep=0,
+        cfg=_dc_config(n_processes=1, apply_outage_grouping=apply_outage_grouping),
+        on_progress=lambda done, total: calls.append((done, total)),
+    )
+    return calls
+
+
+def test_on_progress_total_counts_outage_groups() -> None:
+    """Progress ``total`` is the outage-group count.
+
+    Uses the cross-coupler example so grouping has switch-level structure.
+    On a bus-branch network every contingency shares one component and the
+    grouped outage takes out the slack bus.
+    """
+    net = example_multivoltage_cross_coupler()
+    nminus1_def = _progress_definition(net, contingency_limit=None)
+
+    # Translation drops contingencies whose elements are not in the network.
+    pp_def = translate_nminus1_for_pandapower(nminus1_def, net)
+    expected_contingencies = len(pp_def.contingencies)
+    expected_groups = len(get_outage_group_for_contingency(net, pp_def.contingencies))
+
+    ungrouped = _progress_calls(net, nminus1_def, apply_outage_grouping=False)
+    assert ungrouped[0] == (0, expected_contingencies)
+    assert ungrouped[-1] == (expected_contingencies,) * 2
+
+    grouped = _progress_calls(net, nminus1_def, apply_outage_grouping=True)
+    assert grouped[0] == (0, expected_groups)
+    assert grouped[-1] == (expected_groups, expected_groups)
+    assert expected_groups <= expected_contingencies
+
+
+def test_a_failing_progress_callback_does_not_fail_the_analysis(pandapower_net: pp.pandapowerNet) -> None:
+    nminus1_def = _progress_definition(pandapower_net)
+
+    def explode(done: int, total: int) -> None:
+        raise RuntimeError("callback is broken")
+
+    result = run_contingency_analysis_pandapower(
+        net=pandapower_net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test_job",
+        timestep=0,
+        cfg=_dc_config(n_processes=1),
+        on_progress=explode,
+    )
+
+    assert result is not None
+    assert not result.branch_results.empty
+
+
+@pytest.mark.xdist_group("ray")
+def test_progress_queue_carries_group_counts_from_workers(init_ray) -> None:
+    queue = Queue(actor_options={"num_cpus": 0})
+
+    @ray.remote
+    def report(target: Queue, groups: int) -> None:
+        target.put_nowait(groups)
+
+    ray.get([report.remote(queue, 2) for _ in range(3)])
+
+    assert sum(queue.get_nowait() for _ in range(3)) == 6
+
+
+@pytest.mark.xdist_group("ray")
+def test_on_progress_reports_outage_groups_on_the_parallel_path(pandapower_net: pp.pandapowerNet, init_ray) -> None:
+    nminus1_def = _progress_definition(pandapower_net)
+    calls: list[tuple[int, int]] = []
+
+    run_contingency_analysis_pandapower(
+        net=pandapower_net,
+        n_minus_1_definition=nminus1_def,
+        job_id="test_job",
+        timestep=0,
+        cfg=_dc_config(n_processes=4),
+        on_progress=lambda done, total: calls.append((done, total)),
+    )
+
+    total = calls[0][1]
+    assert calls[0] == (0, total)
+    # No-change polls are not reported.
+    dones = [done for done, _ in calls]
+    assert dones == sorted(set(dones))
+    assert all(0 <= done <= total for done in dones)
+    assert calls[-1] == (total, total)
+    assert {reported_total for _, reported_total in calls} == {total}
+
+
+@pytest.mark.xdist_group("ray")
+def test_progress_callback_does_not_change_results(pandapower_net: pp.pandapowerNet, init_ray) -> None:
+    nminus1_def = _progress_definition(pandapower_net)
+
+    def analyse(n_processes, on_progress):
+        result = run_contingency_analysis_pandapower(
+            net=pandapower_net,
+            n_minus_1_definition=nminus1_def,
+            job_id="test_job",
+            timestep=0,
+            cfg=_dc_config(n_processes=n_processes),
+            on_progress=on_progress,
+        )
+        # Parallel concatenation order is not stable; sort before comparing.
+        return result.branch_results.sort_index()
+
+    for n_processes in (1, 4):
+        with_hook = analyse(n_processes, lambda done, total: None)
+        without_hook = analyse(n_processes, None)
+        assert with_hook.equals(without_hook), f"results diverged for n_processes={n_processes}"

--- a/packages/contingency_analysis_pkg/tests/pandapower/test_contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/test_contingency_analysis_pandapower.py
@@ -575,7 +575,7 @@ def test_on_progress_total_counts_outage_groups() -> None:
 
     ungrouped = _progress_calls(net, nminus1_def, apply_outage_grouping=False)
     assert ungrouped[0] == (0, expected_contingencies)
-    assert ungrouped[-1] == (expected_contingencies,) * 2
+    assert ungrouped[-1] == (expected_contingencies, expected_contingencies)
 
     grouped = _progress_calls(net, nminus1_def, apply_outage_grouping=True)
     assert grouped[0] == (0, expected_groups)

--- a/packages/contingency_analysis_pkg/tests/pandapower/test_result_filter_wiring_pandapower.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/test_result_filter_wiring_pandapower.py
@@ -199,7 +199,7 @@ def test_the_parallel_path_is_told_which_contingency_is_the_basecase(nminus1_def
     class _Captured(Exception):
         """Raised to stop the run once the parallel context has been observed."""
 
-    def _capture(net, n_minus_1_definition, ctx):  # noqa: ANN001, ANN202, ARG001
+    def _capture(net, n_minus_1_definition, ctx, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001
         captured["ctx"] = ctx
         raise _Captured
 


### PR DESCRIPTION
## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

It doesn't, and I cannot seem to open one.

## What is the new behavior (if this is a feature change)?

A long N-1 run is currently opaque: `run_contingency_analysis_pandapower` returns only when the
whole analysis is done, so a caller cannot tell a run that is progressing from one that is stuck, and has nothing to show a user for minutes at a time.

This adds an optional `on_progress` callback to `run_contingency_analysis_pandapower`:

Few key points on the implementation:
- Counted in `outage_groups`, so the total can be smaller than the contingency list if grouping is on.
- First call is `(0, total)`, after that it runs roughly every second
- `done` is monotonic; `total` never changes
- Runs on the calling thread, never from a Ray worker, so the callback doesn't need to be thread-safe or picklable
- Exceptions raised by the callback are logged and swallowed - they never fail an analysis
- If `on_progress` is omitted the service behaves same as before
- Both sequential and parallel execution paths are covered
- Sequential reports directly from the outage loop, throttled to at most one call per second
- In Parallel, as a callable cannot be serialised into a Ray worker, workers put finished group counts on a Ray Queue, and the driver reads the queue while it waits

### Tests

- Sequential and parallel paths both report `(0, total)` first, and `(total, total)` last.
- `total` counts outage groups: asserted against both grouped and ungrouped definitions.
- A callback that raises does not fail the analysis.
- The worker queue carries group counts back to the driver.
- Results are byte-for-byte identical with and without the hook, across several `n_processes` values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
