### PR TITLE
feat: split distance protection into three zones

### DIFF
--- a/docs/contingency_analysis/cascade.md
+++ b/docs/contingency_analysis/cascade.md
@@ -51,7 +51,7 @@ flowchart TD
         end
 
         subgraph DETECT["Detect Triggers"]
-            DT["Distance Protection<br/>Impedance vs. polygon zones<br/>⚠ WARNING 🔴 DANGER"]
+            DT["Distance Protection<br/>Impedance vs. polygon zones<br/>⚠ WARNING 🟠 ALARM 🔴 DANGER"]
             OL["Current Overload<br/>loading% vs. threshold"]
         end
 
@@ -120,7 +120,7 @@ flowchart TD
 | Type | Detection | Threshold |
 |---|---|---|
 | **Current overload** | Branch loading exceeds the threshold resolved for its element type and case | Configurable per `CascadeConfig` |
-| **Distance protection** | Relay impedance falls inside warning or danger polygon zone | Defined per relay in `sw_characteristics` |
+| **Distance protection** | Relay impedance falls inside any of the three polygon zones | Defined per relay in `sw_characteristics` |
 
 ### Current overload thresholds
 
@@ -131,16 +131,21 @@ Each branch result row gets its own threshold, resolved from the element type
 (`line`, transformer, or anything else) and from whether the row belongs to the base
 case or to a contingency:
 
+These live on `CascadeConfig.overload`, an `OverloadConfig`:
+
 | Row | Threshold | Falls back to |
 |---|---|---|
-| `line`, base case | `basecase_line_loading_threshold` | `current_loading_threshold` |
-| `line`, contingency | `contingency_line_loading_threshold` | `basecase_line_loading_threshold`, then `current_loading_threshold` |
-| `trafo` / `trafo3w`, base case | `basecase_transformer_loading_threshold` | `current_loading_threshold` |
-| `trafo` / `trafo3w`, contingency | `contingency_transformer_loading_threshold` | `basecase_transformer_loading_threshold`, then `current_loading_threshold` |
-| any other table (e.g. `impedance`) | `current_loading_threshold` | — |
+| `line`, base case | `overload.basecase_line` | `overload.current_loading_threshold` |
+| `line`, contingency | `overload.contingency_line` | `overload.basecase_line`, then `overload.current_loading_threshold` |
+| `trafo` / `trafo3w`, base case | `overload.basecase_transformer` | `overload.current_loading_threshold` |
+| `trafo` / `trafo3w`, contingency | `overload.contingency_transformer` | `overload.basecase_transformer`, then `overload.current_loading_threshold` |
+| any other table (e.g. `impedance`) | `overload.current_loading_threshold` | — |
 
 All four overrides are optional. When none of them are set, every branch is compared
 against `current_loading_threshold`, exactly as before they existed.
+
+Unlike the distance-protection factors, these keep their fallback chain: the scalar
+`current_loading_threshold` is the value every row uses until a more specific one is set.
 
 ## Base-case screening
 
@@ -148,8 +153,8 @@ A base case that already violates makes every contingency cascade meaningless: t
 would start from an already-broken state, and practically every contingency would report one.
 
 Before any contingency is computed, the solved N-0 network is therefore screened once with the
-same overload and distance-protection detection the simulator uses. Both the warning and the
-danger zone count as a violation — either means the relay is already reading into its
+same overload and distance-protection detection the simulator uses. Any of the three zones
+counts as a violation — each means the relay is already reading into its
 protection characteristic in N-0.
 
 When the base case violates:
@@ -176,14 +181,25 @@ Cascade screening is opt-in. Pass a `CascadeConfig` instance when building the
 analysis context:
 
 ```python
-from toop_engine_contingency_analysis.pandapower.cascade import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import (
+    CascadeConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    OverloadConfig,
+)
 
 cascade_cfg = CascadeConfig(
     depth_limit=5,
-    current_loading_threshold=1.0,
     min_island_size=10,
-    basecase_distance_protection_factor=0.9,
-    contingency_distance_protection_factor=0.95,  # falls back to basecase factor if None
+    overload=OverloadConfig(current_loading_threshold=1.0),
+    distance_protection=DistanceProtectionConfig(
+        alarm=DistanceProtectionFactors(
+            basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+        ),
+        warning=DistanceProtectionFactors(
+            basecase_line=1.41, basecase_transformer=1.41, contingency_line=1.41, contingency_transformer=1.41
+        ),
+    ),
     cascade_log_elements=["line", "trafo", "trafo3w"],
     stop_cascade_on_basecase_violation=True,  # skip the cascade when N-0 already violates
 )
@@ -195,15 +211,70 @@ To trip lines at 150 % and transformers at 180 % instead, add the per-type overr
 ```python
 cascade_cfg = CascadeConfig(
     depth_limit=5,
-    current_loading_threshold=1.0,      # still used for e.g. impedances
-    basecase_line_loading_threshold=1.5,
-    basecase_transformer_loading_threshold=1.8,
     min_island_size=10,
-    basecase_distance_protection_factor=0.9,
-    contingency_distance_protection_factor=0.95,
+    overload=OverloadConfig(
+        current_loading_threshold=1.0,  # still used for e.g. impedances
+        basecase_line=1.5,
+        basecase_transformer=1.8,
+    ),
+    distance_protection=DistanceProtectionConfig(
+        alarm=DistanceProtectionFactors(
+            basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+        ),
+        warning=DistanceProtectionFactors(
+            basecase_line=1.41, basecase_transformer=1.41, contingency_line=1.41, contingency_transformer=1.41
+        ),
+    ),
     cascade_log_elements=["line", "trafo", "trafo3w"],
 )
 ```
+
+### Distance protection factors
+
+A factor divides the relay impedance measurement before the polygon test
+(`x = |r_ohm| / factor`), so a larger factor moves the measured point toward the origin
+and **widens** the effective area. `1.0` leaves the relay polygon exactly as the relay
+defines it.
+
+### The three zones
+
+A measurement falls into one of three nested zones. `DistanceProtectionSeverity` names them,
+innermost first:
+
+| Zone | What it is | Configurable |
+|---|---|---|
+| `DANGER` | The relay polygon exactly as the relay defines it — the real trip boundary | **No.** No factor may widen it |
+| `ALARM` | The ring just outside the danger polygon | `distance_protection.alarm` |
+| `WARNING` | The outermost ring | `distance_protection.warning` |
+
+They nest — danger inside alarm inside warning — which in factor terms means
+`1.0 <= alarm <= warning` on each axis. Nothing enforces that: a narrower warning area still
+works, because a relay inside its raw polygon trips on the danger zone regardless.
+
+A relay trips when it is inside **any** zone; the severity recorded on the event is the
+innermost zone it reached. So the warning factors are normally what decide *which* relays
+trip, while the alarm factors only move the `ALARM`/`WARNING` labelling boundary.
+
+`DistanceProtectionConfig` holds one `DistanceProtectionFactors` group per configurable zone,
+and each group carries the four case/element combinations:
+
+| | `basecase_line` | `contingency_line` | `basecase_transformer` | `contingency_transformer` |
+|---|---|---|---|---|
+| `alarm` | ✓ | ✓ | ✓ | ✓ |
+| `warning` | ✓ | ✓ | ✓ | ✓ |
+
+**All eight are required** — none has a default and none falls back to another. A
+configuration therefore always states the factor it wants on every axis, and a caller written
+against an older release fails at construction instead of silently picking up a default.
+
+!!! note "The trip boundary is not configurable"
+    The danger zone is the relay polygon untouched, so no setting here can make the
+    simulation report a trip inside a boundary the physical relay would not cross. Only the
+    two outer screening rings take factors.
+
+A relay whose `protection_element` is `None` — its protected side carries both a line and a
+transformer, or neither — takes **the larger of the line and transformer factors**, so an
+ambiguous relay is screened at least as widely as either candidate would screen it.
 
 When `cascade` is `None` in the context, the cascade step is skipped and
 `LoadflowResults.cascade_results` is an empty DataFrame.
@@ -218,11 +289,16 @@ to `net.switch` via `net.switch["origin_id"]` → `sw_characteristics["breaker_u
 |---|---|---|
 | `breaker_uuid` | `str` | Unique ID of the relay; matched against `net.switch["origin_id"]` |
 | `relay_side` | `str` | Side of the switch the relay measures from: `"bus"` or `"element"` |
+| `protection_side` | `str` | Side the relay protects, and so the side isolated when it opens: `"bus"` or `"element"` |
 | `angle` | `float` | Opening angle of the protection zone polygon (degrees) |
 | `r_i` | `float` | Inner resistance reach of the danger zone (Ω) |
 | `r_v` | `float` | Outer resistance reach of the danger zone (Ω) |
 | `x_v` | `float` | Outer reactance reach of the danger zone (Ω) |
-| `custom_warning_distance_protection` | `float` | Per-relay warning zone scale factor; overrides the global `CascadeConfig` factors when set |
+| `protection_element` | `str` or `None` | Which element the relay protects: `"line"`, `"trafo"`, or `None` when the protected side carries both or neither |
+| `custom_base_alarm` | `float` | Per-relay alarm factor for the base case; `NaN` falls back to the global factor |
+| `custom_base_warning` | `float` | Per-relay warning factor for the base case; `NaN` falls back to the global factor |
+| `custom_contingency_alarm` | `float` | Per-relay alarm factor after a contingency; `NaN` falls back to the global factor |
+| `custom_contingency_warning` | `float` | Per-relay warning factor after a contingency; `NaN` falls back to the global factor |
 
 Example:
 
@@ -233,11 +309,16 @@ net.sw_characteristics = pd.DataFrame([
     {
         "breaker_uuid": "relay-uuid-1",
         "relay_side": "bus",
+        "protection_side": "element",
         "angle": 80.0,       # degrees
         "r_i": 2.5,          # Ω
         "r_v": 10.0,         # Ω
         "x_v": 15.0,         # Ω
-        "custom_warning_distance_protection": 0.9,
+        "protection_element": "line",
+        "custom_base_alarm": float("nan"),      # no override -> global alarm factor
+        "custom_base_warning": 0.9,
+        "custom_contingency_alarm": float("nan"),
+        "custom_contingency_warning": 0.9,
     },
 ])
 
@@ -274,7 +355,7 @@ Cascade events are stored in `LoadflowResults.cascade_results`. Each row describ
 | `loading` | Branch loading value that caused the trip (current overload events) |
 | `r_ohm` | Relay resistance measurement at trip time (distance protection events) |
 | `x_ohm` | Relay reactance measurement at trip time (distance protection events) |
-| `distance_protection_severity` | How deep into the protection zone: `WARNING` or `DANGER` (distance protection events) |
+| `distance_protection_severity` | Innermost zone reached: `DANGER`, `ALARM` or `WARNING` (distance protection events) |
 | `activated_schemes_per_iter` | SpPS schemes that activated during this cascade step (JSON string) |
 
 ### Base-case violation rows

--- a/docs/contingency_analysis/cascade.md
+++ b/docs/contingency_analysis/cascade.md
@@ -194,10 +194,20 @@ cascade_cfg = CascadeConfig(
     overload=OverloadConfig(current_loading_threshold=1.0),
     distance_protection=DistanceProtectionConfig(
         alarm=DistanceProtectionFactors(
-            basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                basecase_line=1.0,
+            basecase_transformer=1.0,
+            basecase_bus_coupler=1.0,
+            contingency_line=1.0,
+            contingency_transformer=1.0,
+            contingency_bus_coupler=1.0,
         ),
         warning=DistanceProtectionFactors(
-            basecase_line=1.41, basecase_transformer=1.41, contingency_line=1.41, contingency_transformer=1.41
+                basecase_line=1.41,
+            basecase_transformer=1.41,
+            basecase_bus_coupler=1.41,
+            contingency_line=1.41,
+            contingency_transformer=1.41,
+            contingency_bus_coupler=1.41,
         ),
     ),
     cascade_log_elements=["line", "trafo", "trafo3w"],
@@ -219,10 +229,20 @@ cascade_cfg = CascadeConfig(
     ),
     distance_protection=DistanceProtectionConfig(
         alarm=DistanceProtectionFactors(
-            basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                basecase_line=1.0,
+            basecase_transformer=1.0,
+            basecase_bus_coupler=1.0,
+            contingency_line=1.0,
+            contingency_transformer=1.0,
+            contingency_bus_coupler=1.0,
         ),
         warning=DistanceProtectionFactors(
-            basecase_line=1.41, basecase_transformer=1.41, contingency_line=1.41, contingency_transformer=1.41
+                basecase_line=1.41,
+            basecase_transformer=1.41,
+            basecase_bus_coupler=1.41,
+            contingency_line=1.41,
+            contingency_transformer=1.41,
+            contingency_bus_coupler=1.41,
         ),
     ),
     cascade_log_elements=["line", "trafo", "trafo3w"],
@@ -256,25 +276,26 @@ innermost zone it reached. So the warning factors are normally what decide *whic
 trip, while the alarm factors only move the `ALARM`/`WARNING` labelling boundary.
 
 `DistanceProtectionConfig` holds one `DistanceProtectionFactors` group per configurable zone,
-and each group carries the four case/element combinations:
+and each group carries every case/element combination:
 
-| | `basecase_line` | `contingency_line` | `basecase_transformer` | `contingency_transformer` |
-|---|---|---|---|---|
-| `alarm` | ✓ | ✓ | ✓ | ✓ |
-| `warning` | ✓ | ✓ | ✓ | ✓ |
+| | `line` | `transformer` | `bus_coupler` |
+|---|---|---|---|
+| **base case** | `basecase_line` | `basecase_transformer` | `basecase_bus_coupler` |
+| **contingency** | `contingency_line` | `contingency_transformer` | `contingency_bus_coupler` |
 
-**All eight are required** — none has a default and none falls back to another. A
-configuration therefore always states the factor it wants on every axis, and a caller written
-against an older release fails at construction instead of silently picking up a default.
+Six per zone, so **twelve in total, all required** — none has a default and none falls back to
+another. A configuration therefore always states the factor it wants on every axis, and a
+caller written against an older release fails at construction instead of silently picking up
+a default.
 
 !!! note "The trip boundary is not configurable"
     The danger zone is the relay polygon untouched, so no setting here can make the
     simulation report a trip inside a boundary the physical relay would not cross. Only the
     two outer screening rings take factors.
 
-A relay whose `protection_element` is `None` — its protected side carries both a line and a
-transformer, or neither — takes **the larger of the line and transformer factors**, so an
-ambiguous relay is screened at least as widely as either candidate would screen it.
+A relay whose `protection_element` is `None` — its protected side carries no single element
+type — takes **the largest of the three factors**, so an ambiguous relay is screened at least
+as widely as any candidate would screen it.
 
 When `cascade` is `None` in the context, the cascade step is skipped and
 `LoadflowResults.cascade_results` is an empty DataFrame.
@@ -294,7 +315,7 @@ to `net.switch` via `net.switch["origin_id"]` → `sw_characteristics["breaker_u
 | `r_i` | `float` | Inner resistance reach of the danger zone (Ω) |
 | `r_v` | `float` | Outer resistance reach of the danger zone (Ω) |
 | `x_v` | `float` | Outer reactance reach of the danger zone (Ω) |
-| `protection_element` | `str` or `None` | Which element the relay protects: `"line"`, `"trafo"`, or `None` when the protected side carries both or neither |
+| `protection_element` | `str` or `None` | Which element the relay protects: `"line"`, `"trafo"`, `"bus_coupler"`, or `None` when the protected side carries no single type |
 | `custom_base_alarm` | `float` | Per-relay alarm factor for the base case; `NaN` falls back to the global factor |
 | `custom_base_warning` | `float` | Per-relay warning factor for the base case; `NaN` falls back to the global factor |
 | `custom_contingency_alarm` | `float` | Per-relay alarm factor after a contingency; `NaN` falls back to the global factor |

--- a/docs/contingency_analysis/cascade.md
+++ b/docs/contingency_analysis/cascade.md
@@ -350,6 +350,37 @@ net.switch["origin_id"] = "relay-uuid-1"
 If `sw_characteristics` is absent or empty, distance protection triggers are skipped
 and only current overload is checked.
 
+## Inspecting the resolved factors
+
+`describe_relay_zones` answers "what will this configuration actually apply to each relay"
+without running a load flow. Pass the relay table and the config, get one row per relay with
+its polygon and the factor that each zone and case resolves to:
+
+```python
+from toop_engine_contingency_analysis.pandapower.cascade.detection import describe_relay_zones
+
+described = describe_relay_zones(net.sw_characteristics, cascade_cfg)
+```
+
+It returns a copy of the relay table with every original column kept, plus:
+
+| Column | Description |
+|---|---|
+| `poly` | The protection polygon, built from `angle`, `r_i`, `r_v` and `x_v` |
+| `effective_alarm_basecase`, `effective_alarm_contingency` | Effective alarm factor for each case |
+| `effective_warning_basecase`, `effective_warning_contingency` | Effective warning factor for each case |
+
+`angle` comes back in radians. This is exactly what `prepare_cascade_run_constants` puts on
+the network before a run, so the preview and the run see the same table.
+
+The factors are resolved by the same code the cascade uses, so what you see is what a run
+applies: per-relay overrides are already folded in, and a relay with no `protection_element`
+already shows the maximum described above. The danger zone has no column, because its factor
+is always `1.0`.
+
+The input frame is not modified. `angle` is read in degrees unless a `poly` column is already
+present, which is how `prepare_cascade_run_constants` marks a table it has converted.
+
 ## Output
 
 Cascade events are stored in `LoadflowResults.cascade_results`. Each row describes one element trip at one cascade step.

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/configuration/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/configuration/__init__.py
@@ -5,6 +5,18 @@
 # you can obtain one at https://mozilla.org/MPL/2.0/.
 # Mozilla Public License, version 2.0
 
-from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
+    CascadeConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    DistanceProtectionSeverity,
+    OverloadConfig,
+)
 
-__all__ = ["CascadeConfig"]
+__all__ = [
+    "CascadeConfig",
+    "DistanceProtectionConfig",
+    "DistanceProtectionFactors",
+    "DistanceProtectionSeverity",
+    "OverloadConfig",
+]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
@@ -9,6 +9,7 @@ from .basecase_screen import BASECASE_CASCADE_NUMBER, screen_basecase_for_violat
 from .context import build_cascade_context, get_switch_characteristics, prepare_cascade_run_constants
 from .distance_protection import (
     evaluate_distance_protection_triggers,
+    get_alarm_area,
     get_danger_area,
     get_warning_area,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "build_cascade_context",
     "evaluate_distance_protection_triggers",
     "evaluate_overload_triggers",
+    "get_alarm_area",
     "get_complex_impedance",
     "get_danger_area",
     "get_switch_characteristics",

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/__init__.py
@@ -8,6 +8,7 @@
 from .basecase_screen import BASECASE_CASCADE_NUMBER, screen_basecase_for_violations
 from .context import build_cascade_context, get_switch_characteristics, prepare_cascade_run_constants
 from .distance_protection import (
+    describe_relay_zones,
     evaluate_distance_protection_triggers,
     get_alarm_area,
     get_danger_area,
@@ -27,6 +28,7 @@ from .switch_preparation import (
 __all__ = [
     "BASECASE_CASCADE_NUMBER",
     "build_cascade_context",
+    "describe_relay_zones",
     "evaluate_distance_protection_triggers",
     "evaluate_overload_triggers",
     "get_alarm_area",

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/basecase_screen.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/basecase_screen.py
@@ -24,7 +24,10 @@ import pandapower as pp
 import pandas as pd
 import pandera.typing as pat
 import polars as pl
-from toop_engine_contingency_analysis.pandapower.cascade.configuration import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import (
+    CascadeConfig,
+    DistanceProtectionSeverity,
+)
 from toop_engine_contingency_analysis.pandapower.cascade.detection.context import build_cascade_context
 from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection import (
     evaluate_distance_protection_triggers,
@@ -120,7 +123,11 @@ def _basecase_distance_protection_events(tripped: pd.DataFrame) -> list[CascadeE
             cascade_reason=CascadeReasonType.CASCADE_REASON_DISTANCE,
             r_ohm=float(row.r_ohm),
             x_ohm=float(row.x_ohm),
-            distance_protection_severity="DANGER" if bool(row.danger_inside) else "WARNING",
+            distance_protection_severity=DistanceProtectionSeverity.innermost(
+                danger_inside=bool(row.danger_inside),
+                alarm_inside=bool(row.alarm_inside),
+                warning_inside=bool(row.warning_inside),
+            ),
         )
         for row in tripped.itertuples()
     ]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/basecase_screen.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/basecase_screen.py
@@ -193,7 +193,7 @@ def screen_basecase_for_violations(
     if not switch_results_df.empty and "sw_characteristics" in net:
         cascade_context = build_cascade_context(net, all_cb_couplers)
         switch_prepared = prepare_switch_results_for_protection(net, switch_results_df, cascade_context=cascade_context)
-        tripped = evaluate_distance_protection_triggers(switch_prepared, cascade_configuration)
+        tripped = evaluate_distance_protection_triggers(switch_prepared)
         relay_events = _basecase_distance_protection_events(tripped)
 
     if overload_events or relay_events:

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/context.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/context.py
@@ -19,7 +19,8 @@ def get_switch_characteristics(net: pp.pandapowerNet, closed_status: bool | None
     """Build the relay information table used by cascade checks.
 
     This combines pandapower switch rows with their protection settings, such as
-    relay side and distance protection shape. The ``angle``/``poly`` columns of
+    relay side, protected element type, the per-relay factor overrides and the
+    distance protection shape. The ``angle``/``poly`` columns of
     ``net.sw_characteristics`` are expected to be already prepared (radians +
     polygon) by :func:`prepare_cascade_run_constants`; this function only reads
     them.
@@ -41,7 +42,20 @@ def get_switch_characteristics(net: pp.pandapowerNet, closed_status: bool | None
 
     return filtered_switches[["bus", "element", "origin_id"]].merge(
         net.sw_characteristics[
-            ["breaker_uuid", "poly", "relay_side", "protection_side", "custom_warning_distance_protection"]
+            [
+                "breaker_uuid",
+                "poly",
+                "relay_side",
+                "protection_side",
+                # Which element the relay protects ("line", "trafo", or None when the protected
+                # side carries both or neither); picks the element-type axis of the global factor.
+                "protection_element",
+                # Per-relay factor overrides, by severity and case. NaN falls back to the global.
+                "custom_base_alarm",
+                "custom_base_warning",
+                "custom_contingency_alarm",
+                "custom_contingency_warning",
+            ]
         ],
         left_on="origin_id",
         right_on="breaker_uuid",

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/context.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/context.py
@@ -7,10 +7,10 @@
 
 """Build shared cascade detection context from a pandapower network."""
 
-import numpy as np
 import pandapower as pp
 import pandas as pd
-from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection import _build_poly
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection import describe_relay_zones
 from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeContext
 from toop_engine_contingency_analysis.pandapower.cascade.outage_groups.topology import get_busbars_couplers
 
@@ -47,14 +47,13 @@ def get_switch_characteristics(net: pp.pandapowerNet, closed_status: bool | None
                 "poly",
                 "relay_side",
                 "protection_side",
-                # Which element the relay protects ("line", "trafo", or None when the protected
-                # side carries both or neither); picks the element-type axis of the global factor.
-                "protection_element",
-                # Per-relay factor overrides, by severity and case. NaN falls back to the global.
-                "custom_base_alarm",
-                "custom_base_warning",
-                "custom_contingency_alarm",
-                "custom_contingency_warning",
+                # The factor each relay resolves to, per zone and case. prepare_cascade_run_constants
+                # folded protection_element and the custom_* overrides into these once per job, so
+                # neither is needed here. The names must match what resolve_effective_factors writes.
+                "effective_alarm_basecase",
+                "effective_alarm_contingency",
+                "effective_warning_basecase",
+                "effective_warning_contingency",
             ]
         ],
         left_on="origin_id",
@@ -63,15 +62,22 @@ def get_switch_characteristics(net: pp.pandapowerNet, closed_status: bool | None
     )
 
 
-def prepare_cascade_run_constants(net: pp.pandapowerNet) -> set[str]:
+def prepare_cascade_run_constants(net: pp.pandapowerNet, cascade_configuration: CascadeConfig) -> set[str]:
     """Compute per-run cascade constants once, on the base-case network.
 
     Two things are prepared here so they are not redone for every outage:
 
-    1. ``net.sw_characteristics`` is converted in place — ``angle`` to radians and
-       the derived ``poly`` polygon — so the (per-outage) :func:`build_cascade_context`
-       becomes a pure read. The conversion is idempotent: ``poly`` acts as a sentinel,
-       so calling this twice on the same net (e.g. a reused network) is safe.
+    1. ``net.sw_characteristics`` is replaced by a prepared copy from
+       :func:`~toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection.describe_relay_zones`
+       — ``angle`` in radians, the derived ``poly`` polygon, and the factor every relay
+       resolves to for both zones and both cases — so the per-outage
+       :func:`build_cascade_context` becomes a pure read.
+
+       A relay's factor depends only on the relay and the configuration, never on which
+       contingency is running, so the element-type lookup and the override fallback happen
+       once here instead of twice per outage. The polygon conversion is idempotent, ``poly``
+       acting as the sentinel, while the factors are rewritten on every call so a second call
+       with a different configuration cannot leave stale ones behind.
     2. The busbar-coupler classification is computed for **all** ``CB`` switches on
        the base-case (all-closed) topology. Per outage, :func:`build_cascade_context`
        just intersects this set with the currently closed switches.
@@ -79,7 +85,10 @@ def prepare_cascade_run_constants(net: pp.pandapowerNet) -> set[str]:
     Parameters
     ----------
     net : pp.pandapowerNet
-        Base-case pandapower network (switch topology applied). Mutated in place.
+        Base-case pandapower network (switch topology applied). Its ``sw_characteristics``
+        table is replaced with the prepared one.
+    cascade_configuration : CascadeConfig
+        Cascade settings the factors are resolved from.
 
     Returns
     -------
@@ -90,12 +99,9 @@ def prepare_cascade_run_constants(net: pp.pandapowerNet) -> set[str]:
     if "sw_characteristics" not in net:
         return set()
 
-    # Create ``poly`` even when the table is empty so the per-outage merge in
-    # ``get_switch_characteristics`` still finds the column (mirrors the previous
-    # unconditional conversion). ``poly`` doubles as the idempotency sentinel.
-    if "poly" not in net.sw_characteristics.columns:
-        net.sw_characteristics["angle"] = np.radians(net.sw_characteristics["angle"])
-        net.sw_characteristics["poly"] = net.sw_characteristics.apply(_build_poly, axis=1)
+    # The prepared copy carries every original column plus poly and the factor columns, so it
+    # can simply replace the table the per-outage merge reads from.
+    net["sw_characteristics"] = describe_relay_zones(net.sw_characteristics, cascade_configuration)
 
     cb_origin_ids = net.switch.loc[net.switch.type == "CB", "origin_id"].tolist()
     return set(get_busbars_couplers(net, cb_origin_ids))

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
@@ -13,7 +13,10 @@ import numpy as np
 import pandas as pd
 import shapely
 from shapely.geometry import Polygon
-from toop_engine_contingency_analysis.pandapower.cascade.configuration import CascadeConfig
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import (
+    CascadeConfig,
+    DistanceProtectionSeverity,
+)
 from toop_engine_contingency_analysis.pandapower.cascade.detection.switch_preparation import (
     get_complex_impedance,
 )
@@ -47,47 +50,160 @@ def _build_poly(row: pd.Series) -> Polygon:
     )
 
 
-def get_warning_area(
+def _effective_factors(
     df: pd.DataFrame,
-    basecase_distance_protection_factor: float,
-    contingency_distance_protection_factor: float,
-) -> pd.Series:
-    """Check whether each relay measurement is inside the warning area.
+    cascade_configuration: CascadeConfig,
+    severity: DistanceProtectionSeverity,
+) -> np.ndarray:
+    """Resolve the impedance factor that applies to each relay measurement.
 
-    The warning area is a larger version of the danger area. It marks cases
-    that are not yet in the strict trip zone but are close enough to continue
-    the cascade check.
+    A measurement is divided by its factor before being tested against the relay polygon
+    (``x = |r_ohm| / factor``), so the factor is what widens or narrows the effective zone.
+    Which factor a given row gets is decided on three independent axes:
+
+    - **severity** - from the ``severity`` argument. Fixed for the whole call rather than
+      per row, because one call tests one zone.
+    - **case** - whether the row is the base case or a contingency, from the ``contingency``
+      column.
+    - **protected element type** - line or transformer, from the ``protection_element``
+      column.
+
+    Two sources can supply the value for those three axes, the first that has one winning:
+
+    1. the per-relay override column for this row's severity and case, where it is not NaN;
+    2. otherwise the global factor configured for that severity, case and element type.
+
+    The steps below take one axis at a time. Each is a whole-column numpy operation: this
+    runs twice per outage over every monitored relay, so nothing walks the frame row by row.
 
     Parameters
     ----------
     df : pd.DataFrame
-        Switch result table with impedance values and protection polygons.
-    basecase_distance_protection_factor : float
-        Warning-area scale for basecase rows.
-    contingency_distance_protection_factor : float
-        Warning-area scale for contingency rows.
+        Switch result table, carrying ``contingency``, ``protection_element`` and the four
+        ``custom_*`` override columns.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the eight global factors.
+    severity : DistanceProtectionSeverity
+        Which zone is being tested, and so which factor group and override columns apply.
+        Only ``ALARM`` and ``WARNING`` are configurable; ``DANGER`` raises.
+
+    Returns
+    -------
+    np.ndarray
+        One factor per row, as a per-unit ratio.
+    """
+    # Step 1: severity. One call tests one zone, so this is picked once, not per row. It
+    # decides both the factor group and which two override columns the steps below read.
+    distance_protection = cascade_configuration.distance_protection
+    if severity is DistanceProtectionSeverity.ALARM:
+        factors = distance_protection.alarm
+        basecase_column, contingency_column = "custom_base_alarm", "custom_contingency_alarm"
+    elif severity is DistanceProtectionSeverity.WARNING:
+        factors = distance_protection.warning
+        basecase_column, contingency_column = "custom_base_warning", "custom_contingency_warning"
+    else:
+        # DANGER has no factors: it is the relay polygon itself.
+        raise ValueError(f"{severity} has no factors; the danger area is the raw relay polygon")
+
+    # Step 2: case. Leaves one line factor and one transformer factor per row.
+    is_basecase = (df["contingency"] == "BASECASE").to_numpy()
+    line = np.where(is_basecase, factors.basecase_line, factors.contingency_line)
+    transformer = np.where(is_basecase, factors.basecase_transformer, factors.contingency_transformer)
+
+    # Step 3: element type. Which of the two factors each row is entitled to.
+    #
+    # Use .eq, not ==: on an empty frame the column can arrive as float64, and numpy would
+    # then return a scalar False instead of an empty mask.
+    is_line = df["protection_element"].eq("line").to_numpy()
+    is_transformer = df["protection_element"].eq("trafo").to_numpy()
+
+    # Step 4: start every row on the unknown-type factor.
+    #
+    # protection_element is None when the protected side has both a line and a transformer,
+    # or neither. The larger factor gives the wider area, so a relay of unknown type is
+    # never screened too narrowly.
+    global_factors = np.maximum(line, transformer)
+
+    # Step 5: rows whose type is known take that type's factor instead.
+    global_factors = np.where(is_line, line, global_factors)
+    global_factors = np.where(is_transformer, transformer, global_factors)
+
+    # Step 6: the relay's own override wins where it set one. Only the column for the row's
+    # case is read, so a relay can override the base case and not the contingency, or vice versa.
+    overrides = np.where(is_basecase, df[basecase_column].to_numpy(), df[contingency_column].to_numpy())
+    return np.where(pd.isna(overrides), global_factors, overrides).astype(float)
+
+
+def _inside_area(df: pd.DataFrame, effective_factors: np.ndarray) -> pd.Series:
+    """Test each relay measurement against its polygon, scaled by ``effective_factors``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Switch result table with ``r_ohm``, ``x_ohm`` and ``poly``.
+    effective_factors : np.ndarray
+        One factor per row, from :func:`_effective_factors`.
 
     Returns
     -------
     pd.Series
-        Boolean series where True means the row is inside the warning area.
+        Boolean series where True means the row is inside the scaled area.
     """
-    fallback_factors = np.where(
-        df["contingency"] == "BASECASE",
-        basecase_distance_protection_factor,
-        contingency_distance_protection_factor,
-    )
-    factors = df["custom_warning_distance_protection"].to_numpy()
-    effective_factors = np.where(pd.isna(factors), fallback_factors, factors)
-
     x = (np.abs(df["r_ohm"].to_numpy()) / effective_factors).astype(float)
     y = (np.abs(df["x_ohm"].to_numpy()) / effective_factors).astype(float)
     flags = shapely.covers(df["poly"].to_numpy(), shapely.points(x, y))
     return pd.Series(flags, index=df.index)
 
 
+def get_warning_area(df: pd.DataFrame, cascade_configuration: CascadeConfig) -> pd.Series:
+    """Check whether each relay measurement is inside the warning area.
+
+    The warning area is the outermost of the three zones, so this is what decides whether a
+    relay trips at all; the other two only say how deep the trip went.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Switch result table with impedance values and protection polygons.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the warning factors.
+
+    Returns
+    -------
+    pd.Series
+        Boolean series where True means the row is inside the warning area.
+    """
+    return _inside_area(df, _effective_factors(df, cascade_configuration, DistanceProtectionSeverity.WARNING))
+
+
+def get_alarm_area(df: pd.DataFrame, cascade_configuration: CascadeConfig) -> pd.Series:
+    """Check whether each relay measurement is inside the alarm area.
+
+    The alarm area sits between the danger polygon and the warning area. It does not add
+    trips of its own - every row inside it is already inside the wider warning area - it only
+    separates an ``ALARM``-labelled trip from a ``WARNING``-labelled one.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Switch result table with impedance values and protection polygons.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the alarm factors.
+
+    Returns
+    -------
+    pd.Series
+        Boolean series where True means the row is inside the alarm area.
+    """
+    return _inside_area(df, _effective_factors(df, cascade_configuration, DistanceProtectionSeverity.ALARM))
+
+
 def get_danger_area(df: pd.DataFrame) -> pd.Series:
     """Check whether each relay measurement is inside the danger area.
+
+    The danger area is the relay polygon exactly as the relay defines it - the real trip
+    boundary. It takes no configuration on purpose: a factor here would make the simulation
+    report trips the physical relay would never perform.
 
     Parameters
     ----------
@@ -99,10 +215,8 @@ def get_danger_area(df: pd.DataFrame) -> pd.Series:
     pd.Series
         Boolean series where True means the row is inside the danger area.
     """
-    x = np.abs(df["r_ohm"].to_numpy())
-    y = np.abs(df["x_ohm"].to_numpy())
-    flags = shapely.covers(df["poly"].to_numpy(), shapely.points(x, y))
-    return pd.Series(flags, index=df.index)
+    # A factor of 1.0 on every row leaves the measurement untouched.
+    return _inside_area(df, np.ones(len(df.index)))
 
 
 def evaluate_distance_protection_triggers(
@@ -111,23 +225,29 @@ def evaluate_distance_protection_triggers(
 ) -> pd.DataFrame:
     """Find switches that should trip because of distance protection.
 
+    A row trips when it is inside any of the three zones. With the zones nested as expected
+    that is just the warning area, but the union is what is actually taken, so a configuration
+    with a warning area narrower than the relay polygon still trips on the danger zone. All
+    three flags travel with the rows so the caller can label each trip with
+    :meth:`DistanceProtectionSeverity.innermost`.
+
     Parameters
     ----------
     switch_results : pd.DataFrame
         Switch result table already joined with relay characteristics.
     cascade_configuration : CascadeConfig
-        Cascade settings with warning-area factors.
+        Cascade settings with the alarm and warning factors.
 
     Returns
     -------
     pd.DataFrame
-        Subset of switch_results that is inside the warning or danger area.
+        Subset of switch_results inside at least one zone, carrying the ``danger_inside``,
+        ``alarm_inside`` and ``warning_inside`` flags.
     """
     switch_results["r_ohm"], switch_results["x_ohm"] = get_complex_impedance(switch_results)
     switch_results["danger_inside"] = get_danger_area(switch_results)
-    switch_results["warning_inside"] = get_warning_area(
-        switch_results,
-        basecase_distance_protection_factor=cascade_configuration.basecase_distance_protection_factor,
-        contingency_distance_protection_factor=cascade_configuration.contingency_distance_protection_factor,
-    )
-    return switch_results[switch_results["warning_inside"] | switch_results["danger_inside"]]
+    switch_results["alarm_inside"] = get_alarm_area(switch_results, cascade_configuration)
+    switch_results["warning_inside"] = get_warning_area(switch_results, cascade_configuration)
+    return switch_results[
+        switch_results["warning_inside"] | switch_results["alarm_inside"] | switch_results["danger_inside"]
+    ]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
@@ -65,8 +65,8 @@ def _effective_factors(
       per row, because one call tests one zone.
     - **case** - whether the row is the base case or a contingency, from the ``contingency``
       column.
-    - **protected element type** - line or transformer, from the ``protection_element``
-      column.
+    - **protected element type** - line, transformer or bus coupler, from the
+      ``protection_element`` column.
 
     Two sources can supply the value for those three axes, the first that has one winning:
 
@@ -105,28 +105,31 @@ def _effective_factors(
         # DANGER has no factors: it is the relay polygon itself.
         raise ValueError(f"{severity} has no factors; the danger area is the raw relay polygon")
 
-    # Step 2: case. Leaves one line factor and one transformer factor per row.
+    # Step 2: case. Leaves one factor per element type per row.
     is_basecase = (df["contingency"] == "BASECASE").to_numpy()
     line = np.where(is_basecase, factors.basecase_line, factors.contingency_line)
     transformer = np.where(is_basecase, factors.basecase_transformer, factors.contingency_transformer)
+    bus_coupler = np.where(is_basecase, factors.basecase_bus_coupler, factors.contingency_bus_coupler)
 
-    # Step 3: element type. Which of the two factors each row is entitled to.
+    # Step 3: element type. Which of those factors each row is entitled to.
     #
     # Use .eq, not ==: on an empty frame the column can arrive as float64, and numpy would
     # then return a scalar False instead of an empty mask.
     is_line = df["protection_element"].eq("line").to_numpy()
     is_transformer = df["protection_element"].eq("trafo").to_numpy()
+    is_bus_coupler = df["protection_element"].eq("bus_coupler").to_numpy()
 
     # Step 4: start every row on the unknown-type factor.
     #
-    # protection_element is None when the protected side has both a line and a transformer,
-    # or neither. The larger factor gives the wider area, so a relay of unknown type is
-    # never screened too narrowly.
-    global_factors = np.maximum(line, transformer)
+    # protection_element is None when the protected side carries no single element type. The
+    # largest factor gives the widest area, so a relay of unknown type is never screened too
+    # narrowly.
+    global_factors = np.maximum(np.maximum(line, transformer), bus_coupler)
 
     # Step 5: rows whose type is known take that type's factor instead.
     global_factors = np.where(is_line, line, global_factors)
     global_factors = np.where(is_transformer, transformer, global_factors)
+    global_factors = np.where(is_bus_coupler, bus_coupler, global_factors)
 
     # Step 6: the relay's own override wins where it set one. Only the column for the row's
     # case is read, so a relay can override the base case and not the contingency, or vice versa.

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/distance_protection.py
@@ -50,91 +50,121 @@ def _build_poly(row: pd.Series) -> Polygon:
     )
 
 
-def _effective_factors(
-    df: pd.DataFrame,
+def _resolve_one_case(
+    relays: pd.DataFrame,
     cascade_configuration: CascadeConfig,
     severity: DistanceProtectionSeverity,
+    *,
+    basecase: bool,
 ) -> np.ndarray:
-    """Resolve the impedance factor that applies to each relay measurement.
+    """Resolve the factor each relay gets for one zone and one case.
 
     A measurement is divided by its factor before being tested against the relay polygon
     (``x = |r_ohm| / factor``), so the factor is what widens or narrows the effective zone.
-    Which factor a given row gets is decided on three independent axes:
+    Two sources can supply it, the first that has one winning:
 
-    - **severity** - from the ``severity`` argument. Fixed for the whole call rather than
-      per row, because one call tests one zone.
-    - **case** - whether the row is the base case or a contingency, from the ``contingency``
-      column.
-    - **protected element type** - line, transformer or bus coupler, from the
-      ``protection_element`` column.
+    1. the per-relay override column for this zone and case, where it is not NaN;
+    2. otherwise the global factor configured for this zone, case and element type.
 
-    Two sources can supply the value for those three axes, the first that has one winning:
-
-    1. the per-relay override column for this row's severity and case, where it is not NaN;
-    2. otherwise the global factor configured for that severity, case and element type.
-
-    The steps below take one axis at a time. Each is a whole-column numpy operation: this
-    runs twice per outage over every monitored relay, so nothing walks the frame row by row.
+    Zone and case are both fixed by the arguments, so only the element type varies per row and
+    the global factors are plain scalars here.
 
     Parameters
     ----------
-    df : pd.DataFrame
-        Switch result table, carrying ``contingency``, ``protection_element`` and the four
-        ``custom_*`` override columns.
+    relays : pd.DataFrame
+        Relay table with ``protection_element`` and the four ``custom_*`` override columns.
     cascade_configuration : CascadeConfig
-        Cascade settings holding the eight global factors.
+        Cascade settings holding the alarm and warning factors.
     severity : DistanceProtectionSeverity
-        Which zone is being tested, and so which factor group and override columns apply.
-        Only ``ALARM`` and ``WARNING`` are configurable; ``DANGER`` raises.
+        Which zone to resolve. Only ``ALARM`` and ``WARNING`` are configurable.
+    basecase : bool
+        Resolve the base-case factors rather than the contingency ones.
 
     Returns
     -------
     np.ndarray
-        One factor per row, as a per-unit ratio.
+        One factor per relay, as a per-unit ratio.
     """
-    # Step 1: severity. One call tests one zone, so this is picked once, not per row. It
-    # decides both the factor group and which two override columns the steps below read.
+    # Step 1: zone. Fixes the factor group and which override column applies.
     distance_protection = cascade_configuration.distance_protection
     if severity is DistanceProtectionSeverity.ALARM:
         factors = distance_protection.alarm
-        basecase_column, contingency_column = "custom_base_alarm", "custom_contingency_alarm"
+        override_column = "custom_base_alarm" if basecase else "custom_contingency_alarm"
     elif severity is DistanceProtectionSeverity.WARNING:
         factors = distance_protection.warning
-        basecase_column, contingency_column = "custom_base_warning", "custom_contingency_warning"
+        override_column = "custom_base_warning" if basecase else "custom_contingency_warning"
     else:
         # DANGER has no factors: it is the relay polygon itself.
         raise ValueError(f"{severity} has no factors; the danger area is the raw relay polygon")
 
-    # Step 2: case. Leaves one factor per element type per row.
-    is_basecase = (df["contingency"] == "BASECASE").to_numpy()
-    line = np.where(is_basecase, factors.basecase_line, factors.contingency_line)
-    transformer = np.where(is_basecase, factors.basecase_transformer, factors.contingency_transformer)
-    bus_coupler = np.where(is_basecase, factors.basecase_bus_coupler, factors.contingency_bus_coupler)
+    # Step 2: case. Fixed for the whole call, so one scalar per element type.
+    if basecase:
+        line, transformer, bus_coupler = (
+            factors.basecase_line,
+            factors.basecase_transformer,
+            factors.basecase_bus_coupler,
+        )
+    else:
+        line, transformer, bus_coupler = (
+            factors.contingency_line,
+            factors.contingency_transformer,
+            factors.contingency_bus_coupler,
+        )
 
-    # Step 3: element type. Which of those factors each row is entitled to.
+    # Step 3: element type. Which of those scalars each row is entitled to.
     #
     # Use .eq, not ==: on an empty frame the column can arrive as float64, and numpy would
     # then return a scalar False instead of an empty mask.
-    is_line = df["protection_element"].eq("line").to_numpy()
-    is_transformer = df["protection_element"].eq("trafo").to_numpy()
-    is_bus_coupler = df["protection_element"].eq("bus_coupler").to_numpy()
+    is_line = relays["protection_element"].eq("line").to_numpy()
+    is_transformer = relays["protection_element"].eq("trafo").to_numpy()
+    is_bus_coupler = relays["protection_element"].eq("bus_coupler").to_numpy()
 
     # Step 4: start every row on the unknown-type factor.
     #
     # protection_element is None when the protected side carries no single element type. The
     # largest factor gives the widest area, so a relay of unknown type is never screened too
     # narrowly.
-    global_factors = np.maximum(np.maximum(line, transformer), bus_coupler)
+    global_factors = np.full(len(relays.index), max(line, transformer, bus_coupler), dtype=float)
 
     # Step 5: rows whose type is known take that type's factor instead.
     global_factors = np.where(is_line, line, global_factors)
     global_factors = np.where(is_transformer, transformer, global_factors)
     global_factors = np.where(is_bus_coupler, bus_coupler, global_factors)
 
-    # Step 6: the relay's own override wins where it set one. Only the column for the row's
-    # case is read, so a relay can override the base case and not the contingency, or vice versa.
-    overrides = np.where(is_basecase, df[basecase_column].to_numpy(), df[contingency_column].to_numpy())
+    # Step 6: the relay's own override wins where it set one.
+    overrides = relays[override_column].to_numpy()
     return np.where(pd.isna(overrides), global_factors, overrides).astype(float)
+
+
+def resolve_effective_factors(
+    relays: pd.DataFrame,
+    cascade_configuration: CascadeConfig,
+) -> dict[str, np.ndarray]:
+    """Resolve every relay's factor for both configurable zones and both cases.
+
+    The result depends only on the relay and the configuration, never on which contingency is
+    being computed, so this runs once per job rather than once per outage.
+
+    Parameters
+    ----------
+    relays : pd.DataFrame
+        Relay table with ``protection_element`` and the four ``custom_*`` override columns.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the alarm and warning factors.
+
+    Returns
+    -------
+    dict[str, np.ndarray]
+        One entry per zone and case, keyed by the column name it is written to.
+    """
+    alarm = DistanceProtectionSeverity.ALARM
+    warning = DistanceProtectionSeverity.WARNING
+    return {
+        "effective_alarm_basecase": _resolve_one_case(relays, cascade_configuration, alarm, basecase=True),
+        "effective_alarm_contingency": _resolve_one_case(relays, cascade_configuration, alarm, basecase=False),
+        "effective_warning_basecase": _resolve_one_case(relays, cascade_configuration, warning, basecase=True),
+        "effective_warning_contingency": _resolve_one_case(relays, cascade_configuration, warning, basecase=False),
+    }
 
 
 def _inside_area(df: pd.DataFrame, effective_factors: np.ndarray) -> pd.Series:
@@ -145,7 +175,7 @@ def _inside_area(df: pd.DataFrame, effective_factors: np.ndarray) -> pd.Series:
     df : pd.DataFrame
         Switch result table with ``r_ohm``, ``x_ohm`` and ``poly``.
     effective_factors : np.ndarray
-        One factor per row, from :func:`_effective_factors`.
+        One factor per row.
 
     Returns
     -------
@@ -158,7 +188,7 @@ def _inside_area(df: pd.DataFrame, effective_factors: np.ndarray) -> pd.Series:
     return pd.Series(flags, index=df.index)
 
 
-def get_warning_area(df: pd.DataFrame, cascade_configuration: CascadeConfig) -> pd.Series:
+def get_warning_area(df: pd.DataFrame) -> pd.Series:
     """Check whether each relay measurement is inside the warning area.
 
     The warning area is the outermost of the three zones, so this is what decides whether a
@@ -167,38 +197,48 @@ def get_warning_area(df: pd.DataFrame, cascade_configuration: CascadeConfig) -> 
     Parameters
     ----------
     df : pd.DataFrame
-        Switch result table with impedance values and protection polygons.
-    cascade_configuration : CascadeConfig
-        Cascade settings holding the warning factors.
+        Switch result table with impedance values, protection polygons, ``contingency`` and
+        the warning factor columns written by :func:`resolve_effective_factors`.
 
     Returns
     -------
     pd.Series
         Boolean series where True means the row is inside the warning area.
     """
-    return _inside_area(df, _effective_factors(df, cascade_configuration, DistanceProtectionSeverity.WARNING))
+    is_basecase = (df["contingency"] == "BASECASE").to_numpy()
+    effective_factors = np.where(
+        is_basecase,
+        df["effective_warning_basecase"].to_numpy(),
+        df["effective_warning_contingency"].to_numpy(),
+    ).astype(float)
+    return _inside_area(df, effective_factors)
 
 
-def get_alarm_area(df: pd.DataFrame, cascade_configuration: CascadeConfig) -> pd.Series:
+def get_alarm_area(df: pd.DataFrame) -> pd.Series:
     """Check whether each relay measurement is inside the alarm area.
 
-    The alarm area sits between the danger polygon and the warning area. It does not add
-    trips of its own - every row inside it is already inside the wider warning area - it only
+    The alarm area sits between the danger polygon and the warning area. It does not add trips
+    of its own - every row inside it is already inside the wider warning area - it only
     separates an ``ALARM``-labelled trip from a ``WARNING``-labelled one.
 
     Parameters
     ----------
     df : pd.DataFrame
-        Switch result table with impedance values and protection polygons.
-    cascade_configuration : CascadeConfig
-        Cascade settings holding the alarm factors.
+        Switch result table with impedance values, protection polygons, ``contingency`` and
+        the alarm factor columns written by :func:`resolve_effective_factors`.
 
     Returns
     -------
     pd.Series
         Boolean series where True means the row is inside the alarm area.
     """
-    return _inside_area(df, _effective_factors(df, cascade_configuration, DistanceProtectionSeverity.ALARM))
+    is_basecase = (df["contingency"] == "BASECASE").to_numpy()
+    effective_factors = np.where(
+        is_basecase,
+        df["effective_alarm_basecase"].to_numpy(),
+        df["effective_alarm_contingency"].to_numpy(),
+    ).astype(float)
+    return _inside_area(df, effective_factors)
 
 
 def get_danger_area(df: pd.DataFrame) -> pd.Series:
@@ -222,10 +262,49 @@ def get_danger_area(df: pd.DataFrame) -> pd.Series:
     return _inside_area(df, np.ones(len(df.index)))
 
 
-def evaluate_distance_protection_triggers(
-    switch_results: pd.DataFrame,
+def describe_relay_zones(
+    sw_characteristics: pd.DataFrame,
     cascade_configuration: CascadeConfig,
 ) -> pd.DataFrame:
+    """Prepare a relay table: derive its polygons and resolve its effective factors.
+
+    Everything a relay needs before any load flow runs. Also answers "what will this
+    configuration actually apply to each relay", which otherwise only becomes visible once a
+    cascade has run.
+
+    The danger zone gets no column: it is the polygon itself, so its factor is always ``1.0``.
+
+    Parameters
+    ----------
+    sw_characteristics : pd.DataFrame
+        Relay table as attached to ``net.sw_characteristics``: ``breaker_uuid``,
+        ``protection_element``, the polygon dimensions (``angle``, ``r_i``, ``r_v``, ``x_v``)
+        and the four ``custom_*`` override columns. Not modified. ``angle`` is read in degrees
+        unless a ``poly`` column is already present, which marks a table already prepared.
+    cascade_configuration : CascadeConfig
+        Cascade settings holding the alarm and warning factors.
+
+    Returns
+    -------
+    pd.DataFrame
+        A copy of the input carrying every original column, with ``angle`` converted to
+        radians, the derived ``poly`` polygon, and one factor column per zone and case as
+        written by :func:`resolve_effective_factors`.
+    """
+    relays = sw_characteristics.copy()
+    if "poly" not in relays.columns:
+        relays["angle"] = np.radians(relays["angle"])
+        # apply over an empty frame returns a DataFrame, which cannot be assigned as a column.
+        relays["poly"] = (
+            relays.apply(_build_poly, axis=1) if not relays.empty else pd.Series(dtype=object, index=relays.index)
+        )
+
+    for column, values in resolve_effective_factors(relays, cascade_configuration).items():
+        relays[column] = values
+    return relays
+
+
+def evaluate_distance_protection_triggers(switch_results: pd.DataFrame) -> pd.DataFrame:
     """Find switches that should trip because of distance protection.
 
     A row trips when it is inside any of the three zones. With the zones nested as expected
@@ -237,9 +316,8 @@ def evaluate_distance_protection_triggers(
     Parameters
     ----------
     switch_results : pd.DataFrame
-        Switch result table already joined with relay characteristics.
-    cascade_configuration : CascadeConfig
-        Cascade settings with the alarm and warning factors.
+        Switch result table already joined with relay characteristics, so it carries the
+        polygons and the precomputed factor columns.
 
     Returns
     -------
@@ -249,8 +327,8 @@ def evaluate_distance_protection_triggers(
     """
     switch_results["r_ohm"], switch_results["x_ohm"] = get_complex_impedance(switch_results)
     switch_results["danger_inside"] = get_danger_area(switch_results)
-    switch_results["alarm_inside"] = get_alarm_area(switch_results, cascade_configuration)
-    switch_results["warning_inside"] = get_warning_area(switch_results, cascade_configuration)
+    switch_results["alarm_inside"] = get_alarm_area(switch_results)
+    switch_results["warning_inside"] = get_warning_area(switch_results)
     return switch_results[
         switch_results["warning_inside"] | switch_results["alarm_inside"] | switch_results["danger_inside"]
     ]

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/overload.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/detection/overload.py
@@ -75,11 +75,11 @@ def resolve_loading_thresholds(
     # Both transformer tables resolve to the same threshold, so "trafo" stands for both.
     is_transformer = np.isin(element_tables, list(TRANSFORMER_TABLES))
 
-    line_basecase = cascade_configuration.loading_threshold("line", basecase=True)
-    line_contingency = cascade_configuration.loading_threshold("line", basecase=False)
-    transformer_basecase = cascade_configuration.loading_threshold("trafo", basecase=True)
-    transformer_contingency = cascade_configuration.loading_threshold("trafo", basecase=False)
-    other = cascade_configuration.current_loading_threshold
+    line_basecase = cascade_configuration.overload.threshold("line", basecase=True)
+    line_contingency = cascade_configuration.overload.threshold("line", basecase=False)
+    transformer_basecase = cascade_configuration.overload.threshold("trafo", basecase=True)
+    transformer_contingency = cascade_configuration.overload.threshold("trafo", basecase=False)
+    other = cascade_configuration.overload.current_loading_threshold
 
     # Every row starts at the scalar threshold; lines and transformers overwrite it.
     thresholds = np.full(len(current_res), other, dtype=float)

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/models.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/models.py
@@ -62,7 +62,11 @@ class CascadeEvent:
     """Identifier of the outage group that produced this event, if available."""
 
     distance_protection_severity: Optional[str] = None
-    """Optional severity label for distance protection events."""
+    """Which distance-protection zone the measurement fell into.
+
+    One of :class:`~toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas.DistanceProtectionSeverity`
+    (``"ALARM"`` or ``"WARNING"``), or None for events that are not relay trips.
+    """
 
     activated_schemes_per_iter: str | None = None
     """JSON string of SpPS scheme names that activated per inner load-flow iteration."""

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/outage_groups/events.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/outage_groups/events.py
@@ -11,6 +11,7 @@ import hashlib
 
 import pandapower as pp
 import pandera.typing as pat
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import DistanceProtectionSeverity
 from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeEvent, CascadeReasonType
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
 from toop_engine_interfaces.loadflow_results import BranchResultSchema, SwitchResultsSchema
@@ -68,7 +69,11 @@ def get_outage_group_distance_protection_log_info(
     events = []
     for ind, out_gr in outage_groups.items():
         element = tripped_switches_df[tripped_switches_df.switch_id == ind].iloc[0]
-        severity = "DANGER" if bool(element.danger_inside) else "WARNING"
+        severity = DistanceProtectionSeverity.innermost(
+            danger_inside=bool(element.danger_inside),
+            alarm_inside=bool(element.alarm_inside),
+            warning_inside=bool(element.warning_inside),
+        )
         outage_group_id = _hash_outage_group_element_names(net, out_gr)
 
         for idx, el_type in out_gr:

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/cascade/simulation/simulator.py
@@ -269,10 +269,7 @@ class CascadeSimulator:
         branch_for_overload = prepare_branch_results_for_overload(branch_results)
 
         return CascadeTriggers(
-            tripped_switches=evaluate_distance_protection_triggers(
-                switch_prepared,
-                self._cfg,
-            ),
+            tripped_switches=evaluate_distance_protection_triggers(switch_prepared),
             current_overloaded_elements=evaluate_overload_triggers(
                 current_res=branch_for_overload,
                 cascade_configuration=self._cfg,

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/contingency_analysis_pandapower.py
@@ -973,7 +973,7 @@ def run_contingency_analysis_pandapower(
     # Cascade run-invariants: convert sw_characteristics once and precompute the
     # base-case busbar-coupler set, so neither is redone per outage. Skipped when
     # cascade screening is disabled.
-    bus_couplers_mrids: set[str] = prepare_cascade_run_constants(net) if cfg.cascade is not None else set()
+    bus_couplers_mrids: set[str] = prepare_cascade_run_constants(net, cfg.cascade) if cfg.cascade is not None else set()
 
     # A base case that already violates makes every contingency cascade meaningless, so it is
     # reported once here and cascade simulation is switched off for the whole run. The N-1 load

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -94,14 +94,14 @@ class DistanceProtectionSeverity(str, Enum):
 
 
 class DistanceProtectionFactors(BaseModel):
-    """The four impedance factors of one severity: case x protected element type.
+    """The six impedance factors of one severity: case x protected element type.
 
     A factor divides the relay impedance measurement before the polygon test
     (``x = |r_ohm| / factor``), so a larger factor moves the measured point toward the origin
     and *widens* the effective protection area. ``1.0`` leaves the polygon exactly as the
     relay defines it.
 
-    All four are required. Nothing falls back to anything else, so a configuration always
+    All six are required. Nothing falls back to anything else, so a configuration always
     states the factor it wants on every axis and an un-migrated caller fails loudly.
     """
 
@@ -113,11 +113,17 @@ class DistanceProtectionFactors(BaseModel):
     basecase_transformer: float
     """Factor for transformer relays in the base case."""
 
+    basecase_bus_coupler: float
+    """Factor for bus-coupler relays in the base case."""
+
     contingency_line: float
     """Factor for line relays after a contingency."""
 
     contingency_transformer: float
     """Factor for transformer relays after a contingency."""
+
+    contingency_bus_coupler: float
+    """Factor for bus-coupler relays after a contingency."""
 
 
 class DistanceProtectionConfig(BaseModel):

--- a/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
+++ b/packages/contingency_analysis_pkg/src/toop_engine_contingency_analysis/pandapower/pandapower_helpers/schemas.py
@@ -8,6 +8,7 @@
 """Schemas for N-1"""
 
 import dataclasses
+from enum import Enum
 
 import pandapower as pp
 import pandas as pd
@@ -38,68 +39,149 @@ from toop_engine_interfaces.spps_parameters import (
 TRANSFORMER_TABLES = frozenset({"trafo", "trafo3w"})
 
 
-class CascadeConfig(BaseModel):
-    """Configuration for cascading protection screening after contingency load flow."""
+class DistanceProtectionSeverity(str, Enum):
+    """The three zones a relay measurement can fall into, innermost first.
+
+    The zones nest: ``DANGER`` lies inside ``ALARM``, which lies inside ``WARNING``. A
+    measurement in the danger area is therefore in all three, and the innermost zone it
+    reaches is the one worth reporting.
+
+    Only ``ALARM`` and ``WARNING`` are configurable, through the matching factor groups on
+    :class:`DistanceProtectionConfig`. ``DANGER`` is the relay polygon exactly as the relay
+    defines it - the real trip boundary, which no factor is allowed to widen.
+    """
+
+    DANGER = "DANGER"
+    ALARM = "ALARM"
+    WARNING = "WARNING"
+
+    @classmethod
+    def innermost(cls, *, danger_inside: bool, alarm_inside: bool, warning_inside: bool) -> str:
+        """Name the innermost zone a tripped measurement reached.
+
+        The zones nest, so a row inside the danger area is inside all three and the innermost
+        one is what gets reported. Where two zones are configured with the same factor they
+        cover the same area, and the inner name wins for free.
+
+        Parameters
+        ----------
+        danger_inside : bool
+            Whether the measurement is inside the danger polygon.
+        alarm_inside : bool
+            Whether the measurement is inside the alarm area.
+        warning_inside : bool
+            Whether the measurement is inside the warning area.
+
+        Returns
+        -------
+        str
+            The matching severity value.
+
+        Raises
+        ------
+        ValueError
+            If the measurement is in no zone at all, which means it should never have been
+            treated as a trip. Callers pass rows that distance protection already selected,
+            and that selection is the union of the three zones.
+        """
+        if danger_inside:
+            return cls.DANGER.value
+        if alarm_inside:
+            return cls.ALARM.value
+        if warning_inside:
+            return cls.WARNING.value
+        raise ValueError("measurement is inside no distance-protection zone, so it has no severity")
+
+
+class DistanceProtectionFactors(BaseModel):
+    """The four impedance factors of one severity: case x protected element type.
+
+    A factor divides the relay impedance measurement before the polygon test
+    (``x = |r_ohm| / factor``), so a larger factor moves the measured point toward the origin
+    and *widens* the effective protection area. ``1.0`` leaves the polygon exactly as the
+    relay defines it.
+
+    All four are required. Nothing falls back to anything else, so a configuration always
+    states the factor it wants on every axis and an un-migrated caller fails loudly.
+    """
 
     model_config = ConfigDict(frozen=True)
 
-    depth_limit: int
-    """Maximum number of cascade iterations to run before stopping."""
+    basecase_line: float
+    """Factor for line relays in the base case."""
+
+    basecase_transformer: float
+    """Factor for transformer relays in the base case."""
+
+    contingency_line: float
+    """Factor for line relays after a contingency."""
+
+    contingency_transformer: float
+    """Factor for transformer relays after a contingency."""
+
+
+class DistanceProtectionConfig(BaseModel):
+    """Distance-protection screening settings: one factor group per configurable zone.
+
+    The danger zone has no entry here. It is the relay polygon as the relay defines it, so
+    there is no factor that could widen it - see :class:`DistanceProtectionSeverity`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    alarm: DistanceProtectionFactors
+    """Factors for the alarm area, the middle zone just outside the danger polygon.
+
+    Widening this moves the boundary between an ``ALARM``-labelled and a ``WARNING``-labelled
+    trip. It does not change *which* relays trip: the warning area is wider, and that is what
+    the cascade triggers on.
+    """
+
+    warning: DistanceProtectionFactors
+    """Factors for the warning area, the outermost zone.
+
+    This is normally the widest of the three zones, so in practice these factors decide which
+    relays trip at all. Every trip is then labelled by the innermost zone it reached.
+
+    The zones are expected to nest - danger inside alarm inside warning, which means
+    ``1.0 <= alarm <= warning`` on each axis - but nothing enforces it. A narrower warning
+    area still works: a relay inside its raw polygon trips on the danger zone regardless.
+    """
+
+
+class OverloadConfig(BaseModel):
+    """Current-overload screening thresholds, as per-unit ratios (``i / i_max``)."""
+
+    model_config = ConfigDict(frozen=True)
 
     current_loading_threshold: float
     """Loading factor above which a branch is considered overloaded and triggers a cascade.
 
-    This is a per-unit ratio (``i / i_max``), not a percentage: ``1.5`` means 150 %.
-    It applies to every branch for which no more specific threshold below is set,
-    and is the only threshold used when none of them are set.
+    This applies to every branch for which no more specific threshold below is set, and is the
+    only threshold used when none of them are. ``1.5`` means 150 %.
     """
 
-    basecase_line_loading_threshold: Optional[float] = None
+    basecase_line: Optional[float] = None
     """Loading factor for lines in the base case.
     If not set, current_loading_threshold is used.
     """
 
-    contingency_line_loading_threshold: Optional[float] = None
+    contingency_line: Optional[float] = None
     """Loading factor for lines after a contingency.
-    If not set, basecase_line_loading_threshold is used, then current_loading_threshold.
+    If not set, basecase_line is used, then current_loading_threshold.
     """
 
-    basecase_transformer_loading_threshold: Optional[float] = None
+    basecase_transformer: Optional[float] = None
     """Loading factor for transformers (``trafo`` and ``trafo3w``) in the base case.
     If not set, current_loading_threshold is used.
     """
 
-    contingency_transformer_loading_threshold: Optional[float] = None
+    contingency_transformer: Optional[float] = None
     """Loading factor for transformers (``trafo`` and ``trafo3w``) after a contingency.
-    If not set, basecase_transformer_loading_threshold is used, then current_loading_threshold.
+    If not set, basecase_transformer is used, then current_loading_threshold.
     """
 
-    min_island_size: int
-    """Minimum number of buses in an island for it to be kept; smaller islands are dropped."""
-
-    basecase_distance_protection_factor: float
-    """Scaling factor applied to relay impedance measurements in the base-case network."""
-
-    contingency_distance_protection_factor: Optional[float] = None
-    """Scaling factor applied to relay impedance measurements after a contingency.
-    If not set, basecase_distance_protection_factor is used.
-    """
-
-    cascade_log_elements: list[str]
-    """MRIDs of elements whose cascade events should be written to the log (e.g. line, trafo, trafo3w)."""
-
-    stop_cascade_on_basecase_violation: bool = True
-    """Skip cascade simulation for every contingency when the base case already violates.
-
-    A base case that is overloaded, or whose relay impedance already sits inside a distance
-    protection zone, makes the N-1 cascade results meaningless: the cascade would be started
-    from an already-broken state, and practically every contingency would report one. When
-    this is enabled the base case is screened once, before any contingency is computed, and a
-    violation is reported as ``BASECASE_*`` cascade events instead. The N-1 load flows
-    themselves still run; only the cascade simulation is skipped.
-    """
-
-    def loading_threshold(self, element_table: str, *, basecase: bool) -> float:
+    def threshold(self, element_table: str, *, basecase: bool) -> float:
         """Resolve the loading threshold that applies to one branch.
 
         Parameters
@@ -120,11 +202,11 @@ class CascadeConfig(BaseModel):
         """
         # Pick the pair of overrides for this element type; other tables have none.
         if element_table == "line":
-            basecase_threshold = self.basecase_line_loading_threshold
-            contingency_threshold = self.contingency_line_loading_threshold
+            basecase_threshold = self.basecase_line
+            contingency_threshold = self.contingency_line
         elif element_table in TRANSFORMER_TABLES:
-            basecase_threshold = self.basecase_transformer_loading_threshold
-            contingency_threshold = self.contingency_transformer_loading_threshold
+            basecase_threshold = self.basecase_transformer
+            contingency_threshold = self.contingency_transformer
         else:
             return self.current_loading_threshold
 
@@ -134,6 +216,38 @@ class CascadeConfig(BaseModel):
         if basecase_threshold is not None:
             return basecase_threshold
         return self.current_loading_threshold
+
+
+class CascadeConfig(BaseModel):
+    """Configuration for cascading protection screening after contingency load flow."""
+
+    model_config = ConfigDict(frozen=True)
+
+    depth_limit: int
+    """Maximum number of cascade iterations to run before stopping."""
+
+    min_island_size: int
+    """Minimum number of buses in an island for it to be kept; smaller islands are dropped."""
+
+    overload: OverloadConfig
+    """Thresholds for the current-overload trigger."""
+
+    distance_protection: DistanceProtectionConfig
+    """Factors for the distance-protection trigger."""
+
+    cascade_log_elements: list[str]
+    """MRIDs of elements whose cascade events should be written to the log (e.g. line, trafo, trafo3w)."""
+
+    stop_cascade_on_basecase_violation: bool = True
+    """Skip cascade simulation for every contingency when the base case already violates.
+
+    A base case that is overloaded, or whose relay impedance already sits inside a distance
+    protection zone, makes the N-1 cascade results meaningless: the cascade would be started
+    from an already-broken state, and practically every contingency would report one. When
+    this is enabled the base case is screened once, before any contingency is computed, and a
+    violation is reported as ``BASECASE_*`` cascade events instead. The N-1 load flows
+    themselves still run; only the cascade simulation is skipped.
+    """
 
 
 @dataclasses.dataclass

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_basecase_screen.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_basecase_screen.py
@@ -16,6 +16,7 @@ from toop_engine_contingency_analysis.pandapower.cascade.basecase import (
     build_basecase_cascade_results,
     screen_basecase_for_cascade,
 )
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import DistanceProtectionSeverity
 from toop_engine_contingency_analysis.pandapower.cascade.detection.basecase_screen import (
     _resolve_branch_element,
 )
@@ -24,6 +25,9 @@ from toop_engine_contingency_analysis.pandapower.pandapower_helpers import trans
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     CascadeConfig,
     ContingencyAnalysisConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    OverloadConfig,
     ParallelConfig,
 )
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import SEPARATOR, get_globally_unique_id
@@ -62,11 +66,17 @@ def _healthy_net() -> pp.pandapowerNet:
 def _cascade_config(*, stop_on_basecase: bool) -> CascadeConfig:
     return CascadeConfig(
         depth_limit=3,
-        current_loading_threshold=1.5,
+        overload=OverloadConfig(current_loading_threshold=1.5),
         min_island_size=2,
         cascade_log_elements=["line", "switch"],
-        basecase_distance_protection_factor=1.5,
-        contingency_distance_protection_factor=1.5,
+        distance_protection=DistanceProtectionConfig(
+            alarm=DistanceProtectionFactors(
+                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+            ),
+            warning=DistanceProtectionFactors(
+                basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+            ),
+        ),
         stop_cascade_on_basecase_violation=stop_on_basecase,
     )
 
@@ -132,7 +142,11 @@ def test_basecase_distance_protection_reports_r_and_x() -> None:
     for row in relay_rows:
         assert row["r_ohm"] is not None
         assert row["x_ohm"] is not None
-        assert row["distance_protection_severity"] in {"DANGER", "WARNING"}
+        assert row["distance_protection_severity"] in {
+            DistanceProtectionSeverity.DANGER.value,
+            DistanceProtectionSeverity.ALARM.value,
+            DistanceProtectionSeverity.WARNING.value,
+        }
 
 
 def test_skipping_the_cascade_keeps_the_n1_loadflow_results() -> None:

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_basecase_screen.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_basecase_screen.py
@@ -71,10 +71,20 @@ def _cascade_config(*, stop_on_basecase: bool) -> CascadeConfig:
         cascade_log_elements=["line", "switch"],
         distance_protection=DistanceProtectionConfig(
             alarm=DistanceProtectionFactors(
-                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                basecase_line=1.0,
+                basecase_transformer=1.0,
+                basecase_bus_coupler=1.0,
+                contingency_line=1.0,
+                contingency_transformer=1.0,
+                contingency_bus_coupler=1.0,
             ),
             warning=DistanceProtectionFactors(
-                basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+                basecase_line=1.5,
+                basecase_transformer=1.5,
+                basecase_bus_coupler=1.5,
+                contingency_line=1.5,
+                contingency_transformer=1.5,
+                contingency_bus_coupler=1.5,
             ),
         ),
         stop_cascade_on_basecase_violation=stop_on_basecase,

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_busbar_cascade.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_busbar_cascade.py
@@ -191,10 +191,20 @@ class TestCascadesBB(unittest.TestCase):
             cascade_log_elements=["line", "switch"],
             distance_protection=DistanceProtectionConfig(
                 alarm=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
                 warning=DistanceProtectionFactors(
-                    basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+                    basecase_line=1.5,
+                    basecase_transformer=1.5,
+                    basecase_bus_coupler=1.5,
+                    contingency_line=1.5,
+                    contingency_transformer=1.5,
+                    contingency_bus_coupler=1.5,
                 ),
             ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
@@ -319,10 +329,20 @@ class TestCascadesBB(unittest.TestCase):
             cascade_log_elements=["line", "switch"],
             distance_protection=DistanceProtectionConfig(
                 alarm=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
                 warning=DistanceProtectionFactors(
-                    basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+                    basecase_line=1.5,
+                    basecase_transformer=1.5,
+                    basecase_bus_coupler=1.5,
+                    contingency_line=1.5,
+                    contingency_transformer=1.5,
+                    contingency_bus_coupler=1.5,
                 ),
             ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_busbar_cascade.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_busbar_cascade.py
@@ -11,10 +11,14 @@ import numpy as np
 import pandapower as pp
 import pandas as pd
 from toop_engine_contingency_analysis.pandapower import run_contingency_analysis_pandapower
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import DistanceProtectionSeverity
 from toop_engine_contingency_analysis.pandapower.cascade.models import CascadeReasonType
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     CascadeConfig,
     ContingencyAnalysisConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    OverloadConfig,
     ParallelConfig,
 )
 from toop_engine_grid_helpers.pandapower.pandapower_id_helpers import get_globally_unique_id
@@ -105,7 +109,11 @@ def create_net():
             "angle": [30.0, 30.0],
             "relay_side": ["element", "element"],
             "protection_side": ["element", "element"],
-            "custom_warning_distance_protection": [np.nan, np.nan],
+            "protection_element": ["line", "line"],
+            "custom_base_alarm": [np.nan, np.nan],
+            "custom_base_warning": [np.nan, np.nan],
+            "custom_contingency_alarm": [np.nan, np.nan],
+            "custom_contingency_warning": [np.nan, np.nan],
         },
     )
 
@@ -178,11 +186,17 @@ class TestCascadesBB(unittest.TestCase):
 
         cascade_cfg = CascadeConfig(
             depth_limit=3,
-            current_loading_threshold=1.5,
+            overload=OverloadConfig(current_loading_threshold=1.5),
             min_island_size=2,
             cascade_log_elements=["line", "switch"],
-            basecase_distance_protection_factor=1.5,
-            contingency_distance_protection_factor=1.5,
+            distance_protection=DistanceProtectionConfig(
+                alarm=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+                warning=DistanceProtectionFactors(
+                    basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+                ),
+            ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
             # which is exactly what the base-case screen short-circuits.
             stop_cascade_on_basecase_violation=False,
@@ -238,7 +252,7 @@ class TestCascadesBB(unittest.TestCase):
             assert set(e.keys()) == expected_keys
             assert e["cascade_number"] == 1
             assert e["cascade_reason"] == CascadeReasonType.CASCADE_REASON_DISTANCE
-            assert e["distance_protection_severity"] == "DANGER"
+            assert e["distance_protection_severity"] == DistanceProtectionSeverity.DANGER.value
             assert isinstance(e["contingency_name"], str)
             assert isinstance(e["element_mrid"], str)
             assert isinstance(e["element_name"], str)
@@ -300,11 +314,17 @@ class TestCascadesBB(unittest.TestCase):
 
         cascade_cfg = CascadeConfig(
             depth_limit=3,
-            current_loading_threshold=1.5,
+            overload=OverloadConfig(current_loading_threshold=1.5),
             min_island_size=2,
             cascade_log_elements=["line", "switch"],
-            basecase_distance_protection_factor=1.5,
-            contingency_distance_protection_factor=1.5,
+            distance_protection=DistanceProtectionConfig(
+                alarm=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+                warning=DistanceProtectionFactors(
+                    basecase_line=1.5, basecase_transformer=1.5, contingency_line=1.5, contingency_transformer=1.5
+                ),
+            ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
             # which is exactly what the base-case screen short-circuits.
             stop_cascade_on_basecase_violation=False,

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -643,9 +643,9 @@ def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
 
     net = build_cascade_test_net()
     pp.runpp(net, lightsim2grid=False)
-    # Prepare the per-run cascade constants (angle/poly on sw_characteristics), as the
-    # production path does before running the simulator.
-    prepare_cascade_run_constants(net)
+    # Prepare the per-run cascade constants (angle/poly and the resolved factors on
+    # sw_characteristics), as the production path does before running the simulator.
+    prepare_cascade_run_constants(net, simulator._cfg)
 
     captured: list[pd.DataFrame] = []
 

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -22,6 +22,9 @@ from toop_engine_contingency_analysis.pandapower.cascade.simulation.simulator im
 from toop_engine_contingency_analysis.pandapower.pandapower_helpers.schemas import (
     CascadeConfig,
     ContingencyAnalysisConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    OverloadConfig,
     PandapowerContingency,
     ParallelConfig,
     SingleOutageSppsContext,
@@ -148,7 +151,11 @@ def build_cascade_test_net():
             "angle": [30.0, 30.0, 30.0, 35.0, 30.0, 30.0],
             "relay_side": ["element", "element", "element", "bus", "element", "element"],
             "protection_side": ["element", "element", "element", "bus", "element", "element"],
-            "custom_warning_distance_protection": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "protection_element": ["line", "line", "line", "line", "line", "line"],
+            "custom_base_alarm": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "custom_base_warning": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "custom_contingency_alarm": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "custom_contingency_warning": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
         },
     )
 
@@ -219,7 +226,11 @@ def build_line_and_transformer_net():
             "angle": [30.0],
             "relay_side": ["element"],
             "protection_side": ["element"],
-            "custom_warning_distance_protection": [np.nan],
+            "protection_element": ["line"],
+            "custom_base_alarm": [np.nan],
+            "custom_base_warning": [np.nan],
+            "custom_contingency_alarm": [np.nan],
+            "custom_contingency_warning": [np.nan],
         },
     )
     net.bus["Busbar_id"] = ""
@@ -293,11 +304,17 @@ class TestCascades(unittest.TestCase):
 
         cascade_cfg = CascadeConfig(
             depth_limit=3,
-            current_loading_threshold=1.5,
+            overload=OverloadConfig(current_loading_threshold=1.5),
             min_island_size=2,
             cascade_log_elements=["line", "switch"],
-            basecase_distance_protection_factor=2,
-            contingency_distance_protection_factor=2,
+            distance_protection=DistanceProtectionConfig(
+                alarm=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+                warning=DistanceProtectionFactors(
+                    basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+                ),
+            ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
             # which is exactly what the base-case screen short-circuits.
             stop_cascade_on_basecase_violation=False,
@@ -427,11 +444,17 @@ class TestCascades(unittest.TestCase):
 
         cascade_cfg = CascadeConfig(
             depth_limit=3,
-            current_loading_threshold=1.5,
+            overload=OverloadConfig(current_loading_threshold=1.5),
             min_island_size=2,
             cascade_log_elements=["line", "switch"],
-            basecase_distance_protection_factor=2,
-            contingency_distance_protection_factor=2,
+            distance_protection=DistanceProtectionConfig(
+                alarm=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+                warning=DistanceProtectionFactors(
+                    basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+                ),
+            ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
             # which is exactly what the base-case screen short-circuits.
             stop_cascade_on_basecase_violation=False,
@@ -573,10 +596,17 @@ def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
     simulator = CascadeSimulator(
         cfg=CascadeConfig(
             depth_limit=1,
-            current_loading_threshold=1.0,
+            overload=OverloadConfig(current_loading_threshold=1.0),
             min_island_size=1,
             cascade_log_elements=[],
-            basecase_distance_protection_factor=1.0,
+            distance_protection=DistanceProtectionConfig(
+                alarm=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+                warning=DistanceProtectionFactors(
+                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                ),
+            ),
         ),
         spps=spps,
     )
@@ -642,13 +672,19 @@ def test_cascade_trips_the_element_types_above_their_own_threshold(
     cascade_cfg = CascadeConfig(
         depth_limit=2,
         # Deliberately unreachable: every trip below must come from a type-specific threshold.
-        current_loading_threshold=99.0,
-        basecase_line_loading_threshold=line_threshold,
-        basecase_transformer_loading_threshold=transformer_threshold,
+        overload=OverloadConfig(
+            current_loading_threshold=99.0, basecase_line=line_threshold, basecase_transformer=transformer_threshold
+        ),
         min_island_size=1,
         cascade_log_elements=["line", "trafo"],
-        basecase_distance_protection_factor=0.01,
-        contingency_distance_protection_factor=0.01,
+        distance_protection=DistanceProtectionConfig(
+            alarm=DistanceProtectionFactors(
+                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+            ),
+            warning=DistanceProtectionFactors(
+                basecase_line=0.01, basecase_transformer=0.01, contingency_line=0.01, contingency_transformer=0.01
+            ),
+        ),
         # The net is deliberately overloaded in the base case to force a cascade, which is
         # exactly what the base-case screen short-circuits.
         stop_cascade_on_basecase_violation=False,
@@ -713,12 +749,18 @@ def _l1_cascade_config(**threshold_fields: float) -> CascadeConfig:
         depth_limit=3,
         min_island_size=2,
         cascade_log_elements=["line", "switch"],
-        basecase_distance_protection_factor=2,
-        contingency_distance_protection_factor=2,
+        distance_protection=DistanceProtectionConfig(
+            alarm=DistanceProtectionFactors(
+                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+            ),
+            warning=DistanceProtectionFactors(
+                basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+            ),
+        ),
         # The net is deliberately overloaded in the base case to force a cascade, which is
         # exactly what the base-case screen short-circuits.
         stop_cascade_on_basecase_violation=False,
-        **threshold_fields,
+        overload=OverloadConfig(**threshold_fields),
     )
 
 
@@ -730,16 +772,14 @@ def test_line_threshold_replaces_the_scalar_threshold_for_lines() -> None:
     the lines are compared against the override rather than against it.
     """
     scalar_events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=1.5))
-    override_events = _run_l1_cascade(
-        _l1_cascade_config(current_loading_threshold=99.0, basecase_line_loading_threshold=1.5)
-    )
+    override_events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=99.0, basecase_line=1.5))
 
     assert [event["element_mrid"] for event in scalar_events] == ["line:l2", "line:l4", "line:l7"]
     assert override_events == scalar_events
 
 
 def test_transformer_threshold_does_not_apply_to_lines() -> None:
-    events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=99.0, basecase_transformer_loading_threshold=1.5))
+    events = _run_l1_cascade(_l1_cascade_config(current_loading_threshold=99.0, basecase_transformer=1.5))
 
     assert events == []
 
@@ -760,8 +800,8 @@ def test_basecase_and_contingency_thresholds_are_applied_per_case(
     events = _run_l1_cascade(
         _l1_cascade_config(
             current_loading_threshold=99.0,
-            basecase_line_loading_threshold=basecase_threshold,
-            contingency_line_loading_threshold=contingency_threshold,
+            basecase_line=basecase_threshold,
+            contingency_line=contingency_threshold,
         )
     )
 

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_cascade_multi_step.py
@@ -309,10 +309,20 @@ class TestCascades(unittest.TestCase):
             cascade_log_elements=["line", "switch"],
             distance_protection=DistanceProtectionConfig(
                 alarm=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
                 warning=DistanceProtectionFactors(
-                    basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+                    basecase_line=2,
+                    basecase_transformer=2,
+                    basecase_bus_coupler=2,
+                    contingency_line=2,
+                    contingency_transformer=2,
+                    contingency_bus_coupler=2,
                 ),
             ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
@@ -449,10 +459,20 @@ class TestCascades(unittest.TestCase):
             cascade_log_elements=["line", "switch"],
             distance_protection=DistanceProtectionConfig(
                 alarm=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
                 warning=DistanceProtectionFactors(
-                    basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+                    basecase_line=2,
+                    basecase_transformer=2,
+                    basecase_bus_coupler=2,
+                    contingency_line=2,
+                    contingency_transformer=2,
+                    contingency_bus_coupler=2,
                 ),
             ),
             # This fixture deliberately starts from an overloaded base case to force a cascade,
@@ -601,10 +621,20 @@ def test_simulate_switch_results_filtered_to_protection_scope_only() -> None:
             cascade_log_elements=[],
             distance_protection=DistanceProtectionConfig(
                 alarm=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
                 warning=DistanceProtectionFactors(
-                    basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                    basecase_line=1.0,
+                    basecase_transformer=1.0,
+                    basecase_bus_coupler=1.0,
+                    contingency_line=1.0,
+                    contingency_transformer=1.0,
+                    contingency_bus_coupler=1.0,
                 ),
             ),
         ),
@@ -679,10 +709,20 @@ def test_cascade_trips_the_element_types_above_their_own_threshold(
         cascade_log_elements=["line", "trafo"],
         distance_protection=DistanceProtectionConfig(
             alarm=DistanceProtectionFactors(
-                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                basecase_line=1.0,
+                basecase_transformer=1.0,
+                basecase_bus_coupler=1.0,
+                contingency_line=1.0,
+                contingency_transformer=1.0,
+                contingency_bus_coupler=1.0,
             ),
             warning=DistanceProtectionFactors(
-                basecase_line=0.01, basecase_transformer=0.01, contingency_line=0.01, contingency_transformer=0.01
+                basecase_line=0.01,
+                basecase_transformer=0.01,
+                basecase_bus_coupler=0.01,
+                contingency_line=0.01,
+                contingency_transformer=0.01,
+                contingency_bus_coupler=0.01,
             ),
         ),
         # The net is deliberately overloaded in the base case to force a cascade, which is
@@ -751,10 +791,20 @@ def _l1_cascade_config(**threshold_fields: float) -> CascadeConfig:
         cascade_log_elements=["line", "switch"],
         distance_protection=DistanceProtectionConfig(
             alarm=DistanceProtectionFactors(
-                basecase_line=1.0, basecase_transformer=1.0, contingency_line=1.0, contingency_transformer=1.0
+                basecase_line=1.0,
+                basecase_transformer=1.0,
+                basecase_bus_coupler=1.0,
+                contingency_line=1.0,
+                contingency_transformer=1.0,
+                contingency_bus_coupler=1.0,
             ),
             warning=DistanceProtectionFactors(
-                basecase_line=2, basecase_transformer=2, contingency_line=2, contingency_transformer=2
+                basecase_line=2,
+                basecase_transformer=2,
+                basecase_bus_coupler=2,
+                contingency_line=2,
+                contingency_transformer=2,
+                contingency_bus_coupler=2,
             ),
         ),
         # The net is deliberately overloaded in the base case to force a cascade, which is

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
@@ -1,0 +1,435 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+"""Distance-protection zones and the factor selection behind them.
+
+The three zones nest danger inside alarm inside warning. Danger is the relay polygon as the
+relay defines it and takes no factors; alarm and warning are each configurable on two axes,
+case and protected element type.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+import shapely
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import (
+    CascadeConfig,
+    DistanceProtectionConfig,
+    DistanceProtectionFactors,
+    DistanceProtectionSeverity,
+    OverloadConfig,
+)
+from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection import (
+    _build_poly,
+    _effective_factors,
+    evaluate_distance_protection_triggers,
+    get_alarm_area,
+    get_danger_area,
+    get_warning_area,
+)
+
+#: ``_build_poly`` with ``r_i == r_v == x_v`` degenerates to the square [0, 10] x [0, 10],
+#: so a measurement is inside exactly while both scaled coordinates are <= 10.
+REACH = 10.0
+
+SLOTS = ("basecase_line", "basecase_transformer", "contingency_line", "contingency_transformer")
+
+OVERRIDE_COLUMNS = (
+    "custom_base_alarm",
+    "custom_base_warning",
+    "custom_contingency_alarm",
+    "custom_contingency_warning",
+)
+
+
+def _square_poly() -> shapely.Polygon:
+    row = pd.Series({"r_i": REACH, "r_v": REACH, "x_v": REACH, "angle": math.radians(30.0)})
+    return _build_poly(row)
+
+
+def _relays(
+    protection_element: list,
+    r_ohm: list[float],
+    contingency: list[str] | None = None,
+    **overrides: list,
+) -> pd.DataFrame:
+    """Build a switch-result frame of relays that all share one square protection zone."""
+    count = len(protection_element)
+    data = {
+        "contingency": contingency if contingency is not None else ["BASECASE"] * count,
+        "protection_element": protection_element,
+        "r_ohm": r_ohm,
+        "x_ohm": [0.0] * count,
+        "poly": [_square_poly()] * count,
+    }
+    for column in OVERRIDE_COLUMNS:
+        data[column] = overrides.get(column, [np.nan] * count)
+    return pd.DataFrame(data)
+
+
+def _factors(**overrides: float) -> DistanceProtectionFactors:
+    """Neutral on every axis except the ones a test names.
+
+    1.0 leaves the relay polygon exactly as the relay defines it, so a test that cares about
+    one axis stays readable while still supplying all four required values.
+    """
+    values = dict.fromkeys(SLOTS, 1.0)
+    values.update(overrides)
+    return DistanceProtectionFactors(**values)
+
+
+def _config(alarm: dict | None = None, warning: dict | None = None) -> CascadeConfig:
+    return CascadeConfig(
+        depth_limit=1,
+        min_island_size=1,
+        cascade_log_elements=[],
+        overload=OverloadConfig(current_loading_threshold=1.0),
+        distance_protection=DistanceProtectionConfig(
+            alarm=_factors(**(alarm or {})),
+            warning=_factors(**(warning or {})),
+        ),
+    )
+
+
+def _severities(df: pd.DataFrame, cfg: CascadeConfig) -> list[str]:
+    """Label each row the way the cascade does: by the innermost zone it reached."""
+    danger = get_danger_area(df)
+    alarm = get_alarm_area(df, cfg)
+    warning = get_warning_area(df, cfg)
+    return [
+        DistanceProtectionSeverity.innermost(
+            danger_inside=bool(is_danger), alarm_inside=bool(is_alarm), warning_inside=bool(is_warning)
+        )
+        for is_danger, is_alarm, is_warning in zip(danger, alarm, warning, strict=True)
+    ]
+
+
+class TestDangerArea:
+    """The innermost zone: the relay polygon, with nothing applied to it."""
+
+    def test_is_the_raw_relay_polygon(self):
+        """No factor touches the danger area, so it matches a bare polygon test value for value."""
+        r_ohm = [0.0, 5.0, REACH, REACH + 1e-9, 20.0, -5.0]
+        df = _relays(protection_element=["line"] * len(r_ohm), r_ohm=r_ohm)
+
+        expected = shapely.covers(
+            df["poly"].to_numpy(),
+            shapely.points(np.abs(df["r_ohm"].to_numpy()), np.abs(df["x_ohm"].to_numpy())),
+        )
+
+        assert get_danger_area(df).tolist() == expected.tolist()
+
+    def test_ignores_the_element_type(self):
+        """With no factors there is no element-type axis to select on."""
+        df = _relays(protection_element=["trafo", "line", None], r_ohm=[5.0, 5.0, 5.0])
+
+        assert get_danger_area(df).tolist() == [True, True, True]
+
+
+class TestAlarmArea:
+    """The middle zone, configurable on case and element type."""
+
+    def test_a_wider_factor_widens_only_the_matching_relays(self):
+        """A transformer alarm factor must not move line relays."""
+        cfg = _config(alarm={"basecase_transformer": 2.0}, warning={"basecase_transformer": 2.0})
+        # 20 / 2.0 = 10 -> on the boundary, inside. At 1.0 it would be 20, outside.
+        df = _relays(protection_element=["trafo", "line"], r_ohm=[20.0, 20.0])
+
+        assert get_alarm_area(df, cfg).tolist() == [True, False]
+
+    def test_reads_the_alarm_override_not_the_warning_one(self):
+        """The alarm area reads custom_*_alarm; the warning override must not reach it."""
+        cfg = _config()
+        df = _relays(
+            protection_element=["line", "line"],
+            r_ohm=[20.0, 20.0],
+            custom_base_alarm=[2.0, np.nan],
+            custom_base_warning=[np.nan, 2.0],
+        )
+
+        assert get_alarm_area(df, cfg).tolist() == [True, False]
+
+
+class TestWarningFactorSelection:
+    """The warning factor is chosen by case and protected element type."""
+
+    def test_transformer_relay_uses_the_transformer_factor(self):
+        """A trafo relay with no override takes the transformer factor, not the line one."""
+        cfg = _config(warning={"basecase_transformer": 2.0})
+        df = _relays(protection_element=["trafo", "line"], r_ohm=[20.0, 20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True, False]
+
+    def test_an_override_wins_over_the_transformer_factor(self):
+        """The per-relay override replaces the global factor for its severity and case."""
+        cfg = _config(warning={"basecase_transformer": 2.0})
+        df = _relays(protection_element=["trafo"], r_ohm=[20.0], custom_base_warning=[1.0])
+
+        assert get_warning_area(df, cfg).tolist() == [False]
+
+    def test_the_override_is_picked_by_case(self):
+        """A base-case row reads custom_base_warning, a contingency row the contingency one."""
+        cfg = _config()
+        df = _relays(
+            protection_element=["line", "line"],
+            r_ohm=[20.0, 20.0],
+            contingency=["BASECASE", "outage-1"],
+            custom_base_warning=[2.0, 1.0],
+            custom_contingency_warning=[1.0, 2.0],
+        )
+
+        assert get_warning_area(df, cfg).tolist() == [True, True]
+
+    def test_the_global_factor_is_picked_by_case(self):
+        """Without overrides, contingency rows use the contingency factor."""
+        cfg = _config(warning={"contingency_line": 2.0})
+        df = _relays(
+            protection_element=["line", "line"],
+            r_ohm=[20.0, 20.0],
+            contingency=["BASECASE", "outage-1"],
+        )
+
+        assert get_warning_area(df, cfg).tolist() == [False, True]
+
+
+class TestUnknownProtectionElement:
+    """protection_element is None when the side carries both elements, or neither."""
+
+    def test_takes_the_wider_of_the_two_factors(self):
+        """The larger factor widens the area, so the ambiguous relay is screened as widely."""
+        cfg = _config(warning={"basecase_transformer": 2.0})
+        df = _relays(protection_element=[None], r_ohm=[20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True]
+
+    def test_the_wider_factor_wins_whichever_side_it_is_on(self):
+        """The rule is max(line, transformer), not "always the transformer"."""
+        cfg = _config(warning={"basecase_line": 2.0})
+        df = _relays(protection_element=[None], r_ohm=[20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True]
+
+
+class TestInnermostSeverity:
+    """A trip is labelled by the innermost zone it reached."""
+
+    def test_danger_wins_over_everything(self):
+        severity = DistanceProtectionSeverity.innermost(danger_inside=True, alarm_inside=True, warning_inside=True)
+
+        assert severity == DistanceProtectionSeverity.DANGER.value
+
+    def test_alarm_when_the_danger_polygon_was_not_reached(self):
+        severity = DistanceProtectionSeverity.innermost(danger_inside=False, alarm_inside=True, warning_inside=True)
+
+        assert severity == DistanceProtectionSeverity.ALARM.value
+
+    def test_warning_when_only_the_outer_zone_was_reached(self):
+        severity = DistanceProtectionSeverity.innermost(danger_inside=False, alarm_inside=False, warning_inside=True)
+
+        assert severity == DistanceProtectionSeverity.WARNING.value
+
+    def test_a_narrow_outer_zone_still_reports_the_inner_one(self):
+        """Factors below 1.0 can leave a danger hit outside both configured zones."""
+        severity = DistanceProtectionSeverity.innermost(danger_inside=True, alarm_inside=False, warning_inside=False)
+
+        assert severity == DistanceProtectionSeverity.DANGER.value
+
+    def test_no_zone_at_all_is_rejected(self):
+        """Such a row was never a trip, so asking for its severity is a caller bug."""
+        with pytest.raises(ValueError, match="no distance-protection zone"):
+            DistanceProtectionSeverity.innermost(danger_inside=False, alarm_inside=False, warning_inside=False)
+
+    def test_the_result_is_a_plain_string(self):
+        """It lands in a pandera Series[str]; an Enum member would not hash like its value."""
+        severity = DistanceProtectionSeverity.innermost(danger_inside=True, alarm_inside=False, warning_inside=False)
+
+        assert severity in {"DANGER", "ALARM", "WARNING"}
+
+
+class TestFactorGrouping:
+    """Each of the eight configurable values must reach its own slot."""
+
+    def test_each_slot_is_read_from_its_own_field(self):
+        """A distinct value per slot catches any two of them being crossed."""
+        cfg = _config(
+            warning={
+                "basecase_line": 1.0,
+                "contingency_line": 2.0,
+                "basecase_transformer": 3.0,
+                "contingency_transformer": 4.0,
+            }
+        )
+
+        assert cfg.distance_protection.warning == DistanceProtectionFactors(
+            basecase_line=1.0, basecase_transformer=3.0, contingency_line=2.0, contingency_transformer=4.0
+        )
+
+    def test_the_severities_are_independent(self):
+        """Setting the warning factors must not move the alarm ones."""
+        cfg = _config(warning={"basecase_line": 1.41, "contingency_transformer": 1.6})
+
+        assert cfg.distance_protection.alarm == _factors()
+
+    @pytest.mark.parametrize("missing", SLOTS)
+    def test_every_factor_is_required(self, missing: str):
+        """No factor has a default: an un-migrated caller fails loudly instead of silently."""
+        values = dict.fromkeys(SLOTS, 1.0)
+        del values[missing]
+
+        with pytest.raises(ValueError):
+            DistanceProtectionFactors(**values)
+
+    @pytest.mark.parametrize("missing", ["alarm", "warning"])
+    def test_both_configurable_zones_are_required(self, missing: str):
+        groups = {"alarm": _factors(), "warning": _factors()}
+        del groups[missing]
+
+        with pytest.raises(ValueError):
+            DistanceProtectionConfig(**groups)
+
+
+class TestCoincidingZones:
+    """Two zones with the same factor are the same area, so the innermost name always wins.
+
+    This is not special-cased anywhere: if the alarm and warning factors are equal, every row
+    inside the warning area is inside the identical alarm area, so the alarm flag is already
+    set and ``innermost`` reports the inner name. The tests pin that down because the labels
+    are what operators read.
+    """
+
+    def test_alarm_equal_to_warning_never_reports_warning(self):
+        """The two areas coincide, so a trip in them is an ALARM, not a WARNING."""
+        cfg = _config(alarm={"basecase_line": 2.0}, warning={"basecase_line": 2.0})
+        # 15 / 2.0 = 7.5, inside both; outside the danger polygon, which reaches only to 10.
+        df = _relays(protection_element=["line"], r_ohm=[15.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True]
+        assert _severities(df, cfg) == [DistanceProtectionSeverity.ALARM.value]
+
+    def test_alarm_equal_to_danger_never_reports_alarm(self):
+        """An alarm factor of 1.0 makes the alarm area the raw polygon, so trips are DANGER."""
+        cfg = _config(alarm={"basecase_line": 1.0}, warning={"basecase_line": 2.0})
+        df = _relays(protection_element=["line"], r_ohm=[5.0])
+
+        assert _severities(df, cfg) == [DistanceProtectionSeverity.DANGER.value]
+
+    def test_all_three_equal_reports_danger(self):
+        """With every factor at 1.0 the three zones are one area, reported as the innermost."""
+        cfg = _config(alarm={"basecase_line": 1.0}, warning={"basecase_line": 1.0})
+        df = _relays(protection_element=["line"], r_ohm=[5.0])
+
+        assert _severities(df, cfg) == [DistanceProtectionSeverity.DANGER.value]
+
+    def test_distinct_zones_still_reach_every_label(self):
+        """The collapse above is the zones coinciding, not the labels being unreachable."""
+        cfg = _config(alarm={"basecase_line": 1.5}, warning={"basecase_line": 2.0})
+        # 5 is inside the polygon; 15 / 1.5 = 10 is on the alarm edge; 18 / 1.5 = 12 is outside
+        # the alarm area but 18 / 2.0 = 9 is inside the warning one.
+        df = _relays(protection_element=["line"] * 3, r_ohm=[5.0, 15.0, 18.0])
+
+        assert _severities(df, cfg) == [
+            DistanceProtectionSeverity.DANGER.value,
+            DistanceProtectionSeverity.ALARM.value,
+            DistanceProtectionSeverity.WARNING.value,
+        ]
+
+
+def _measurements(r_ohm: list[float]) -> pd.DataFrame:
+    """Build the raw switch columns that produce the given resistances.
+
+    ``get_complex_impedance`` derives r and x from vm, i, p and q. With ``q = 0`` the angle is
+    zero, so all of the impedance lands on the resistance axis; ``i = 1000`` then makes
+    ``vm = r * sqrt(3)`` give exactly ``r`` ohms.
+    """
+    count = len(r_ohm)
+    return pd.DataFrame(
+        {
+            "vm": [value * math.sqrt(3) for value in r_ohm],
+            "i": [1000.0] * count,
+            "p": [1.0] * count,
+            "q": [0.0] * count,
+            "contingency": ["BASECASE"] * count,
+            "protection_element": ["line"] * count,
+            "poly": [_square_poly()] * count,
+            **{column: [np.nan] * count for column in OVERRIDE_COLUMNS},
+        }
+    )
+
+
+class TestEvaluateDistanceProtectionTriggers:
+    """The entry point: derive the impedance, flag all three zones, keep what tripped."""
+
+    def test_it_derives_r_and_x_from_the_measurements(self):
+        cfg = _config()
+        df = _measurements([5.0])
+
+        evaluate_distance_protection_triggers(df, cfg)
+
+        assert df["r_ohm"].tolist() == pytest.approx([5.0])
+        assert df["x_ohm"].tolist() == pytest.approx([0.0])
+
+    def test_it_flags_all_three_zones(self):
+        """A row deep inside the polygon is inside every zone."""
+        cfg = _config(warning={"basecase_line": 2.0})
+        df = _measurements([5.0])
+
+        tripped = evaluate_distance_protection_triggers(df, cfg)
+
+        assert tripped["danger_inside"].tolist() == [True]
+        assert tripped["alarm_inside"].tolist() == [True]
+        assert tripped["warning_inside"].tolist() == [True]
+
+    def test_it_keeps_only_rows_inside_a_zone(self):
+        """5 is in the polygon, 15 only in the widened warning area, 30 in nothing."""
+        cfg = _config(warning={"basecase_line": 2.0})
+        df = _measurements([5.0, 15.0, 30.0])
+
+        tripped = evaluate_distance_protection_triggers(df, cfg)
+
+        assert tripped.index.tolist() == [0, 1]
+        assert tripped["danger_inside"].tolist() == [True, False]
+        assert tripped["warning_inside"].tolist() == [True, True]
+
+    def test_a_danger_hit_survives_a_narrower_warning_area(self):
+        """Selection is the union, so factors below 1.0 cannot hide a relay in its polygon."""
+        cfg = _config(alarm={"basecase_line": 0.5}, warning={"basecase_line": 0.5})
+        # 8 is inside the polygon, but 8 / 0.5 = 16 is outside both configured zones.
+        df = _measurements([8.0])
+
+        tripped = evaluate_distance_protection_triggers(df, cfg)
+
+        assert tripped["danger_inside"].tolist() == [True]
+        assert tripped["alarm_inside"].tolist() == [False]
+        assert tripped["warning_inside"].tolist() == [False]
+        assert len(tripped) == 1
+
+    def test_nothing_inside_gives_an_empty_result(self):
+        cfg = _config()
+        df = _measurements([30.0])
+
+        assert evaluate_distance_protection_triggers(df, cfg).empty
+
+
+def test_the_danger_zone_has_no_factors():
+    """_effective_factors covers the configurable zones only; danger is the raw polygon."""
+    cfg = _config()
+    df = _relays(protection_element=["line"], r_ohm=[5.0])
+
+    with pytest.raises(ValueError, match="raw relay polygon"):
+        _effective_factors(df, cfg, DistanceProtectionSeverity.DANGER)
+
+
+def test_an_empty_relay_frame_is_handled():
+    """The base-case screen calls these with whatever the outage produced, empty included."""
+    cfg = _config()
+    df = _relays(protection_element=[], r_ohm=[])
+
+    assert get_danger_area(df).tolist() == []
+    assert get_alarm_area(df, cfg).tolist() == []
+    assert get_warning_area(df, cfg).tolist() == []

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
@@ -38,7 +38,14 @@ from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_prot
 #: so a measurement is inside exactly while both scaled coordinates are <= 10.
 REACH = 10.0
 
-SLOTS = ("basecase_line", "basecase_transformer", "contingency_line", "contingency_transformer")
+SLOTS = (
+    "basecase_line",
+    "basecase_transformer",
+    "basecase_bus_coupler",
+    "contingency_line",
+    "contingency_transformer",
+    "contingency_bus_coupler",
+)
 
 OVERRIDE_COLUMNS = (
     "custom_base_alarm",
@@ -198,6 +205,40 @@ class TestWarningFactorSelection:
         assert get_warning_area(df, cfg).tolist() == [False, True]
 
 
+class TestBusCouplerFactor:
+    """bus_coupler is a third protection_element value with a factor of its own."""
+
+    def test_a_bus_coupler_relay_uses_the_bus_coupler_factor(self):
+        """Only the coupler moves; the line and transformer relays keep the neutral factor."""
+        cfg = _config(warning={"basecase_bus_coupler": 2.0})
+        df = _relays(protection_element=["bus_coupler", "line", "trafo"], r_ohm=[20.0, 20.0, 20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True, False, False]
+
+    def test_a_line_factor_does_not_move_bus_couplers(self):
+        cfg = _config(warning={"basecase_line": 2.0})
+        df = _relays(protection_element=["bus_coupler"], r_ohm=[20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [False]
+
+    def test_it_is_picked_by_case_like_the_others(self):
+        cfg = _config(warning={"contingency_bus_coupler": 2.0})
+        df = _relays(
+            protection_element=["bus_coupler", "bus_coupler"],
+            r_ohm=[20.0, 20.0],
+            contingency=["BASECASE", "outage-1"],
+        )
+
+        assert get_warning_area(df, cfg).tolist() == [False, True]
+
+    def test_a_per_relay_override_still_wins(self):
+        """The custom_* columns are per severity and case, so they cover every element type."""
+        cfg = _config(warning={"basecase_bus_coupler": 2.0})
+        df = _relays(protection_element=["bus_coupler"], r_ohm=[20.0], custom_base_warning=[1.0])
+
+        assert get_warning_area(df, cfg).tolist() == [False]
+
+
 class TestUnknownProtectionElement:
     """protection_element is None when the side carries both elements, or neither."""
 
@@ -208,9 +249,16 @@ class TestUnknownProtectionElement:
 
         assert get_warning_area(df, cfg).tolist() == [True]
 
-    def test_the_wider_factor_wins_whichever_side_it_is_on(self):
-        """The rule is max(line, transformer), not "always the transformer"."""
+    def test_the_wider_factor_wins_whichever_type_it_belongs_to(self):
+        """The rule is the maximum over all three, not "always the transformer"."""
         cfg = _config(warning={"basecase_line": 2.0})
+        df = _relays(protection_element=[None], r_ohm=[20.0])
+
+        assert get_warning_area(df, cfg).tolist() == [True]
+
+    def test_the_bus_coupler_factor_takes_part_in_the_maximum(self):
+        """A wide bus-coupler factor reaches unclassified relays like the other two do."""
+        cfg = _config(warning={"basecase_bus_coupler": 2.0})
         df = _relays(protection_element=[None], r_ohm=[20.0])
 
         assert get_warning_area(df, cfg).tolist() == [True]
@@ -263,11 +311,18 @@ class TestFactorGrouping:
                 "contingency_line": 2.0,
                 "basecase_transformer": 3.0,
                 "contingency_transformer": 4.0,
+                "basecase_bus_coupler": 5.0,
+                "contingency_bus_coupler": 6.0,
             }
         )
 
         assert cfg.distance_protection.warning == DistanceProtectionFactors(
-            basecase_line=1.0, basecase_transformer=3.0, contingency_line=2.0, contingency_transformer=4.0
+            basecase_line=1.0,
+            basecase_transformer=3.0,
+            basecase_bus_coupler=5.0,
+            contingency_line=2.0,
+            contingency_transformer=4.0,
+            contingency_bus_coupler=6.0,
         )
 
     def test_the_severities_are_independent(self):

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_distance_protection_factors.py
@@ -27,16 +27,27 @@ from toop_engine_contingency_analysis.pandapower.cascade.configuration import (
 )
 from toop_engine_contingency_analysis.pandapower.cascade.detection.distance_protection import (
     _build_poly,
-    _effective_factors,
+    _resolve_one_case,
+    describe_relay_zones,
     evaluate_distance_protection_triggers,
     get_alarm_area,
     get_danger_area,
     get_warning_area,
+    resolve_effective_factors,
 )
 
 #: ``_build_poly`` with ``r_i == r_v == x_v`` degenerates to the square [0, 10] x [0, 10],
 #: so a measurement is inside exactly while both scaled coordinates are <= 10.
 REACH = 10.0
+
+#: What describe_relay_zones adds on top of the relay table it is given.
+DERIVED_COLUMNS = {
+    "poly",
+    "effective_alarm_basecase",
+    "effective_alarm_contingency",
+    "effective_warning_basecase",
+    "effective_warning_contingency",
+}
 
 SLOTS = (
     "basecase_line",
@@ -80,6 +91,14 @@ def _relays(
     return pd.DataFrame(data)
 
 
+def _prepared(df: pd.DataFrame, cfg: CascadeConfig) -> pd.DataFrame:
+    """Add the factor columns a job precomputes, so the area helpers can read them."""
+    prepared = df.copy()
+    for column, values in resolve_effective_factors(df, cfg).items():
+        prepared[column] = values
+    return prepared
+
+
 def _factors(**overrides: float) -> DistanceProtectionFactors:
     """Neutral on every axis except the ones a test names.
 
@@ -107,8 +126,8 @@ def _config(alarm: dict | None = None, warning: dict | None = None) -> CascadeCo
 def _severities(df: pd.DataFrame, cfg: CascadeConfig) -> list[str]:
     """Label each row the way the cascade does: by the innermost zone it reached."""
     danger = get_danger_area(df)
-    alarm = get_alarm_area(df, cfg)
-    warning = get_warning_area(df, cfg)
+    alarm = get_alarm_area(_prepared(df, cfg))
+    warning = get_warning_area(_prepared(df, cfg))
     return [
         DistanceProtectionSeverity.innermost(
             danger_inside=bool(is_danger), alarm_inside=bool(is_alarm), warning_inside=bool(is_warning)
@@ -148,7 +167,7 @@ class TestAlarmArea:
         # 20 / 2.0 = 10 -> on the boundary, inside. At 1.0 it would be 20, outside.
         df = _relays(protection_element=["trafo", "line"], r_ohm=[20.0, 20.0])
 
-        assert get_alarm_area(df, cfg).tolist() == [True, False]
+        assert get_alarm_area(_prepared(df, cfg)).tolist() == [True, False]
 
     def test_reads_the_alarm_override_not_the_warning_one(self):
         """The alarm area reads custom_*_alarm; the warning override must not reach it."""
@@ -160,7 +179,7 @@ class TestAlarmArea:
             custom_base_warning=[np.nan, 2.0],
         )
 
-        assert get_alarm_area(df, cfg).tolist() == [True, False]
+        assert get_alarm_area(_prepared(df, cfg)).tolist() == [True, False]
 
 
 class TestWarningFactorSelection:
@@ -171,14 +190,14 @@ class TestWarningFactorSelection:
         cfg = _config(warning={"basecase_transformer": 2.0})
         df = _relays(protection_element=["trafo", "line"], r_ohm=[20.0, 20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True, False]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True, False]
 
     def test_an_override_wins_over_the_transformer_factor(self):
         """The per-relay override replaces the global factor for its severity and case."""
         cfg = _config(warning={"basecase_transformer": 2.0})
         df = _relays(protection_element=["trafo"], r_ohm=[20.0], custom_base_warning=[1.0])
 
-        assert get_warning_area(df, cfg).tolist() == [False]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [False]
 
     def test_the_override_is_picked_by_case(self):
         """A base-case row reads custom_base_warning, a contingency row the contingency one."""
@@ -191,7 +210,7 @@ class TestWarningFactorSelection:
             custom_contingency_warning=[1.0, 2.0],
         )
 
-        assert get_warning_area(df, cfg).tolist() == [True, True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True, True]
 
     def test_the_global_factor_is_picked_by_case(self):
         """Without overrides, contingency rows use the contingency factor."""
@@ -202,7 +221,7 @@ class TestWarningFactorSelection:
             contingency=["BASECASE", "outage-1"],
         )
 
-        assert get_warning_area(df, cfg).tolist() == [False, True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [False, True]
 
 
 class TestBusCouplerFactor:
@@ -213,13 +232,13 @@ class TestBusCouplerFactor:
         cfg = _config(warning={"basecase_bus_coupler": 2.0})
         df = _relays(protection_element=["bus_coupler", "line", "trafo"], r_ohm=[20.0, 20.0, 20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True, False, False]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True, False, False]
 
     def test_a_line_factor_does_not_move_bus_couplers(self):
         cfg = _config(warning={"basecase_line": 2.0})
         df = _relays(protection_element=["bus_coupler"], r_ohm=[20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [False]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [False]
 
     def test_it_is_picked_by_case_like_the_others(self):
         cfg = _config(warning={"contingency_bus_coupler": 2.0})
@@ -229,14 +248,14 @@ class TestBusCouplerFactor:
             contingency=["BASECASE", "outage-1"],
         )
 
-        assert get_warning_area(df, cfg).tolist() == [False, True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [False, True]
 
     def test_a_per_relay_override_still_wins(self):
         """The custom_* columns are per severity and case, so they cover every element type."""
         cfg = _config(warning={"basecase_bus_coupler": 2.0})
         df = _relays(protection_element=["bus_coupler"], r_ohm=[20.0], custom_base_warning=[1.0])
 
-        assert get_warning_area(df, cfg).tolist() == [False]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [False]
 
 
 class TestUnknownProtectionElement:
@@ -247,21 +266,21 @@ class TestUnknownProtectionElement:
         cfg = _config(warning={"basecase_transformer": 2.0})
         df = _relays(protection_element=[None], r_ohm=[20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True]
 
     def test_the_wider_factor_wins_whichever_type_it_belongs_to(self):
         """The rule is the maximum over all three, not "always the transformer"."""
         cfg = _config(warning={"basecase_line": 2.0})
         df = _relays(protection_element=[None], r_ohm=[20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True]
 
     def test_the_bus_coupler_factor_takes_part_in_the_maximum(self):
         """A wide bus-coupler factor reaches unclassified relays like the other two do."""
         cfg = _config(warning={"basecase_bus_coupler": 2.0})
         df = _relays(protection_element=[None], r_ohm=[20.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True]
 
 
 class TestInnermostSeverity:
@@ -364,7 +383,7 @@ class TestCoincidingZones:
         # 15 / 2.0 = 7.5, inside both; outside the danger polygon, which reaches only to 10.
         df = _relays(protection_element=["line"], r_ohm=[15.0])
 
-        assert get_warning_area(df, cfg).tolist() == [True]
+        assert get_warning_area(_prepared(df, cfg)).tolist() == [True]
         assert _severities(df, cfg) == [DistanceProtectionSeverity.ALARM.value]
 
     def test_alarm_equal_to_danger_never_reports_alarm(self):
@@ -422,9 +441,10 @@ class TestEvaluateDistanceProtectionTriggers:
 
     def test_it_derives_r_and_x_from_the_measurements(self):
         cfg = _config()
-        df = _measurements([5.0])
+        # Bind the prepared frame: the function writes r_ohm and x_ohm onto what it is given.
+        df = _prepared(_measurements([5.0]), cfg)
 
-        evaluate_distance_protection_triggers(df, cfg)
+        evaluate_distance_protection_triggers(df)
 
         assert df["r_ohm"].tolist() == pytest.approx([5.0])
         assert df["x_ohm"].tolist() == pytest.approx([0.0])
@@ -434,7 +454,7 @@ class TestEvaluateDistanceProtectionTriggers:
         cfg = _config(warning={"basecase_line": 2.0})
         df = _measurements([5.0])
 
-        tripped = evaluate_distance_protection_triggers(df, cfg)
+        tripped = evaluate_distance_protection_triggers(_prepared(df, cfg))
 
         assert tripped["danger_inside"].tolist() == [True]
         assert tripped["alarm_inside"].tolist() == [True]
@@ -445,7 +465,7 @@ class TestEvaluateDistanceProtectionTriggers:
         cfg = _config(warning={"basecase_line": 2.0})
         df = _measurements([5.0, 15.0, 30.0])
 
-        tripped = evaluate_distance_protection_triggers(df, cfg)
+        tripped = evaluate_distance_protection_triggers(_prepared(df, cfg))
 
         assert tripped.index.tolist() == [0, 1]
         assert tripped["danger_inside"].tolist() == [True, False]
@@ -457,7 +477,7 @@ class TestEvaluateDistanceProtectionTriggers:
         # 8 is inside the polygon, but 8 / 0.5 = 16 is outside both configured zones.
         df = _measurements([8.0])
 
-        tripped = evaluate_distance_protection_triggers(df, cfg)
+        tripped = evaluate_distance_protection_triggers(_prepared(df, cfg))
 
         assert tripped["danger_inside"].tolist() == [True]
         assert tripped["alarm_inside"].tolist() == [False]
@@ -468,16 +488,120 @@ class TestEvaluateDistanceProtectionTriggers:
         cfg = _config()
         df = _measurements([30.0])
 
-        assert evaluate_distance_protection_triggers(df, cfg).empty
+        assert evaluate_distance_protection_triggers(_prepared(df, cfg)).empty
 
 
 def test_the_danger_zone_has_no_factors():
-    """_effective_factors covers the configurable zones only; danger is the raw polygon."""
+    """The resolver covers the configurable zones only; danger is the raw polygon."""
     cfg = _config()
     df = _relays(protection_element=["line"], r_ohm=[5.0])
 
     with pytest.raises(ValueError, match="raw relay polygon"):
-        _effective_factors(df, cfg, DistanceProtectionSeverity.DANGER)
+        _resolve_one_case(df, cfg, DistanceProtectionSeverity.DANGER, basecase=True)
+
+
+def _sw_characteristics(protection_element: list, **overrides: list) -> pd.DataFrame:
+    """A relay table shaped like net.sw_characteristics, with angle still in degrees."""
+    count = len(protection_element)
+    data = {
+        "breaker_uuid": [f"relay-{index}" for index in range(count)],
+        "relay_side": ["bus"] * count,
+        "protection_side": ["element"] * count,
+        "protection_element": protection_element,
+        "angle": [30.0] * count,
+        "r_i": [REACH] * count,
+        "r_v": [REACH] * count,
+        "x_v": [REACH] * count,
+    }
+    for column in OVERRIDE_COLUMNS:
+        data[column] = overrides.get(column, [np.nan] * count)
+    return pd.DataFrame(data)
+
+
+class TestDescribeRelayZones:
+    """Resolve polygons and effective factors straight from a relay table."""
+
+    def test_it_reports_one_row_per_relay_with_its_polygon(self):
+        cfg = _config()
+        relays = _sw_characteristics(protection_element=["line", "trafo"])
+
+        described = describe_relay_zones(relays, cfg)
+
+        assert described["breaker_uuid"].tolist() == ["relay-0", "relay-1"]
+        assert described["poly"].map(lambda poly: poly.equals(_square_poly())).all()
+
+    def test_it_resolves_both_cases_per_zone(self):
+        """Four factor columns: two zones times two cases."""
+        cfg = _config(
+            alarm={"basecase_line": 1.1, "contingency_line": 1.2},
+            warning={"basecase_line": 1.3, "contingency_line": 1.4},
+        )
+        described = describe_relay_zones(_sw_characteristics(protection_element=["line"]), cfg)
+
+        assert described["effective_alarm_basecase"].tolist() == [1.1]
+        assert described["effective_alarm_contingency"].tolist() == [1.2]
+        assert described["effective_warning_basecase"].tolist() == [1.3]
+        assert described["effective_warning_contingency"].tolist() == [1.4]
+
+    def test_it_follows_the_element_type(self):
+        cfg = _config(warning={"basecase_transformer": 2.0, "basecase_bus_coupler": 3.0})
+        relays = _sw_characteristics(protection_element=["line", "trafo", "bus_coupler"])
+
+        described = describe_relay_zones(relays, cfg)
+
+        assert described["effective_warning_basecase"].tolist() == [1.0, 2.0, 3.0]
+
+    def test_a_per_relay_override_shows_up_in_the_result(self):
+        """This is the point of the helper: see the value a relay really gets."""
+        cfg = _config(warning={"basecase_line": 2.0})
+        relays = _sw_characteristics(protection_element=["line", "line"], custom_base_warning=[5.0, np.nan])
+
+        described = describe_relay_zones(relays, cfg)
+
+        assert described["effective_warning_basecase"].tolist() == [5.0, 2.0]
+
+    def test_it_does_not_modify_the_input(self):
+        """angle stays in degrees on the caller's frame, and no poly column is added to it."""
+        cfg = _config()
+        relays = _sw_characteristics(protection_element=["line"])
+
+        describe_relay_zones(relays, cfg)
+
+        assert relays["angle"].tolist() == [30.0]
+        assert "poly" not in relays.columns
+
+    def test_an_already_prepared_table_is_not_converted_twice(self):
+        """A poly column marks a table prepare_cascade_run_constants already handled."""
+        cfg = _config()
+        prepared = _sw_characteristics(protection_element=["line"])
+        prepared["angle"] = np.radians(prepared["angle"])
+        prepared["poly"] = [_square_poly()]
+
+        described = describe_relay_zones(prepared, cfg)
+
+        assert described["poly"].iloc[0].equals(_square_poly())
+
+    def test_it_keeps_every_original_column(self):
+        """prepare_cascade_run_constants puts this frame on the net in place of the original.
+
+        The per-outage merge then selects relay_side and protection_side from it, so dropping
+        a column here would only surface as a KeyError once an outage runs.
+        """
+        relays = _sw_characteristics(protection_element=["line"])
+
+        described = describe_relay_zones(relays, _config())
+
+        assert set(relays.columns) <= set(described.columns)
+        assert DERIVED_COLUMNS <= set(described.columns)
+
+    def test_an_empty_relay_table_is_handled(self):
+        relays = _sw_characteristics(protection_element=[])
+
+        described = describe_relay_zones(relays, _config())
+
+        assert described.empty
+        assert set(relays.columns) <= set(described.columns)
+        assert DERIVED_COLUMNS <= set(described.columns)
 
 
 def test_an_empty_relay_frame_is_handled():
@@ -486,5 +610,5 @@ def test_an_empty_relay_frame_is_handled():
     df = _relays(protection_element=[], r_ohm=[])
 
     assert get_danger_area(df).tolist() == []
-    assert get_alarm_area(df, cfg).tolist() == []
-    assert get_warning_area(df, cfg).tolist() == []
+    assert get_alarm_area(_prepared(df, cfg)).tolist() == []
+    assert get_warning_area(_prepared(df, cfg)).tolist() == []

--- a/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_overload_thresholds.py
+++ b/packages/contingency_analysis_pkg/tests/pandapower/cascade/test_overload_thresholds.py
@@ -1,0 +1,102 @@
+# Copyright 2026 50Hertz Transmission GmbH and Elia Transmission Belgium SA/NV
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# you can obtain one at https://mozilla.org/MPL/2.0/.
+# Mozilla Public License, version 2.0
+
+"""OverloadConfig.threshold: which loading threshold applies to one branch.
+
+Unlike the distance-protection factors, these keep a fallback chain: the more specific value
+wins, then the base-case one for the same element type, then the scalar that applies to
+everything.
+"""
+
+import pytest
+from toop_engine_contingency_analysis.pandapower.cascade.configuration import OverloadConfig
+
+SCALAR = 1.0
+
+
+def _overload(**overrides: float) -> OverloadConfig:
+    return OverloadConfig(current_loading_threshold=SCALAR, **overrides)
+
+
+class TestNoOverrides:
+    """With nothing set, every branch is compared against the scalar threshold."""
+
+    @pytest.mark.parametrize("element_table", ["line", "trafo", "trafo3w", "impedance"])
+    @pytest.mark.parametrize("basecase", [True, False])
+    def test_everything_uses_the_scalar(self, element_table: str, basecase: bool):
+        assert _overload().threshold(element_table, basecase=basecase) == SCALAR
+
+
+class TestLineThresholds:
+    def test_basecase_uses_the_basecase_line_value(self):
+        assert _overload(basecase_line=1.5).threshold("line", basecase=True) == 1.5
+
+    def test_contingency_prefers_its_own_value(self):
+        cfg = _overload(basecase_line=1.5, contingency_line=1.8)
+
+        assert cfg.threshold("line", basecase=False) == 1.8
+
+    def test_contingency_falls_back_to_the_basecase_value(self):
+        assert _overload(basecase_line=1.5).threshold("line", basecase=False) == 1.5
+
+    def test_a_contingency_only_value_leaves_the_basecase_on_the_scalar(self):
+        cfg = _overload(contingency_line=1.8)
+
+        assert cfg.threshold("line", basecase=True) == SCALAR
+        assert cfg.threshold("line", basecase=False) == 1.8
+
+
+class TestTransformerThresholds:
+    """trafo and trafo3w share one pair of overrides."""
+
+    @pytest.mark.parametrize("element_table", ["trafo", "trafo3w"])
+    def test_basecase_uses_the_basecase_transformer_value(self, element_table: str):
+        assert _overload(basecase_transformer=1.8).threshold(element_table, basecase=True) == 1.8
+
+    @pytest.mark.parametrize("element_table", ["trafo", "trafo3w"])
+    def test_contingency_prefers_its_own_value(self, element_table: str):
+        cfg = _overload(basecase_transformer=1.8, contingency_transformer=2.0)
+
+        assert cfg.threshold(element_table, basecase=False) == 2.0
+
+    @pytest.mark.parametrize("element_table", ["trafo", "trafo3w"])
+    def test_contingency_falls_back_to_the_basecase_value(self, element_table: str):
+        assert _overload(basecase_transformer=1.8).threshold(element_table, basecase=False) == 1.8
+
+
+class TestAxesDoNotLeak:
+    """A threshold set for one element type must not reach the other."""
+
+    def test_a_line_override_does_not_move_transformers(self):
+        cfg = _overload(basecase_line=1.5, contingency_line=1.5)
+
+        assert cfg.threshold("trafo", basecase=True) == SCALAR
+        assert cfg.threshold("trafo", basecase=False) == SCALAR
+
+    def test_a_transformer_override_does_not_move_lines(self):
+        cfg = _overload(basecase_transformer=1.8, contingency_transformer=1.8)
+
+        assert cfg.threshold("line", basecase=True) == SCALAR
+        assert cfg.threshold("line", basecase=False) == SCALAR
+
+    @pytest.mark.parametrize("basecase", [True, False])
+    def test_other_tables_always_use_the_scalar(self, basecase: bool):
+        """impedance has no dedicated threshold, so no override may reach it."""
+        cfg = _overload(
+            basecase_line=1.5,
+            contingency_line=1.5,
+            basecase_transformer=1.8,
+            contingency_transformer=1.8,
+        )
+
+        assert cfg.threshold("impedance", basecase=basecase) == SCALAR
+
+
+def test_the_scalar_threshold_is_required():
+    """It is the root of every fallback chain, so it has no default."""
+    with pytest.raises(ValueError):
+        OverloadConfig()


### PR DESCRIPTION
## Checklist
 
- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)
 
## Does this PR already have an issue describing the problem?
 
Fixes #
 
## What is the new behavior (if this is a feature change)?
 
Distance protection now screens a relay measurement against three nested
zones instead of two: danger, alarm and warning.
 
- **Danger** is the relay polygon as the relay defines it. It takes no
  factors, so nothing can widen the real trip boundary.
- **Alarm** and **warning** sit outside it. Each is configurable per case
  (basecase / contingency) and per protected element type (line / bus_coupler /
  transformer) — eight factors, all required.
 
A relay trips when it is inside any zone. The event records the innermost
zone it reached, as `DANGER`, `ALARM` or `WARNING`.
 
Per-relay overrides come from the four new `custom_*` columns in
`sw_characteristics` and win for their own severity and case. The new
`protection_element` column picks the line, bus_coupler or transformer factor; a relay
whose protected side carries both or neither takes the wider of the two.
 
`CascadeConfig` is regrouped into `OverloadConfig` and
`DistanceProtectionConfig`, so each sub-config owns its own resolver.
 
## Does this PR introduce a breaking change?
 
- [x] Yes
- [ ] No
 
`basecase_distance_protection_factor` and
`contingency_distance_protection_factor` are removed, and `CascadeConfig`
now takes nested `overload` and `distance_protection` sub-configs. Callers
must pass all eight factors explicitly.
 
Consumers reading `distance_protection_severity` should note it can now be
`ALARM` as well as `DANGER` or `WARNING`.