### PR TITLE
fix: drop multi-outage groups that island the grid

### DIFF
--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/inputs.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/inputs.py
@@ -767,7 +767,7 @@ def _load_static_information(binaryio: io.IOBase) -> StaticInformation:
                         else None,
                     )
                 ),
-                multi_outage_branches=list(_load_multi_outage_branch(file)),
+                multi_outage_branches=tuple(_load_multi_outage_branch(file)),
                 nonrel_injection_outage_deltap=jnp.array(file["nonrel_injection_outage_deltap"][:]),
                 nonrel_injection_outage_node=jnp.array(file["nonrel_injection_outage_node"][:]),
                 relevant_injection_outage_sub=jnp.array(file["relevant_injection_outage_sub"][:]),

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/inputs.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/inputs.py
@@ -275,13 +275,9 @@ def validate_static_information(
             "Action start indices should point to the first action of a substation, which should not have any branch actions"
         )
 
-    assert len(di.multi_outage_branches) == len(di.multi_outage_nodes)
-    for branch_arr, node_arr in zip(di.multi_outage_branches, di.multi_outage_nodes, strict=True):
-        assert branch_arr.shape[0] == node_arr.shape[0]
+    for branch_arr in di.multi_outage_branches:
         assert len(branch_arr.shape) == 2
-        assert len(node_arr.shape) == 2
         assert branch_arr.dtype in [jnp.int32, jnp.int64]
-        assert node_arr.dtype in [jnp.int32, jnp.int64]
         assert jnp.all(branch_arr >= 0)
         assert jnp.all(branch_arr < n_branch)
 
@@ -565,20 +561,10 @@ def _save_static_information(binaryio: io.IOBase, static_information: StaticInfo
                     data=nodal_inj_opt.parallel_pst_group_mask,
                 )
 
-        for idx, (branches, nodes) in enumerate(
-            zip(
-                dynamic_information.multi_outage_branches,
-                dynamic_information.multi_outage_nodes,
-                strict=True,
-            )
-        ):
+        for idx, branches in enumerate(dynamic_information.multi_outage_branches):
             file.create_dataset(
                 f"multi_outage_branches_{idx}",
                 data=branches,
-            )
-            file.create_dataset(
-                f"multi_outage_nodes_{idx}",
-                data=nodes,
             )
 
         file.attrs["version"] = version("toop-engine-dc-solver")
@@ -712,14 +698,6 @@ def _load_static_information(binaryio: io.IOBase) -> StaticInformation:
             yield jnp.array(file[f"multi_outage_branches_{idx}"][:])
             idx += 1
 
-    def _load_multi_outage_node(
-        file: h5py.File,
-    ) -> Iterator[Int[np.ndarray, " n_nodes"]]:
-        idx = 0
-        while f"multi_outage_nodes_{idx}" in file:
-            yield jnp.array(file[f"multi_outage_nodes_{idx}"][:])
-            idx += 1
-
     def _get_array_if_exists(file: h5py.File, key: str, default: Optional[Array] = None) -> Optional[Array]:
         return jnp.array(file[key][:]) if key in file else default
 
@@ -790,7 +768,6 @@ def _load_static_information(binaryio: io.IOBase) -> StaticInformation:
                     )
                 ),
                 multi_outage_branches=list(_load_multi_outage_branch(file)),
-                multi_outage_nodes=list(_load_multi_outage_node(file)),
                 nonrel_injection_outage_deltap=jnp.array(file["nonrel_injection_outage_deltap"][:]),
                 nonrel_injection_outage_node=jnp.array(file["nonrel_injection_outage_node"][:]),
                 relevant_injection_outage_sub=jnp.array(file["relevant_injection_outage_sub"][:]),

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
@@ -33,7 +33,7 @@ def build_modf_matrices(
     ptdf: Float[Array, " n_branches n_bus"],
     from_node: Int[Array, " n_branches"],
     to_node: Int[Array, " n_branches"],
-    multi_outage_branches: list[Int[Array, " n_multi_outages max_n_outaged_branches"]],
+    multi_outage_branches: list[Int[Array, " _ _"]],
 ) -> tuple[list[MODFMatrix], Bool[Array, " all_multi_outages"]]:
     """Build the MODF matrix for all multi-outages
 
@@ -48,8 +48,11 @@ def build_modf_matrices(
         The from nodes of the branches
     to_node : Int[Array, " n_branches"]
         The to nodes of the branches
-    multi_outage_branches : list[Int[Array, " n_multi_outages max_n_outaged_branches"]]
-        The list of multi-outage cases as stored in static_information.dynamic_information.multi_outage_branches
+    multi_outage_branches : list[Int[Array, " _ _"]]
+        The list of multi-outage cases as stored in static_information.dynamic_information.multi_outage_branches.
+        The entries are batches grouped by the number of outaged branches, so both the number of
+        outages and the number of outaged branches differ between entries - neither axis may be
+        bound to a shared name.
 
     Returns
     -------

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
@@ -33,7 +33,7 @@ def build_modf_matrices(
     ptdf: Float[Array, " n_branches n_bus"],
     from_node: Int[Array, " n_branches"],
     to_node: Int[Array, " n_branches"],
-    multi_outage_branches: list[Int[Array, " _ _"]],
+    multi_outage_branches: tuple[Int[Array, " _ _"]],
 ) -> tuple[list[MODFMatrix], Bool[Array, " all_multi_outages"]]:
     """Build the MODF matrix for all multi-outages
 
@@ -48,7 +48,7 @@ def build_modf_matrices(
         The from nodes of the branches
     to_node : Int[Array, " n_branches"]
         The to nodes of the branches
-    multi_outage_branches : list[Int[Array, " _ _"]]
+    multi_outage_branches : tuple[Int[Array, " _ _"]]
         The list of multi-outage cases as stored in static_information.dynamic_information.multi_outage_branches.
         The entries are batches grouped by the number of outaged branches, so both the number of
         outages and the number of outaged branches differ between entries - neither axis may be

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
@@ -33,7 +33,7 @@ def build_modf_matrices(
     ptdf: Float[Array, " n_branches n_bus"],
     from_node: Int[Array, " n_branches"],
     to_node: Int[Array, " n_branches"],
-    multi_outage_branches: tuple[Int[Array, " _ _"]],
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
 ) -> tuple[list[MODFMatrix], Bool[Array, " all_multi_outages"]]:
     """Build the MODF matrix for all multi-outages
 
@@ -48,7 +48,7 @@ def build_modf_matrices(
         The from nodes of the branches
     to_node : Int[Array, " n_branches"]
         The to nodes of the branches
-    multi_outage_branches : tuple[Int[Array, " _ _"]]
+    multi_outage_branches : tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
         The list of multi-outage cases as stored in static_information.dynamic_information.multi_outage_branches.
         The entries are batches grouped by the number of outaged branches, so both the number of
         outages and the number of outaged branches differ between entries - neither axis may be

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/multi_outages.py
@@ -33,7 +33,7 @@ def build_modf_matrices(
     ptdf: Float[Array, " n_branches n_bus"],
     from_node: Int[Array, " n_branches"],
     to_node: Int[Array, " n_branches"],
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...],
 ) -> tuple[list[MODFMatrix], Bool[Array, " all_multi_outages"]]:
     """Build the MODF matrix for all multi-outages
 
@@ -48,11 +48,11 @@ def build_modf_matrices(
         The from nodes of the branches
     to_node : Int[Array, " n_branches"]
         The to nodes of the branches
-    multi_outage_branches : tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
+    multi_outage_branches : tuple[Int[Array, " _ _"], ...]
         The list of multi-outage cases as stored in static_information.dynamic_information.multi_outage_branches.
-        The entries are batches grouped by the number of outaged branches, so both the number of
-        outages and the number of outaged branches differ between entries - neither axis may be
-        bound to a shared name.
+        Each entry is one batch of shape (n_outages_in_batch, n_outaged_branches), grouped by the
+        number of outaged branches, so both axes differ between entries - neither may be bound to a
+        jaxtyping name.
 
     Returns
     -------

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
@@ -585,9 +585,11 @@ class DynamicInformation(eqx.Module):
     """An action set to be used in the solver. This holds the possible configurations for each
     substation. Topology actions that are passed into the solver index into this action set."""
 
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
-    """A multi-outage is a set of branches that are failed simultaneously. The last dimension of
-    each array represents the set of branches, the first dimension is a collection of multi-outages.
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...]
+    """A multi-outage is a set of branches that are failed simultaneously. Each entry is one batch
+    of shape (n_outages_in_batch, n_outaged_branches): the last dimension represents the set of
+    branches, the first dimension is a collection of multi-outages. Both axes differ between
+    entries, so neither may be bound to a jaxtyping name.
     This supports padding, hence if you want to group multi-outages with varying numbers of branches,
     you can pad the arrays with invalid branch indices, e.g. int_max. Trade carefully, as this will
     solve a system of linear equations the size of n_branches_failed, irrespective of whether

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
@@ -585,7 +585,7 @@ class DynamicInformation(eqx.Module):
     """An action set to be used in the solver. This holds the possible configurations for each
     substation. Topology actions that are passed into the solver index into this action set."""
 
-    multi_outage_branches: list[Int[Array, " _ _"]]
+    multi_outage_branches: tuple[Int[Array, " _ _"]]
     """A multi-outage is a set of branches that are failed simultaneously. The last dimension of
     each array represents the set of branches, the first dimension is a collection of multi-outages.
     This supports padding, hence if you want to group multi-outages with varying numbers of branches,

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
@@ -585,7 +585,7 @@ class DynamicInformation(eqx.Module):
     """An action set to be used in the solver. This holds the possible configurations for each
     substation. Topology actions that are passed into the solver index into this action set."""
 
-    multi_outage_branches: tuple[Int[Array, " _ _"]]
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
     """A multi-outage is a set of branches that are failed simultaneously. The last dimension of
     each array represents the set of branches, the first dimension is a collection of multi-outages.
     This supports padding, hence if you want to group multi-outages with varying numbers of branches,

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/jax/types.py
@@ -585,20 +585,13 @@ class DynamicInformation(eqx.Module):
     """An action set to be used in the solver. This holds the possible configurations for each
     substation. Topology actions that are passed into the solver index into this action set."""
 
-    multi_outage_branches: list[Int[Array, " n_multi_outages n_branches_failed"]]
-    """A multi-outage consists of a set of branches that are failed simultaneously and a set of
-    nodes (multi_outage_nodes) to which all injections are zeroed. The last dimension of each array
-    represents the set of branches, the first dimension is a collection of multi-outages. This
-    supports padding, hence if you want to group multi-outages with varying numbers of branches, you
-    can pad the arrays with invalid branch indices, e.g. int_max. Trade carefully, as this will
+    multi_outage_branches: list[Int[Array, " _ _"]]
+    """A multi-outage is a set of branches that are failed simultaneously. The last dimension of
+    each array represents the set of branches, the first dimension is a collection of multi-outages.
+    This supports padding, hence if you want to group multi-outages with varying numbers of branches,
+    you can pad the arrays with invalid branch indices, e.g. int_max. Trade carefully, as this will
     solve a system of linear equations the size of n_branches_failed, irrespective of whether
     padding was applied or not. Hence, if possible, use a new group for each number of branches"""
-
-    multi_outage_nodes: list[Int[Array, " n_multi_outages n_nodes_failed"]]
-    """The nodes that correspond to the failures in multi_outage_branches. The length of the list
-    and the first dimension of each list entry is the same as multi_outage_branches. The second can
-    be different. This supports padding, hence if a different number of nodes needs to be zeroed for
-    a branch outage, the array can be padded with invalid node indices, e.g. int_max."""
 
     disconnectable_branches: Int[Array, " n_disconnectable_branches"]
     """The branches that can be disconnected as a remedial action. This is a list of indices into

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
@@ -74,7 +74,7 @@ class BSDFFilterCache(eqx.Module):
     branches_to_outage: Int[Array, " n_branches_to_outage"]
     """Indices of branches that are outaged."""
 
-    multi_outage_branches: tuple[Int[Array, " _ _"], ...]
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
     """Tuples of arrays, each containing the indices of branches involved in multi-outage scenarios.
 
     The batches are grouped by the number of outaged branches, so both axes differ between entries.
@@ -113,7 +113,7 @@ def _filter_splits_by_bsdf_valid_mask_batch(  # ruff: ignore[PLR0913, PLR0917]
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: tuple[Int[Array, " _ _"], ...],
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
 ) -> Bool[Array, " n_repo_batch"]:
     """Return the valid mask for one fixed-size BSDF/LODF validation batch.
 
@@ -134,7 +134,7 @@ def _filter_splits_by_bsdf_valid_mask_batch(  # ruff: ignore[PLR0913, PLR0917]
             slack=slack,
             n_stat=n_stat,
             branches_to_outage=branches_to_outage,
-            multi_outage_branches=tuple(multi_outage_branches),
+            multi_outage_branches=multi_outage_branches,
         )
     )
     valid_mask = valid_mask(repo_batch)
@@ -323,7 +323,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: tuple[Int[Array, " _ _"]],
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
 ) -> Bool[Array, ""]:
     """Check if a substation split is valid after both BSDF and LODF application
 
@@ -357,7 +357,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
         The number of substations in the grid
     branches_to_outage: Int[Array, " n_branches_to_outage"]
         The indices of the branches to outage
-    multi_outage_branches: tuple[Int[Array, " _ _"]]
+    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
         The indices of the branches to outage in the multi-outage case, batched by the number of
         outaged branches, so both axes differ between entries
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
@@ -74,8 +74,11 @@ class BSDFFilterCache(eqx.Module):
     branches_to_outage: Int[Array, " n_branches_to_outage"]
     """Indices of branches that are outaged."""
 
-    multi_outage_branches: tuple[Int[Array, " n_multi_outages n_branches_failed"], ...]
-    """Tuples of arrays, each containing the indices of branches involved in multi-outage scenarios."""
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...]
+    """Tuples of arrays, each containing the indices of branches involved in multi-outage scenarios.
+
+    The batches are grouped by the number of outaged branches, so both axes differ between entries.
+    """
 
 
 def _get_bsdf_filter_cache(
@@ -110,7 +113,7 @@ def _filter_splits_by_bsdf_valid_mask_batch(  # ruff: ignore[PLR0913, PLR0917]
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: tuple[Int[Array, " n_multi_outages n_branches_failed"], ...],
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...],
 ) -> Bool[Array, " n_repo_batch"]:
     """Return the valid mask for one fixed-size BSDF/LODF validation batch.
 
@@ -320,7 +323,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: list[Int[Array, " n_multi_outages n_branches_failed"]],
+    multi_outage_branches: list[Int[Array, " _ _"]],
 ) -> Bool[Array, ""]:
     """Check if a substation split is valid after both BSDF and LODF application
 
@@ -354,8 +357,9 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
         The number of substations in the grid
     branches_to_outage: Int[Array, " n_branches_to_outage"]
         The indices of the branches to outage
-    multi_outage_branches: list[Int[Array, " n_multi_outages n_branches_failed"]]
-        The indices of the branches to outage in the multi-outage case
+    multi_outage_branches: list[Int[Array, " _ _"]]
+        The indices of the branches to outage in the multi-outage case, batched by the number of
+        outaged branches, so both axes differ between entries
 
     Returns
     -------

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
@@ -74,7 +74,7 @@ class BSDFFilterCache(eqx.Module):
     branches_to_outage: Int[Array, " n_branches_to_outage"]
     """Indices of branches that are outaged."""
 
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...]
     """Tuples of arrays, each containing the indices of branches involved in multi-outage scenarios.
 
     The batches are grouped by the number of outaged branches, so both axes differ between entries.
@@ -113,7 +113,7 @@ def _filter_splits_by_bsdf_valid_mask_batch(  # ruff: ignore[PLR0913, PLR0917]
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...],
 ) -> Bool[Array, " n_repo_batch"]:
     """Return the valid mask for one fixed-size BSDF/LODF validation batch.
 
@@ -323,7 +323,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...],
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...],
 ) -> Bool[Array, ""]:
     """Check if a substation split is valid after both BSDF and LODF application
 
@@ -357,7 +357,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
         The number of substations in the grid
     branches_to_outage: Int[Array, " n_branches_to_outage"]
         The indices of the branches to outage
-    multi_outage_branches: tuple[Int[Array, " n_outages_in_batch n_outaged_branches"], ...]
+    multi_outage_branches: tuple[Int[Array, " _ _"], ...]
         The indices of the branches to outage in the multi-outage case, batched by the number of
         outaged branches, so both axes differ between entries
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
@@ -323,7 +323,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
     slack: Int[Array, ""],
     n_stat: Int[Array, ""],
     branches_to_outage: Int[Array, " n_branches_to_outage"],
-    multi_outage_branches: list[Int[Array, " _ _"]],
+    multi_outage_branches: tuple[Int[Array, " _ _"]],
 ) -> Bool[Array, ""]:
     """Check if a substation split is valid after both BSDF and LODF application
 
@@ -357,7 +357,7 @@ def is_valid_bsdf_lodf(  # noqa: PLR0913, PLR0917
         The number of substations in the grid
     branches_to_outage: Int[Array, " n_branches_to_outage"]
         The indices of the branches to outage
-    multi_outage_branches: list[Int[Array, " _ _"]]
+    multi_outage_branches: tuple[Int[Array, " _ _"]]
         The indices of the branches to outage in the multi-outage case, batched by the number of
         outaged branches, so both axes differ between entries
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/action_set.py
@@ -134,7 +134,7 @@ def _filter_splits_by_bsdf_valid_mask_batch(  # ruff: ignore[PLR0913, PLR0917]
             slack=slack,
             n_stat=n_stat,
             branches_to_outage=branches_to_outage,
-            multi_outage_branches=list(multi_outage_branches),
+            multi_outage_branches=tuple(multi_outage_branches),
         )
     )
     valid_mask = valid_mask(repo_batch)

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/convert_to_jax.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/convert_to_jax.py
@@ -270,7 +270,6 @@ def convert_to_jax(
             # Solver arguments
             action_set=action_set,
             multi_outage_branches=[jnp.array(x, dtype=int) for x in network_data.split_multi_outage_branches],
-            multi_outage_nodes=[jnp.array(x, dtype=int) for x in network_data.split_multi_outage_nodes],
             nonrel_injection_outage_deltap=jnp.array(network_data.nonrel_io_deltap, dtype=float),
             nonrel_injection_outage_node=jnp.array(network_data.nonrel_io_node, dtype=int),
             relevant_injection_outage_idx=jnp.array(network_data.rel_io_local_inj_index, dtype=int),

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/convert_to_jax.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/convert_to_jax.py
@@ -269,7 +269,7 @@ def convert_to_jax(
             disconnectable_branches=disconnectable_branches,
             # Solver arguments
             action_set=action_set,
-            multi_outage_branches=[jnp.array(x, dtype=int) for x in network_data.split_multi_outage_branches],
+            multi_outage_branches=tuple(jnp.array(x, dtype=int) for x in network_data.split_multi_outage_branches),
             nonrel_injection_outage_deltap=jnp.array(network_data.nonrel_io_deltap, dtype=float),
             nonrel_injection_outage_node=jnp.array(network_data.nonrel_io_node, dtype=int),
             relevant_injection_outage_idx=jnp.array(network_data.rel_io_local_inj_index, dtype=int),

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/helpers/find_bridges.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/helpers/find_bridges.py
@@ -130,6 +130,138 @@ def find_bridges(
     return branch_is_bridge
 
 
+def _group_islands_network(
+    graph: nx.MultiGraph,
+    from_node: Int[np.ndarray, " n_branch"],
+    to_node: Int[np.ndarray, " n_branch"],
+    base_component_count: int,
+    outaged_branches: Int[np.ndarray, " n_outaged"],
+) -> bool:
+    """Whether outaging the given branches together disconnects the network.
+
+    Mutates ``graph`` in place and restores it, mirroring
+    :func:`_count_bridges_after_outage_on_static_graph`.
+    """
+    edges = [(int(from_node[branch]), int(to_node[branch]), int(branch)) for branch in outaged_branches]
+    graph.remove_edges_from(edges)
+    islands = nx.number_connected_components(graph) > base_component_count
+    graph.add_edges_from(edges)
+    return islands
+
+
+def find_islanding_branch_groups(
+    from_node: Int[np.ndarray, " n_branch"],
+    to_node: Int[np.ndarray, " n_branch"],
+    number_of_nodes: int,
+    branch_group_mask: Bool[np.ndarray, " n_groups n_branch"],
+) -> Bool[np.ndarray, " n_groups"]:
+    """Identify branch groups whose simultaneous outage would island the network.
+
+    A single branch islands the network exactly if it is a bridge, but a group of non-bridges can
+    still form a cut set. The DC solver cannot represent an islanded grid: the MODF denominator of
+    such a group is singular for every topology, so a group has to be recognised the same way
+    :func:`find_bridges` recognises islanding single outages.
+
+    Parameters
+    ----------
+    from_node : Int[np.ndarray, " n_branch"]
+        The from-nodes vector.
+    to_node : Int[np.ndarray, " n_branch"]
+        The to-nodes vector.
+    number_of_nodes: int
+        How many nodes are in the system
+    branch_group_mask: Bool[np.ndarray, " n_groups n_branch"]
+        One row per group, true for every branch that the group outages.
+
+    Returns
+    -------
+    Bool[np.ndarray, " n_groups"]
+        Boolean array of length n_groups, true for every group that islands the network
+    """
+    if branch_group_mask.shape[0] == 0:
+        return np.zeros(0, dtype=bool)
+
+    graph = _get_graph_with_branch_keys(from_node, to_node, number_of_nodes)
+    base_component_count = nx.number_connected_components(graph)
+    return np.array(
+        [
+            _group_islands_network(graph, from_node, to_node, base_component_count, np.flatnonzero(group))
+            for group in branch_group_mask
+        ],
+        dtype=bool,
+    )
+
+
+def find_branches_to_spare_from_groups(
+    from_node: Int[np.ndarray, " n_branch"],
+    to_node: Int[np.ndarray, " n_branch"],
+    number_of_nodes: int,
+    branch_group_mask: Bool[np.ndarray, " n_groups n_branch"],
+) -> Bool[np.ndarray, " n_groups n_branch"]:
+    """Find, per group, the branches that must stay in service for the outage to be computable.
+
+    A three-winding transformer or a busbar outage isolates its own star node or busbar by
+    construction, so the group can never be computed in full. Sparing branches - leaving them in
+    service while the rest of the group is outaged - is what makes the remainder solvable. This is
+    the structural replacement for keying that behaviour off the element type.
+
+    Branches are spared in ascending index order, preferring one whose sparing resolves the
+    islanding on its own, so a group that is repairable by a single spare keeps every other branch.
+
+    Parameters
+    ----------
+    from_node : Int[np.ndarray, " n_branch"]
+        The from-nodes vector.
+    to_node : Int[np.ndarray, " n_branch"]
+        The to-nodes vector.
+    number_of_nodes: int
+        How many nodes are in the system
+    branch_group_mask: Bool[np.ndarray, " n_groups n_branch"]
+        One row per group, true for every branch that the group outages.
+
+    Returns
+    -------
+    Bool[np.ndarray, " n_groups n_branch"]
+        One row per group, true for every branch that has to be spared. An all-false row means the
+        group is computable as it stands; a row equal to its group means it is not computable at all.
+    """
+    spared = np.zeros_like(branch_group_mask)
+    if branch_group_mask.shape[0] == 0:
+        return spared
+
+    graph = _get_graph_with_branch_keys(from_node, to_node, number_of_nodes)
+    base_component_count = nx.number_connected_components(graph)
+
+    for group_index, group in enumerate(branch_group_mask):
+        remaining = group.copy()
+        while remaining.any() and _group_islands_network(
+            graph, from_node, to_node, base_component_count, np.flatnonzero(remaining)
+        ):
+            candidates = np.flatnonzero(remaining)
+            # Stop at the first branch that resolves the islanding on its own, and fall back to the
+            # lowest index when none does; the loop then tries again on the smaller remainder.
+            branch_to_spare = int(
+                next(
+                    (
+                        branch
+                        for branch in candidates
+                        if not _group_islands_network(
+                            graph,
+                            from_node,
+                            to_node,
+                            base_component_count,
+                            candidates[candidates != branch],
+                        )
+                    ),
+                    candidates[0],
+                )
+            )
+            spared[group_index, branch_to_spare] = True
+            remaining[branch_to_spare] = False
+
+    return spared
+
+
 def get_bridge_mainland_node_indices(
     from_node: Int[np.ndarray, " n_branch"],
     to_node: Int[np.ndarray, " n_branch"],

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/helpers/reduce_node_dimension.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/helpers/reduce_node_dimension.py
@@ -22,7 +22,6 @@ from jaxtyping import Bool, Float, Int
 
 def get_significant_nodes(
     relevant_node_mask: Bool[np.ndarray, " n_nodes"],
-    multi_outage_node_mask: Bool[np.ndarray, " n_multioutages n_nodes"],
     relevant_branches: Int[np.ndarray, " n_relevant_branches"],
     from_nodes: Int[np.ndarray, " n_nodes"],
     to_nodes: Int[np.ndarray, " n_nodes"],
@@ -30,16 +29,14 @@ def get_significant_nodes(
 ) -> Bool[np.ndarray, " n_nodes"]:
     """Get all nodes that are in some way significant for the loadflow computations and actions.
 
-    This includes all nodes that are already part of relevant subs, connected to a relevant branch or
-    part of a multi outage.
+    This includes all nodes that are already part of relevant subs or connected to a relevant branch.
+    Multi-outage branches are relevant branches, so their end nodes are covered by that.
     To be sure we don't break stuff after switching, we also add nodes that are 2 branches away.
 
     Parameters
     ----------
     relevant_node_mask : Bool[np.ndarray, " n_nodes"]
         A mask indicating which nodes are significant.
-    multi_outage_node_mask : Bool[np.ndarray, " n_nodes"]
-        A mask indicating which nodes are part of a multi outage.
     relevant_branches : Int[np.ndarray, " n_relevant_branches"]
         The indices of the relevant branches.
     from_nodes : Int[np.ndarray, " n_branches"]
@@ -65,7 +62,6 @@ def get_significant_nodes(
         # Add all nodes that are connected to relevant branches
         significant_nodes[from_nodes[relevant_branch_mask]] = True
         significant_nodes[to_nodes[relevant_branch_mask]] = True
-    significant_nodes |= multi_outage_node_mask.any(axis=0)
     significant_nodes[slack] = True
     return significant_nodes
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
@@ -251,7 +251,7 @@ class NetworkData:
     """A list of the length of relevant nodes.
     Contains Boolean Arrays depicting if injection is non-zero / active in any timesteps"""
 
-    split_multi_outage_branches: Optional[list[Int[np.ndarray, " n_multi_outages n_splits"]]] = None
+    split_multi_outage_branches: Optional[tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...]] = None
     """The indices of the branches that are outaged in the multi-outage cases, sorted by
     the amount of branches involved in the outage and represented as integers"""
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
@@ -251,9 +251,11 @@ class NetworkData:
     """A list of the length of relevant nodes.
     Contains Boolean Arrays depicting if injection is non-zero / active in any timesteps"""
 
-    split_multi_outage_branches: Optional[tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...]] = None
+    split_multi_outage_branches: Optional[tuple[Int[np.ndarray, " _ _"], ...]] = None
     """The indices of the branches that are outaged in the multi-outage cases, sorted by
-    the amount of branches involved in the outage and represented as integers"""
+    the amount of branches involved in the outage and represented as integers. Each entry is one
+    batch of shape (n_outages_in_batch, n_outaged_branches); both axes differ between entries, so
+    neither may be bound to a jaxtyping name."""
 
     nonrel_io_deltap: Optional[Float[np.ndarray, " n_timesteps n_injection_outages"]] = None
     """The delta p for every injection outage at non-relevant substations.

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/network_data.py
@@ -151,9 +151,6 @@ class NetworkData:
     multi_outage_branch_mask: Bool[np.ndarray, " n_multi_outages n_branch"]
     """Which sets of branches should be outaged as part of the multi-outage computation"""
 
-    multi_outage_node_mask: Bool[np.ndarray, " n_multi_outages n_node"]
-    """Which sets of nodes should be outaged as part of the multi-outage computation"""
-
     injection_nodes: Int[np.ndarray, " n_injection"]
     """The node index that the injection injects onto"""
 
@@ -205,6 +202,19 @@ class NetworkData:
     bridging_branch_mask: Optional[Bool[np.ndarray, " n_branch"]] = None
     """Mask of branches that would lead to islanding if outaged"""
 
+    multi_outage_spared_branch_mask: Optional[Bool[np.ndarray, " n_multi_outages n_branch"]] = None
+    """Per multi-outage, the branches that stay in service although the group outages them.
+
+    A trafo3w or busbar group isolates its own star node or busbar by construction, so it can never
+    be computed in full. ``exclude_bridges_from_outage_masks`` determines on the unreduced network
+    which branches have to be spared for the remainder to be solvable, and
+    ``convert_multi_outages`` leaves them out of ``split_multi_outage_branches``.
+
+    ``multi_outage_branch_mask`` keeps the group as defined, so the DC projection still reports the
+    full contingency; this mask records the gap between what is declared and what DC computes.
+    ``None`` means nothing is spared.
+    """
+
     bridge_mainland_node_indices: Optional[Int[np.ndarray, " n_branch"]] = None
     """For each bridging branch, the endpoint node index that stays on the mainland side.
 
@@ -243,10 +253,6 @@ class NetworkData:
 
     split_multi_outage_branches: Optional[list[Int[np.ndarray, " n_multi_outages n_splits"]]] = None
     """The indices of the branches that are outaged in the multi-outage cases, sorted by
-    the amount of branches involved in the outage and represented as integers"""
-
-    split_multi_outage_nodes: Optional[list[Int[np.ndarray, " n_multi_outages n_splits"]]] = None
-    """The indices of the nodes that are outaged in the multi-outage cases, sorted by
     the amount of branches involved in the outage and represented as integers"""
 
     nonrel_io_deltap: Optional[Float[np.ndarray, " n_timesteps n_injection_outages"]] = None
@@ -568,7 +574,6 @@ def extract_network_data_from_interface(interface: BackendInterface) -> NetworkD
         outaged_branch_mask=interface.get_outaged_branch_mask(),
         outaged_injection_mask=interface.get_outaged_injection_mask(),
         multi_outage_branch_mask=interface.get_multi_outage_branches(),
-        multi_outage_node_mask=interface.get_multi_outage_nodes(),
         injection_nodes=interface.get_injection_nodes(),
         mw_injections=interface.get_mw_injections(),
         base_mva=interface.get_base_mva(),
@@ -727,7 +732,10 @@ def validate_network_data(network_data: NetworkData) -> None:
     assert network_data.disconnectable_branch_mask.shape == (n_branch,)
     assert network_data.outaged_branch_mask.shape == (n_branch,)
     assert network_data.multi_outage_branch_mask.shape == (n_multi_outage, n_branch)
-    assert network_data.multi_outage_node_mask.shape == (n_multi_outage, n_nodes)
+    if network_data.multi_outage_spared_branch_mask is not None:
+        assert network_data.multi_outage_spared_branch_mask.shape == (n_multi_outage, n_branch)
+        # A spared branch only ever weakens a group, it never adds one.
+        assert not np.any(network_data.multi_outage_spared_branch_mask & ~network_data.multi_outage_branch_mask)
     assert network_data.injection_nodes.shape == (n_injections,)
     assert network_data.mw_injections.shape == (n_timestep, n_injections)
     assert network_data.ac_dc_mismatch.shape == (n_timestep, n_branch)
@@ -760,7 +768,6 @@ def validate_network_data(network_data: NetworkData) -> None:
     assert network_data.num_injections_per_node.shape == (n_rel_subs,)
     assert len(network_data.active_injections) == n_rel_subs
     assert sum(len(mo) for mo in network_data.split_multi_outage_branches) == n_multi_outage
-    assert sum(len(mo) for mo in network_data.split_multi_outage_nodes) == n_multi_outage
 
     for branch_act, inj_act, sw_dist in zip(
         network_data.branch_action_set,
@@ -1158,9 +1165,8 @@ def extract_nminus1_definition(network_data: NetworkData) -> Nminus1Definition:
     ]
 
     multi_contingencies = []
-    for branch_mask, node_mask, outage_id, outage_name in zip(  # noqa: B007
+    for branch_mask, outage_id, outage_name in zip(
         network_data.multi_outage_branch_mask,
-        network_data.multi_outage_node_mask,
         network_data.multi_outage_ids,
         network_data.multi_outage_names,
         strict=True,
@@ -1172,13 +1178,6 @@ def extract_nminus1_definition(network_data: NetworkData) -> Nminus1Definition:
             )
             if outage
         ]
-        # This does not make sense right now as multi-outages will never have node outages.
-        # TODO refactor multi-outages and change this.
-        # elements += [
-        #     GridElement(id=node_id, type=node_type, kind="node")
-        #     for (node_id, node_type, outage) in zip(network_data.node_ids, network_data.node_types, node_mask)
-        #     if outage
-        # ]
         multi_contingencies.append(Contingency(elements=elements, id=outage_id, name=outage_name))
 
     nonrel_inj_contingencies = [

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/pandapower/pandapower_backend.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/pandapower/pandapower_backend.py
@@ -36,7 +36,6 @@ from toop_engine_grid_helpers.pandapower.pandapower_tasks import (
     get_max_trafo3w_flow,
     get_max_trafo_flow,
     get_trafo3w_ppc_branch_idx,
-    get_trafo3w_ppc_node_idx,
 )
 from toop_engine_grid_helpers.pandapower.station_extraction import (
     add_substation_column_to_bus,
@@ -809,11 +808,10 @@ class PandaPowerBackend(BackendInterface):
         self,
     ) -> tuple[
         Bool[np.ndarray, " n_trafo3w_outages n_branch"],
-        Bool[np.ndarray, " n_trafo3w_outages n_node"],
         list[str],
         list[int],
     ]:
-        """Get mask of outaged branches, busbars and names for trafo3ws to outage
+        """Get mask of outaged branches and names for trafo3ws to outage
 
         True means a branch is outaged, False means it is not outaged.
 
@@ -821,8 +819,6 @@ class PandaPowerBackend(BackendInterface):
         -------
         Bool[np.ndarray, " n_trafo3w_outages n_branch"]
             The mask of outaged branches for every trafo3w-outage
-        Bool[np.ndarray, " n_trafo3w_outages n_node"]
-            The mask of outaged nodes for every trafo3w-outage
         list[str]
             The names of the trafo3w multi-outages
         list[int]
@@ -842,7 +838,6 @@ class PandaPowerBackend(BackendInterface):
             )
             return (
                 np.empty((0, self.ppci["branch"].shape[0]), dtype=bool),
-                np.empty((0, self.ppci["bus"].shape[0]), dtype=bool),
                 [],
                 [],
             )
@@ -856,14 +851,9 @@ class PandaPowerBackend(BackendInterface):
         branch_outages = np.zeros((len(outaged_trafo3w_idx), ppc_branch_inservice.shape[0]), dtype=bool)
         branch_outages[np.arange(len(outaged_trafo3w_idx)), ppc_branch_indices] = True
 
-        ppc_node_indices = get_trafo3w_ppc_node_idx(self.ppci, ppc_branch_indices)
-        bus_outages = np.zeros((len(outaged_trafo3w_idx), self.ppci["bus"].shape[0]), dtype=bool)
-        bus_outages[np.arange(len(outaged_trafo3w_idx)), ppc_node_indices] = True
-
         # Filter down to only ppci-branches
         return (
             branch_outages[:, ppc_branch_inservice],
-            bus_outages,
             trafo3w_outage_names,
             trafo3w_outage_id,
         )
@@ -872,18 +862,15 @@ class PandaPowerBackend(BackendInterface):
         self,
     ) -> tuple[
         Bool[np.ndarray, " n_busbar_outages n_branch"],
-        Bool[np.ndarray, " n_busbar_outages n_node"],
         list[str],
         list[int],
     ]:
-        """Get mask of nodes for which nodal injections will be zeroed
+        """Get mask of branches to outage for every busbar in the multi-outage definition
 
         Returns
         -------
         Bool[np.ndarray, " n_busbar_outages n_branch"],
             The mask of outaged branches for every busbar-outage
-        Bool[np.ndarray, " n_busbar_outages n_node"],
-            The mask of outaged nodes for every busbar-outage
         list[str]
             The names of the busbar multi-outages
         list[int]
@@ -902,7 +889,6 @@ class PandaPowerBackend(BackendInterface):
             )
             return (
                 np.empty((0, self.ppci["branch"].shape[0]), dtype=bool),
-                np.empty((0, self.ppci["bus"].shape[0]), dtype=bool),
                 [],
                 [],
             )
@@ -912,12 +898,10 @@ class PandaPowerBackend(BackendInterface):
         busbar_pp_idx = np.flatnonzero(busbar_mask)
         # Translate busses to ppci_format
         busbar_ppci_idx = self.net._pd2ppc_lookups["bus"][busbar_pp_idx]
-        busbar_outages = np.zeros((len(busbar_ppci_idx), self.ppci["bus"].shape[0]), dtype=bool)
-        busbar_outages[np.arange(len(busbar_ppci_idx)), busbar_ppci_idx] = True
         # Find branches going from or to these bus_idx
         branch_bus_columns = self.ppci["branch"][:, [F_BUS, T_BUS]]
         branch_outages = np.array([(branch_bus_columns == bus_id).any(axis=1) for bus_id in busbar_ppci_idx])
-        return branch_outages, busbar_outages, busbar_outage_names, busbar_outage_id
+        return branch_outages, busbar_outage_names, busbar_outage_id
 
     def get_multi_outage_branches(
         self,
@@ -931,24 +915,8 @@ class PandaPowerBackend(BackendInterface):
         Bool[np.ndarray, " n_multi_outages n_branch"]
             The mask of outaged branches for every multi-outage
         """
-        trafo3w_outages, _, _, _ = self.get_trafo3w_multioutage()
-        busbar_outages, _, _, _ = self.get_busbar_multioutage()
-        return np.concatenate([trafo3w_outages, busbar_outages])
-
-    def get_multi_outage_nodes(
-        self,
-    ) -> Bool[np.ndarray, " n_multi_outages n_node"]:
-        """Get mask of outaged nodes for potential multi-outages
-
-        True means a node is outaged, False means it is not outaged.
-
-        Returns
-        -------
-        Bool[np.ndarray, " n_multi_outages n_node"]
-            The mask of outaged branches for every multi-outage
-        """
-        _, trafo3w_outages, _, _ = self.get_trafo3w_multioutage()
-        _, busbar_outages, _, _ = self.get_busbar_multioutage()
+        trafo3w_outages, _, _ = self.get_trafo3w_multioutage()
+        busbar_outages, _, _ = self.get_busbar_multioutage()
         return np.concatenate([trafo3w_outages, busbar_outages])
 
     def get_injection_nodes(self) -> Int[np.ndarray, " n_injection"]:
@@ -1340,8 +1308,8 @@ class PandaPowerBackend(BackendInterface):
         list[str]
             The names of the multi-outages
         """
-        _, _, trafo_names, _ = self.get_trafo3w_multioutage()
-        _, _, busbar_names, _ = self.get_busbar_multioutage()
+        _, trafo_names, _ = self.get_trafo3w_multioutage()
+        _, busbar_names, _ = self.get_busbar_multioutage()
         return trafo_names + busbar_names
 
     def get_multi_outage_ids_internal(self) -> list[int]:
@@ -1352,8 +1320,8 @@ class PandaPowerBackend(BackendInterface):
         list[int]
             The ids of the multi-outages
         """
-        _, _, _, trafo_ids = self.get_trafo3w_multioutage()
-        _, _, _, busbar_ids = self.get_busbar_multioutage()
+        _, _, trafo_ids = self.get_trafo3w_multioutage()
+        _, _, busbar_ids = self.get_busbar_multioutage()
         return trafo_ids + busbar_ids
 
     def get_multi_outage_ids(self) -> list[str]:
@@ -1380,8 +1348,8 @@ class PandaPowerBackend(BackendInterface):
         list[str]
             The types of the multi-outages
         """
-        _, trafo_outages, _, _ = self.get_trafo3w_multioutage()
-        _, busbar_outages, _, _ = self.get_busbar_multioutage()
+        trafo_outages, _, _ = self.get_trafo3w_multioutage()
+        busbar_outages, _, _ = self.get_busbar_multioutage()
         return ["trafo3w"] * len(trafo_outages) + ["bus"] * len(busbar_outages)
 
     def get_master_asset_topology(self) -> Optional[MasterAssetTopology]:

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/powsybl/powsybl_backend.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/powsybl/powsybl_backend.py
@@ -621,12 +621,6 @@ class PowsyblBackend(BackendInterface):
         """Get a mask of branches that are part of the multi-outage definition, currently always empty."""
         return np.zeros((0, len(self._get_branches())), dtype=bool)
 
-    def get_multi_outage_nodes(
-        self,
-    ) -> Bool[np.ndarray, " n_multi_outages n_node"]:
-        """Get a mask of nodes that are part of the multi-outage definition, currently always empty."""
-        return np.zeros((0, len(self._get_nodes())), dtype=bool)
-
     def get_injection_nodes(self) -> Int[np.ndarray, " n_injection"]:
         """Get the integer busbar indices of the injections"""
         return self._get_injections()["bus_id_int"].values

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -62,6 +62,7 @@ from toop_engine_dc_solver.preprocess.helpers.relevant_branches import (
 )
 from toop_engine_dc_solver.preprocess.network_data import (
     NetworkData,
+    SplitMultiOutageBranches,
     assert_network_data,
     extract_network_data_from_interface,
     get_network_data_stats,
@@ -1103,6 +1104,42 @@ def _log_dropped_multi_outages(
     )
 
 
+def _assert_multi_outage_batches_are_uniform(
+    split_multi_outage_branches: SplitMultiOutageBranches,
+    n_branch: int,
+) -> None:
+    """Assert the batching contract that the ``Int[Array, " _ _"]`` annotation cannot express.
+
+    ``split_multi_outage_branches`` holds one batch per distinct number of outaged branches, and each
+    batch carries its own pair of dimensions, so jaxtyping can only be told that the entries are
+    two-dimensional. The properties that actually matter are checked here instead:
+
+    - Every group within a batch outages the same number of branches, so
+      ``convert_boolean_mask_to_index_array`` never had to pad. A padded row would make the MODF
+      solve a linear system larger than the group needs, which is the whole cost the batching exists
+      to avoid - see ``DynamicInformation.multi_outage_branches``.
+    - Batch widths strictly increase, so each batch corresponds to exactly one group size.
+    - Every entry is a real branch index. Since ``_zero_out_first_branch`` is gone there are no
+      deliberate sentinels left, so an out-of-range index is a bug rather than padding.
+
+    Parameters
+    ----------
+    split_multi_outage_branches : SplitMultiOutageBranches
+        The batched multi-outage branch indices, as handed to the MODF machinery
+    n_branch : int
+        The number of branches the indices point into
+    """
+    widths = [batch.shape[1] for batch in split_multi_outage_branches]
+    assert widths == sorted(set(widths)), (
+        f"Multi-outage batches must have strictly increasing widths, one per group size, got {widths}"
+    )
+    for batch, width in zip(split_multi_outage_branches, widths, strict=True):
+        assert np.all((batch >= 0) & (batch < n_branch)), (
+            f"Multi-outage batch of width {width} carries padding or out-of-range branch indices. "
+            "Every group in a batch must outage exactly the same number of branches."
+        )
+
+
 def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     """Convert the multi-outage masks to a list of indices
 
@@ -1125,7 +1162,7 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
         The network data with the multi-outage masks converted to indices
     """
     if not np.any(network_data.multi_outage_branch_mask):
-        return replace(network_data, split_multi_outage_branches=[])
+        return replace(network_data, split_multi_outage_branches=())
 
     spared_branch_mask = network_data.multi_outage_spared_branch_mask
     if spared_branch_mask is None:
@@ -1154,7 +1191,8 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     computed_branch_mask_split = np.split(computed_branch_mask, split_indices, axis=0)
 
     # Convert the split list from boolean masks to indices for each outage
-    branch_res = [convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split]
+    branch_res = tuple(convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split)
+    _assert_multi_outage_batches_are_uniform(branch_res, n_branch=computed_branch_mask.shape[1])
 
     return replace(
         network_data,

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -30,7 +30,9 @@ from toop_engine_dc_solver.preprocess.helpers.branch_topology import (
     zip_branch_lists,
 )
 from toop_engine_dc_solver.preprocess.helpers.find_bridges import (
+    find_branches_to_spare_from_groups,
     find_bridges,
+    find_islanding_branch_groups,
     find_n_minus_2_safe_branches,
     get_bridge_mainland_node_indices,
 )
@@ -525,19 +527,6 @@ def combine_phaseshift_and_injection(network_data: NetworkData) -> NetworkData:
             network_data.relevant_node_mask,
         ]
     )
-    multi_outage_node_mask = np.concatenate(
-        [
-            np.zeros(
-                (
-                    network_data.multi_outage_node_mask.shape[0],
-                    number_of_phase_shifters,
-                ),
-                dtype=bool,
-            ),
-            network_data.multi_outage_node_mask,
-        ],
-        axis=1,
-    )
     from_nodes = network_data.from_nodes + number_of_phase_shifters
     to_nodes = network_data.to_nodes + number_of_phase_shifters
     bridge_mainland_node_indices = (
@@ -587,7 +576,6 @@ def combine_phaseshift_and_injection(network_data: NetworkData) -> NetworkData:
         outaged_injection_mask=injection_outages,
         mw_injections=mw_injections,
         bridge_mainland_node_indices=bridge_mainland_node_indices,
-        multi_outage_node_mask=multi_outage_node_mask,
         controllable_pst_node_mask=controllable_pst_node_mask,
     )
 
@@ -631,16 +619,6 @@ def add_bus_b_columns_to_ptdf(network_data: NetworkData) -> NetworkData:
                 network_data.relevant_node_mask,
                 np.zeros(n_rel_nodes, dtype=bool),
             ]
-        ),
-        multi_outage_node_mask=np.concatenate(
-            [
-                network_data.multi_outage_node_mask,
-                np.zeros(
-                    (network_data.multi_outage_node_mask.shape[0], n_rel_nodes),
-                    dtype=bool,
-                ),
-            ],
-            axis=1,
         ),
         controllable_pst_node_mask=np.concatenate(
             [
@@ -849,6 +827,11 @@ def reduce_branch_dimension(network_data: NetworkData) -> NetworkData:
         disconnectable_branch_mask=network_data.disconnectable_branch_mask[relevant_branches],
         outaged_branch_mask=network_data.outaged_branch_mask[relevant_branches],
         multi_outage_branch_mask=network_data.multi_outage_branch_mask[:, relevant_branches],
+        multi_outage_spared_branch_mask=(
+            network_data.multi_outage_spared_branch_mask[:, relevant_branches]
+            if network_data.multi_outage_spared_branch_mask is not None
+            else None
+        ),
         branch_ids=[network_data.branch_ids[i] for i in relevant_branches],
         branch_names=[network_data.branch_names[i] for i in relevant_branches],
         branch_types=[network_data.branch_types[i] for i in relevant_branches],
@@ -897,11 +880,33 @@ def filter_disconnectable_branches_nminus2(network_data: NetworkData, n_processe
     )
 
 
-def exclude_bridges_from_outage_masks(network_data: NetworkData) -> NetworkData:
-    """Exclude bridges from the outage masks.
+#: Multi-outage types that a backend synthesises to model one physical element rather than importing
+#: them from a contingency list. They isolate their own star node or busbar by construction, so they
+#: are repaired by sparing branches instead of being dropped.
+SYNTHESISED_MULTI_OUTAGE_TYPES = ("trafo3w", "bus")
 
-    Exclude bridges whose disconnection would lead to islanding from n-1 and disconnection-masks,
-    since this would lead to 0-division anyway
+
+def exclude_bridges_from_outage_masks(network_data: NetworkData) -> NetworkData:
+    """Exclude outages that would island the network from the outage masks.
+
+    Outaging a bridge splits the grid, which the DC formulation cannot represent - the LODF divides
+    by zero - so bridges are dropped from the N-1 and disconnection masks.
+
+    Multi-outages are handled as whole contingencies rather than as loose branches, because a group
+    carries one source contingency id and silently weakening it would misreport what DC computed:
+
+    - An **imported** group is dropped in full if it contains a bridging branch, or if its branches
+      form a cut set between them. Both cases are reported at warning level.
+    - A **synthesised** group (``trafo3w``, ``bus`` - see
+      :data:`SYNTHESISED_MULTI_OUTAGE_TYPES`) models a single physical element and islands its own
+      star node or busbar by construction, so it is repaired instead: bridging branches are removed
+      from the group, and :func:`find_branches_to_spare_from_groups` determines which of the
+      remaining branches have to stay in service. A group left with nothing is dropped.
+
+    The islanding test runs here, on the **unreduced** network, because that is the topology the
+    PTDF describes and therefore the one that decides whether the MODF denominator is singular.
+    ``reduce_branch_dimension`` later drops branches that carry no result, which would make the
+    graph look disconnected where the PTDF is not.
 
     Parameters
     ----------
@@ -911,7 +916,8 @@ def exclude_bridges_from_outage_masks(network_data: NetworkData) -> NetworkData:
     Returns
     -------
     NetworkData
-        The network data with the briding branches removed from n-1 and disconnection-masks
+        The network data with islanding outages removed from the masks, and
+        ``multi_outage_spared_branch_mask`` filled in for the groups that need repairing
     """
     assert network_data.bridging_branch_mask is not None, "Please compute bridges first!"
     excluded_outaged_branch_ids = np.array(network_data.branch_ids)[
@@ -925,20 +931,188 @@ def exclude_bridges_from_outage_masks(network_data: NetworkData) -> NetworkData:
             n_excluded=len(excluded_outaged_branch_ids),
             excluded_branch_ids=excluded_outaged_branch_ids,
         )
+
+    is_synthesised = np.array(
+        [multi_outage_type in SYNTHESISED_MULTI_OUTAGE_TYPES for multi_outage_type in network_data.multi_outage_types],
+        dtype=bool,
+    )
+    group_has_bridge = np.any(network_data.multi_outage_branch_mask & network_data.bridging_branch_mask, axis=1)
+
+    # An imported group is either computed as declared or not at all: dropping the bridging branch
+    # alone would leave a weaker outage running under the source contingency id (invariant 5).
+    dropped_for_bridge = group_has_bridge & ~is_synthesised
+    _log_dropped_multi_outages(
+        network_data,
+        dropped=dropped_for_bridge,
+        reason="bridging_branch",
+        offending_branch_mask=network_data.multi_outage_branch_mask & network_data.bridging_branch_mask,
+    )
+
+    # Synthesised groups keep the existing treatment: drop the bridging branch, keep the group.
+    multi_outage_branch_mask = np.where(
+        is_synthesised[:, None],
+        network_data.multi_outage_branch_mask & ~network_data.bridging_branch_mask,
+        network_data.multi_outage_branch_mask,
+    )
+
+    # A synthesised group can lose every branch it had. Left in place it becomes a row that outages
+    # nothing: a silent duplicate of the base case carrying a real contingency id.
+    emptied = ~multi_outage_branch_mask.any(axis=1)
+    emptied_multi_outage_ids = [
+        multi_outage_id
+        for multi_outage_id, is_emptied, was_dropped in zip(
+            network_data.multi_outage_ids, emptied, dropped_for_bridge, strict=True
+        )
+        if is_emptied and not was_dropped
+    ]
+    if emptied_multi_outage_ids:
+        logger.info(
+            "Excluded multi-outages that lost every element",
+            mask_name="multi_outage_branch_mask",
+            reason="bridging_branch",
+            n_excluded=len(emptied_multi_outage_ids),
+            excluded_contingency_ids=emptied_multi_outage_ids,
+        )
+
+    surviving = ~dropped_for_bridge & ~emptied
+
+    # Bridge exclusion only ever sees one branch at a time, but a group of non-bridges can still be
+    # a cut set. Such a group is singular for every topology, which used to make the BSDF/LODF
+    # action filter reject every split of every substation.
+    islanding = np.zeros(len(is_synthesised), dtype=bool)
+    islanding[surviving] = find_islanding_branch_groups(
+        from_node=network_data.from_nodes,
+        to_node=network_data.to_nodes,
+        number_of_nodes=len(network_data.node_ids),
+        branch_group_mask=multi_outage_branch_mask[surviving],
+    )
+    dropped_for_islanding = islanding & ~is_synthesised
+    _log_dropped_multi_outages(
+        network_data,
+        dropped=dropped_for_islanding,
+        reason="islanding_group",
+        offending_branch_mask=multi_outage_branch_mask,
+    )
+
+    kept_multi_outages = surviving & ~dropped_for_islanding
+
+    # Whatever still islands here is synthesised, so it is repaired rather than dropped.
+    spared_branch_mask = np.zeros_like(multi_outage_branch_mask)
+    repairable = kept_multi_outages & islanding
+    if np.any(repairable):
+        spared_branch_mask[repairable] = find_branches_to_spare_from_groups(
+            from_node=network_data.from_nodes,
+            to_node=network_data.to_nodes,
+            number_of_nodes=len(network_data.node_ids),
+            branch_group_mask=multi_outage_branch_mask[repairable],
+        )
+        spared_ids = {
+            str(multi_outage_id): np.array(network_data.branch_ids)[spared].tolist()
+            for multi_outage_id, spared, is_repaired in zip(
+                network_data.multi_outage_ids, spared_branch_mask, repairable, strict=True
+            )
+            if is_repaired
+        }
+        logger.info(
+            "Spared branches to keep multi-outages computable",
+            mask_name="multi_outage_spared_branch_mask",
+            reason="islanding_group",
+            n_repaired=len(spared_ids),
+            spared_branch_ids_by_contingency_id=spared_ids,
+        )
+
+    # Sparing every branch of a group leaves nothing to compute, so it is dropped like an emptied one.
+    fully_spared = kept_multi_outages & ~(multi_outage_branch_mask & ~spared_branch_mask).any(axis=1)
+    _log_dropped_multi_outages(
+        network_data,
+        dropped=fully_spared,
+        reason="islanding_group_beyond_repair",
+        offending_branch_mask=multi_outage_branch_mask,
+    )
+    kept_multi_outages = kept_multi_outages & ~fully_spared
+
     return replace(
         network_data,
         outaged_branch_mask=network_data.outaged_branch_mask & ~network_data.bridging_branch_mask,
-        multi_outage_branch_mask=network_data.multi_outage_branch_mask & ~network_data.bridging_branch_mask,
+        multi_outage_branch_mask=multi_outage_branch_mask[kept_multi_outages],
+        multi_outage_spared_branch_mask=spared_branch_mask[kept_multi_outages],
+        multi_outage_ids=[
+            multi_outage_id
+            for multi_outage_id, kept in zip(network_data.multi_outage_ids, kept_multi_outages, strict=True)
+            if kept
+        ],
+        multi_outage_names=[
+            multi_outage_name
+            for multi_outage_name, kept in zip(network_data.multi_outage_names, kept_multi_outages, strict=True)
+            if kept
+        ],
+        multi_outage_types=[
+            multi_outage_type
+            for multi_outage_type, kept in zip(network_data.multi_outage_types, kept_multi_outages, strict=True)
+            if kept
+        ],
         disconnectable_branch_mask=network_data.disconnectable_branch_mask & ~network_data.bridging_branch_mask,
+    )
+
+
+def _log_dropped_multi_outages(
+    network_data: NetworkData,
+    dropped: Bool[np.ndarray, " n_multi_outages"],
+    reason: str,
+    offending_branch_mask: Bool[np.ndarray, " n_multi_outages n_branch"],
+) -> None:
+    """Report multi-outages that DC will not compute, naming the branches responsible.
+
+    A dropped group is a contingency the caller asked for and does not get back, so this is a
+    warning rather than the info level used for routine mask trimming.
+
+    Parameters
+    ----------
+    network_data : NetworkData
+        The network data the groups belong to, read for ids, names and branch ids
+    dropped : Bool[np.ndarray, " n_multi_outages"]
+        True for every group being dropped
+    reason : str
+        Machine-readable reason, logged as ``reason``
+    offending_branch_mask : Bool[np.ndarray, " n_multi_outages n_branch"]
+        Per group, the branches that caused the drop
+    """
+    if not np.any(dropped):
+        return
+    branch_ids = np.array(network_data.branch_ids)
+    dropped_details = {
+        str(multi_outage_id): {
+            "name": multi_outage_name,
+            "branch_ids": branch_ids[offending].tolist(),
+        }
+        for multi_outage_id, multi_outage_name, offending, is_dropped in zip(
+            network_data.multi_outage_ids,
+            network_data.multi_outage_names,
+            offending_branch_mask,
+            dropped,
+            strict=True,
+        )
+        if is_dropped
+    }
+    logger.warning(
+        "Excluded multi-outages that DC cannot compute",
+        mask_name="multi_outage_branch_mask",
+        reason=reason,
+        n_excluded=len(dropped_details),
+        excluded_contingencies=dropped_details,
     )
 
 
 def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     """Convert the multi-outage masks to a list of indices
 
-    Furthermore, remove one of the branches from the mask to avoid islanding.
-    Sort them by the amount of branches involved in the outage so that the backend can
-    efficiently batch them
+    Branches that ``exclude_bridges_from_outage_masks`` marked as spared are left out of the
+    computed group: they are what keeps a trafo3w star node or an outaged busbar attached to the
+    rest of the grid. ``multi_outage_branch_mask`` still carries the group as declared, so the DC
+    projection keeps reporting the full contingency.
+
+    Sorts the groups by the number of branches actually computed so that the backend can
+    efficiently batch them.
 
     Parameters
     ----------
@@ -950,73 +1124,43 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     NetworkData
         The network data with the multi-outage masks converted to indices
     """
-    # Make sure no outaged node is in relevant nodes
-    # This is currently not supported
-    assert not np.any(network_data.multi_outage_node_mask & network_data.relevant_node_mask[None, :])
+    if not np.any(network_data.multi_outage_branch_mask):
+        return replace(network_data, split_multi_outage_branches=[])
 
-    if not np.any(network_data.multi_outage_branch_mask) and not np.any(network_data.multi_outage_node_mask):
-        return replace(network_data, split_multi_outage_branches=[], split_multi_outage_nodes=[])
+    spared_branch_mask = network_data.multi_outage_spared_branch_mask
+    if spared_branch_mask is None:
+        spared_branch_mask = np.zeros_like(network_data.multi_outage_branch_mask)
+    computed_branch_mask = network_data.multi_outage_branch_mask & ~spared_branch_mask
+    if network_data.multi_outage_spared_branch_mask is not None:
+        # Only meaningful once exclude_bridges_from_outage_masks has run; calling this conversion
+        # standalone simply computes every group in full.
+        assert np.all(computed_branch_mask.any(axis=1)), (
+            "A multi-outage with nothing left to compute should have been dropped in exclude_bridges_from_outage_masks"
+        )
 
-    n_outaged_branches = np.sum(network_data.multi_outage_branch_mask, axis=1)
+    n_outaged_branches = np.sum(computed_branch_mask, axis=1)
     sorted_indices = np.argsort(n_outaged_branches)
 
     # Reorder the multi-outage masks
     multi_outage_branch_mask = network_data.multi_outage_branch_mask[sorted_indices]
-    multi_outage_node_mask = network_data.multi_outage_node_mask[sorted_indices]
     multi_outage_names = [network_data.multi_outage_names[i] for i in sorted_indices]
     multi_outage_ids = [network_data.multi_outage_ids[i] for i in sorted_indices]
     multi_outage_types = [network_data.multi_outage_types[i] for i in sorted_indices]
+    computed_branch_mask = computed_branch_mask[sorted_indices]
     n_outaged_branches = n_outaged_branches[sorted_indices]
 
     # Split the multi outage masks so that masks with the same number of branches are in one list
     split_indices = np.flatnonzero(np.diff(n_outaged_branches)) + 1
-    multi_outage_branch_mask_split = np.split(multi_outage_branch_mask, split_indices, axis=0)
-    multi_outage_node_mask_split = np.split(multi_outage_node_mask, split_indices, axis=0)
+    computed_branch_mask_split = np.split(computed_branch_mask, split_indices, axis=0)
 
     # Convert the split list from boolean masks to indices for each outage
-    branch_res = [convert_boolean_mask_to_index_array(mask) for mask in multi_outage_branch_mask_split]
-    node_res = [convert_boolean_mask_to_index_array(mask) for mask in multi_outage_node_mask_split]
-
-    # Furthermore, remove the first branch from the outage to avoid islanding
-    # TODO find a more canonical way how to avoid islanding in trafo3w/busbar outages
-    trafo_busbar_outage = np.array([elem_type in ["trafo3w", "bus"] for elem_type in multi_outage_types])
-    trafo_busbar_outage = np.split(trafo_busbar_outage, split_indices)
-
-    def _zero_out_first_branch(
-        indices: Int[np.ndarray, " n_outages n_outaged_branches"],
-        is_trafo_bus: Bool[np.ndarray, " n_outages"],
-    ) -> Int[np.ndarray, " n_outages n_outaged_branches"]:
-        """Set the first branch of the outage to -1, if it is a trafo or busbar outage.
-
-        Parameters
-        ----------
-        indices : Int[np.ndarray, " n_outages n_outaged_branches"]
-            The indices of the branches in the outage
-        is_trafo_bus : Bool[np.ndarray, " n_outages"]
-            The boolean mask indicating if the outage is a trafo or busbar outage
-
-        Returns
-        -------
-        Int[np.ndarray, " n_outages n_outaged_branches"]
-            The indices of the branches in the outage with the first branch set to -1
-        """
-        if indices.size == 0:
-            return indices
-        indices[is_trafo_bus, 0] = -1
-        if np.all(indices[:, 0] == -1):
-            indices = indices[:, 1:]
-        return indices
-
-    branch_res = [
-        _zero_out_first_branch(out, is_trafo_bus) for out, is_trafo_bus in zip(branch_res, trafo_busbar_outage, strict=True)
-    ]
+    branch_res = [convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split]
 
     return replace(
         network_data,
         multi_outage_branch_mask=multi_outage_branch_mask,
-        multi_outage_node_mask=multi_outage_node_mask,
+        multi_outage_spared_branch_mask=spared_branch_mask[sorted_indices],
         split_multi_outage_branches=branch_res,
-        split_multi_outage_nodes=node_res,
         multi_outage_names=multi_outage_names,
         multi_outage_ids=multi_outage_ids,
         multi_outage_types=multi_outage_types,
@@ -1422,7 +1566,6 @@ def reduce_node_dimension(network_data: NetworkData) -> NetworkData:
     assert network_data.ptdf_is_extended is False, (
         "This step adds new columns at the end of the PTDF. Please extend the ptdf after reducing the node dimension."
     )
-    assert network_data.split_multi_outage_nodes is None
 
     relevant_branches = get_relevant_branches(
         from_node=network_data.from_nodes,
@@ -1436,7 +1579,6 @@ def reduce_node_dimension(network_data: NetworkData) -> NetworkData:
     )
     significant_nodes = get_significant_nodes(
         network_data.relevant_node_mask,
-        network_data.multi_outage_node_mask,
         relevant_branches,
         network_data.from_nodes,
         network_data.to_nodes,
@@ -1484,10 +1626,6 @@ def reduce_node_dimension(network_data: NetworkData) -> NetworkData:
         node_types=[network_data.node_types[i] for i in significant_node_ids] + ["REDUCED_NODE"] * n_timesteps,
         bridge_mainland_node_indices=bridge_mainland_node_indices,
         relevant_node_mask=np.r_[network_data.relevant_node_mask[significant_nodes], [False] * n_timesteps],
-        multi_outage_node_mask=np.c_[
-            network_data.multi_outage_node_mask[:, significant_nodes],
-            np.zeros((network_data.multi_outage_node_mask.shape[0], n_timesteps), dtype=bool),
-        ],
     )
 
 

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -1104,16 +1104,16 @@ def _log_dropped_multi_outages(
 
 
 def _assert_multi_outage_batches_are_uniform(
-    split_multi_outage_branches: tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...],
+    split_multi_outage_branches: tuple[Int[np.ndarray, " _ _"], ...],
     n_branch: int,
 ) -> None:
     """Assert the batching contract that the shape annotation cannot express.
 
-    ``split_multi_outage_branches`` holds one batch per distinct number of outaged branches. jaxtyping
-    binds axis names across parameters but not across the elements of a container, so every batch
-    binds ``n_outages_in_batch`` and ``n_outaged_branches`` independently. That is what lets the
-    ragged batching be annotated at all, but it also means the annotation cannot relate the batches
-    to one another. The properties that do relate them are checked here instead:
+    ``split_multi_outage_branches`` holds one batch per distinct number of outaged branches, each of
+    shape (n_outages_in_batch, n_outaged_branches), so both axes vary from batch to batch. jaxtyping
+    binds an axis name across the elements of a container, which means a named axis would make any
+    two-batch tuple fail the check; both axes are therefore anonymous. The properties the annotation
+    can no longer carry are checked here instead:
 
     - Every group within a batch outages the same number of branches, so
       ``convert_boolean_mask_to_index_array`` never had to pad. A padded row would make the MODF
@@ -1125,7 +1125,7 @@ def _assert_multi_outage_batches_are_uniform(
 
     Parameters
     ----------
-    split_multi_outage_branches : tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...]
+    split_multi_outage_branches : tuple[Int[np.ndarray, " _ _"], ...]
         The batched multi-outage branch indices, as handed to the MODF machinery
     n_branch : int
         The number of branches the indices point into

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -1104,14 +1104,16 @@ def _log_dropped_multi_outages(
 
 
 def _assert_multi_outage_batches_are_uniform(
-    split_multi_outage_branches: tuple[Int[np.ndarray, " n_outages n_outaged_branches"]],
+    split_multi_outage_branches: tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...],
     n_branch: int,
 ) -> None:
-    """Assert the batching contract that the ``Int[Array, " _ _"]`` annotation cannot express.
+    """Assert the batching contract that the shape annotation cannot express.
 
-    ``split_multi_outage_branches`` is a list of batches, one per distinct number of outaged
-    branches. Both axes differ between entries, so jaxtyping can only be told that the entries are
-    two-dimensional. The properties that actually matter are checked here instead:
+    ``split_multi_outage_branches`` holds one batch per distinct number of outaged branches. jaxtyping
+    binds axis names across parameters but not across the elements of a container, so every batch
+    binds ``n_outages_in_batch`` and ``n_outaged_branches`` independently. That is what lets the
+    ragged batching be annotated at all, but it also means the annotation cannot relate the batches
+    to one another. The properties that do relate them are checked here instead:
 
     - Every group within a batch outages the same number of branches, so
       ``convert_boolean_mask_to_index_array`` never had to pad. A padded row would make the MODF
@@ -1123,7 +1125,7 @@ def _assert_multi_outage_batches_are_uniform(
 
     Parameters
     ----------
-    split_multi_outage_branches : tuple[Int[np.ndarray, " n_outages n_outaged_branches"]]
+    split_multi_outage_branches : tuple[Int[np.ndarray, " n_outages_in_batch n_outaged_branches"], ...]
         The batched multi-outage branch indices, as handed to the MODF machinery
     n_branch : int
         The number of branches the indices point into
@@ -1161,7 +1163,7 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
         The network data with the multi-outage masks converted to indices
     """
     if not np.any(network_data.multi_outage_branch_mask):
-        return replace(network_data, split_multi_outage_branches=[])
+        return replace(network_data, split_multi_outage_branches=())
 
     spared_branch_mask = network_data.multi_outage_spared_branch_mask
     if spared_branch_mask is None:
@@ -1190,7 +1192,7 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     computed_branch_mask_split = np.split(computed_branch_mask, split_indices, axis=0)
 
     # Convert the split list from boolean masks to indices for each outage
-    branch_res = (convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split)
+    branch_res = tuple(convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split)
     _assert_multi_outage_batches_are_uniform(branch_res, n_branch=computed_branch_mask.shape[1])
 
     return replace(

--- a/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
+++ b/packages/dc_solver_pkg/src/toop_engine_dc_solver/preprocess/preprocess.py
@@ -62,7 +62,6 @@ from toop_engine_dc_solver.preprocess.helpers.relevant_branches import (
 )
 from toop_engine_dc_solver.preprocess.network_data import (
     NetworkData,
-    SplitMultiOutageBranches,
     assert_network_data,
     extract_network_data_from_interface,
     get_network_data_stats,
@@ -1105,13 +1104,13 @@ def _log_dropped_multi_outages(
 
 
 def _assert_multi_outage_batches_are_uniform(
-    split_multi_outage_branches: SplitMultiOutageBranches,
+    split_multi_outage_branches: tuple[Int[np.ndarray, " n_outages n_outaged_branches"]],
     n_branch: int,
 ) -> None:
     """Assert the batching contract that the ``Int[Array, " _ _"]`` annotation cannot express.
 
-    ``split_multi_outage_branches`` holds one batch per distinct number of outaged branches, and each
-    batch carries its own pair of dimensions, so jaxtyping can only be told that the entries are
+    ``split_multi_outage_branches`` is a list of batches, one per distinct number of outaged
+    branches. Both axes differ between entries, so jaxtyping can only be told that the entries are
     two-dimensional. The properties that actually matter are checked here instead:
 
     - Every group within a batch outages the same number of branches, so
@@ -1124,7 +1123,7 @@ def _assert_multi_outage_batches_are_uniform(
 
     Parameters
     ----------
-    split_multi_outage_branches : SplitMultiOutageBranches
+    split_multi_outage_branches : tuple[Int[np.ndarray, " n_outages n_outaged_branches"]]
         The batched multi-outage branch indices, as handed to the MODF machinery
     n_branch : int
         The number of branches the indices point into
@@ -1162,7 +1161,7 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
         The network data with the multi-outage masks converted to indices
     """
     if not np.any(network_data.multi_outage_branch_mask):
-        return replace(network_data, split_multi_outage_branches=())
+        return replace(network_data, split_multi_outage_branches=[])
 
     spared_branch_mask = network_data.multi_outage_spared_branch_mask
     if spared_branch_mask is None:
@@ -1191,7 +1190,7 @@ def convert_multi_outages(network_data: NetworkData) -> NetworkData:
     computed_branch_mask_split = np.split(computed_branch_mask, split_indices, axis=0)
 
     # Convert the split list from boolean masks to indices for each outage
-    branch_res = tuple(convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split)
+    branch_res = (convert_boolean_mask_to_index_array(mask) for mask in computed_branch_mask_split)
     _assert_multi_outage_batches_are_uniform(branch_res, n_branch=computed_branch_mask.shape[1])
 
     return replace(

--- a/packages/dc_solver_pkg/tests/conftest.py
+++ b/packages/dc_solver_pkg/tests/conftest.py
@@ -243,10 +243,10 @@ def static_information_with_multi_outages(
         jax_inputs[2],
         dynamic_information=replace(
             jax_inputs[2].dynamic_information,
-            multi_outage_branches=[
-                jnp.array([[0, 8, 12], [0, 4, 8], [0, 4, 8]], dtype=int),
+            multi_outage_branches=(
                 jnp.array([[0, 8], [12, 8], [12, 0]], dtype=int),
-            ],
+                jnp.array([[0, 8, 12], [0, 4, 8], [0, 4, 8]], dtype=int),
+            ),
         ),
     )
     return static_information

--- a/packages/dc_solver_pkg/tests/conftest.py
+++ b/packages/dc_solver_pkg/tests/conftest.py
@@ -247,10 +247,6 @@ def static_information_with_multi_outages(
                 jnp.array([[0, 8, 12], [0, 4, 8], [0, 4, 8]], dtype=int),
                 jnp.array([[0, 8], [12, 8], [12, 0]], dtype=int),
             ],
-            multi_outage_nodes=[
-                jnp.array([[-1], [-1], [2]], dtype=int),
-                jnp.zeros((3, 0), dtype=int),
-            ],
         ),
     )
     return static_information

--- a/packages/dc_solver_pkg/tests/jax/test_inputs.py
+++ b/packages/dc_solver_pkg/tests/jax/test_inputs.py
@@ -95,7 +95,7 @@ def test_load_save(
         static_information,
         dynamic_information=replace(
             static_information.dynamic_information,
-            multi_outage_branches=[jnp.array([[0, 8, 12]], dtype=int)],
+            multi_outage_branches=(jnp.array([[0, 8, 12]], dtype=int),),
         ),
     )
     save_static_information(os.path.join(tmp_path, "test2.hdf5"), static_information)

--- a/packages/dc_solver_pkg/tests/jax/test_inputs.py
+++ b/packages/dc_solver_pkg/tests/jax/test_inputs.py
@@ -96,7 +96,6 @@ def test_load_save(
         dynamic_information=replace(
             static_information.dynamic_information,
             multi_outage_branches=[jnp.array([[0, 8, 12]], dtype=int)],
-            multi_outage_nodes=[jnp.zeros((1, 0), dtype=int)],
         ),
     )
     save_static_information(os.path.join(tmp_path, "test2.hdf5"), static_information)

--- a/packages/dc_solver_pkg/tests/preprocessing/helper/test_find_bridges.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/helper/test_find_bridges.py
@@ -9,7 +9,9 @@ import networkx as nx
 import numpy as np
 from tests.network_data_pickle import load_network_data
 from toop_engine_dc_solver.preprocess.helpers.find_bridges import (
+    find_branches_to_spare_from_groups,
     find_bridges,
+    find_islanding_branch_groups,
     find_n_minus_2_safe_branches,
     get_number_of_bridges_after_outage,
 )
@@ -187,3 +189,49 @@ def test_get_number_of_bridges_after_outage_matches_old_path_for_complex_grid(
     )
 
     assert np.array_equal(new_counts, old_counts)
+
+
+def _three_winding_transformer_grid() -> tuple[np.ndarray, np.ndarray, int, np.ndarray]:
+    """A meshed triangle plus a three-winding transformer hanging off it.
+
+    Nodes 0, 1 and 2 are the HV/MV/LV sides, node 3 is the star node that only exists inside the
+    transformer. Branches 3, 4 and 5 are its legs, so they are the only branches touching node 3.
+    """
+    from_node = np.array([0, 1, 2, 3, 3, 3], dtype=int)
+    to_node = np.array([1, 2, 0, 0, 1, 2], dtype=int)
+    legs = np.zeros((1, 6), dtype=bool)
+    legs[0, [3, 4, 5]] = True
+    return from_node, to_node, 4, legs
+
+
+def test_three_winding_transformer_group_islands_its_own_star_node() -> None:
+    from_node, to_node, number_of_nodes, legs = _three_winding_transformer_grid()
+
+    # No single leg is a bridge - the star node keeps two connections - yet the three of them
+    # together are a cut set, which is exactly what find_bridges alone cannot see.
+    assert not find_bridges(from_node, to_node, 6, number_of_nodes)[[3, 4, 5]].any()
+    assert find_islanding_branch_groups(from_node, to_node, number_of_nodes, legs)[0]
+
+
+def test_three_winding_transformer_group_spares_exactly_one_leg() -> None:
+    from_node, to_node, number_of_nodes, legs = _three_winding_transformer_grid()
+
+    spared = find_branches_to_spare_from_groups(from_node, to_node, number_of_nodes, legs)
+
+    # One leg stays in service, so the star node keeps a path to the rest of the grid, and it is
+    # the lowest-index leg because sparing it on its own already resolves the islanding.
+    assert np.array_equal(np.flatnonzero(spared[0]), np.array([3]))
+    computed = legs & ~spared
+    assert not find_islanding_branch_groups(from_node, to_node, number_of_nodes, computed)[0]
+    # The other two legs are still computed: the repair is minimal, not a fallback to N-1.
+    assert np.array_equal(np.flatnonzero(computed[0]), np.array([4, 5]))
+
+
+def test_two_legs_of_a_three_winding_transformer_need_no_spare() -> None:
+    """Sparing is keyed off islanding, not off the element type."""
+    from_node, to_node, number_of_nodes, _ = _three_winding_transformer_grid()
+    two_legs = np.zeros((1, 6), dtype=bool)
+    two_legs[0, [3, 4]] = True
+
+    assert not find_islanding_branch_groups(from_node, to_node, number_of_nodes, two_legs)[0]
+    assert not find_branches_to_spare_from_groups(from_node, to_node, number_of_nodes, two_legs).any()

--- a/packages/dc_solver_pkg/tests/preprocessing/helper/test_reduce_node_dimension.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/helper/test_reduce_node_dimension.py
@@ -20,13 +20,6 @@ def test_get_significant_nodes():
 
     # The first entry is relevant, so the bus 0 should be marked as True
     relevant_node_mask = np.array([True, False, False, False, False, False, False, False, False, False])
-    # The 6th bus is outaged, so bus 5 should be marked as True
-    multi_outage_node_mask = np.array(
-        [
-            [False, False, False, False, False, True, False, False, False, False],
-            [False, False, False, False, False, False, False, False, False, False],
-        ]
-    )
     from_nodes = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     to_nodes = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 8])
     relevant_branches = np.array([0])
@@ -35,10 +28,8 @@ def test_get_significant_nodes():
 
     # the slack is also significant, so result 9 -> True
     slack = 9
-    significant_nodes = get_significant_nodes(
-        relevant_node_mask, multi_outage_node_mask, relevant_branches, from_nodes, to_nodes, slack
-    )
-    expected_significant_node_mask = np.array([True, True, True, False, False, True, False, False, False, True])
+    significant_nodes = get_significant_nodes(relevant_node_mask, relevant_branches, from_nodes, to_nodes, slack)
+    expected_significant_node_mask = np.array([True, True, True, False, False, False, False, False, False, True])
     assert np.all(significant_nodes == expected_significant_node_mask)
 
 

--- a/packages/dc_solver_pkg/tests/preprocessing/test_pandapower_backend.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_pandapower_backend.py
@@ -70,12 +70,9 @@ def test_pandapower_backend(data_folder: Path) -> None:
         assert backend.net[pp_type].loc[pp_id, to_lookup[pp_type]] == table_id(backend.get_node_ids()[node])
 
     assert len(backend.get_multi_outage_names()) == len(backend.get_multi_outage_branches())
-    assert len(backend.get_multi_outage_nodes()) == len(backend.get_multi_outage_branches())
     assert len(backend.get_multi_outage_names()) >= backend.net.trafo3w.shape[0]
     trafo3w_multi_outages = backend.get_multi_outage_branches()[: len(backend.net.trafo3w)]
     assert np.all(np.sum(trafo3w_multi_outages, axis=1) == 3)
-    trafo3w_multi_outages = backend.get_multi_outage_nodes()[: len(backend.net.trafo3w)]
-    assert np.all(np.sum(trafo3w_multi_outages, axis=1) == 1)
 
     assert len(backend.get_disconnectable_branch_mask()) == len(backend.get_branch_types())
     assert backend.get_branches_in_maintenance().shape == (

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
@@ -43,6 +43,7 @@ from toop_engine_dc_solver.preprocess.network_data import validate_network_data
 from toop_engine_dc_solver.preprocess.pandapower.pandapower_backend import PandaPowerBackend
 from toop_engine_dc_solver.preprocess.preprocess import (
     NetworkData,
+    _assert_multi_outage_batches_are_uniform,
     add_bus_b_columns_to_ptdf,
     add_nodal_injections_to_network_data,
     combine_phaseshift_and_injection,
@@ -1112,6 +1113,27 @@ def test_filter_inactive_injections(network_data_filled: NetworkData) -> None:
     assert n_inj <= len(network_data_filled.injection_ids)
 
 
+def test_multi_outage_batches_are_uniform_rejects_padded_batches() -> None:
+    """The batch contract is what `Int[Array, " _ _"]` cannot express, so it is asserted instead."""
+    # One batch per group size, ascending, no padding: the shape convert_multi_outages must produce.
+    _assert_multi_outage_batches_are_uniform((np.array([[0, 1], [2, 3]]), np.array([[0, 1, 2]])), n_branch=4)
+
+    # A batch whose groups outage different numbers of branches gets padded with -1 by
+    # convert_boolean_mask_to_index_array, which would silently enlarge the MODF solve.
+    with pytest.raises(AssertionError, match="padding or out-of-range"):
+        _assert_multi_outage_batches_are_uniform((np.array([[0, 1], [2, -1]]),), n_branch=4)
+
+    # Batches out of order, or two batches of the same width, mean the split lost its meaning.
+    with pytest.raises(AssertionError, match="strictly increasing widths"):
+        _assert_multi_outage_batches_are_uniform((np.array([[0, 1, 2]]), np.array([[0, 1]])), n_branch=4)
+    with pytest.raises(AssertionError, match="strictly increasing widths"):
+        _assert_multi_outage_batches_are_uniform((np.array([[0, 1]]), np.array([[2, 3]])), n_branch=4)
+
+    # An index that is not a branch is a bug, not padding.
+    with pytest.raises(AssertionError, match="padding or out-of-range"):
+        _assert_multi_outage_batches_are_uniform((np.array([[0, 9]]),), n_branch=4)
+
+
 def test_convert_multi_outages_no_outages(network_data_filled: NetworkData) -> None:
     # An all-false mask and a mask with no rows at all both mean "nothing to compute".
     network_data = replace(
@@ -1121,7 +1143,7 @@ def test_convert_multi_outages_no_outages(network_data_filled: NetworkData) -> N
     assert network_data.split_multi_outage_branches is None
 
     network_data = convert_multi_outages(network_data)
-    assert network_data.split_multi_outage_branches == []
+    assert network_data.split_multi_outage_branches == ()
 
     network_data = replace(
         network_data_filled,
@@ -1133,7 +1155,7 @@ def test_convert_multi_outages_no_outages(network_data_filled: NetworkData) -> N
     assert network_data.split_multi_outage_branches is None
 
     network_data = convert_multi_outages(network_data)
-    assert network_data.split_multi_outage_branches == []
+    assert network_data.split_multi_outage_branches == ()
 
     # A populated mask yields one batch per distinct number of outaged branches.
     network_data = convert_multi_outages(network_data_filled)

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
@@ -5,10 +5,12 @@
 # you can obtain one at https://mozilla.org/MPL/2.0/.
 # Mozilla Public License, version 2.0
 
+import importlib
 import os
 from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pandapower as pp
@@ -39,7 +41,7 @@ from toop_engine_dc_solver.preprocess.helpers.reduce_node_dimension import get_s
 from toop_engine_dc_solver.preprocess.helpers.relevant_branches import (
     get_relevant_branches,
 )
-from toop_engine_dc_solver.preprocess.network_data import validate_network_data
+from toop_engine_dc_solver.preprocess.network_data import extract_network_data_from_interface, validate_network_data
 from toop_engine_dc_solver.preprocess.pandapower.pandapower_backend import PandaPowerBackend
 from toop_engine_dc_solver.preprocess.preprocess import (
     NetworkData,
@@ -91,6 +93,7 @@ from toop_engine_interfaces.asset_topology.runtime_topology import (
     RuntimeBusGroup,
 )
 from toop_engine_interfaces.folder_structure import PREPROCESSING_PATHS
+from toop_engine_interfaces.messages.preprocess.preprocess_commands import PreprocessParameters
 from toop_engine_interfaces.messages.preprocess.preprocess_heartbeat import PreprocessStage
 from toop_engine_interfaces.messages.preprocess.preprocess_results import DynamicInformationStats
 from toop_engine_interfaces.status_update import NetworkDataStats
@@ -1132,6 +1135,39 @@ def test_multi_outage_batches_are_uniform_rejects_padded_batches() -> None:
     # An index that is not a branch is a bug, not padding.
     with pytest.raises(AssertionError, match="padding or out-of-range"):
         _assert_multi_outage_batches_are_uniform((np.array([[0, 9]]),), n_branch=4)
+
+
+def test_multi_outage_batches_of_different_widths_reach_the_solver(_data_folder: Path) -> None:
+    """Two group sizes must survive the whole pipeline, including the BSDF/LODF action filter.
+
+    Every fixture otherwise yields a single batch, so the ragged path - the reason both axes are
+    bound per batch rather than across them - would go untested.
+    """
+    backend = PandaPowerBackend(DirFileSystem(str(_data_folder)))
+    network_data = extract_network_data_from_interface(backend)
+    # The trafo3w groups end up two branches wide; add a three-branch group of non-bridging
+    # branches so the split produces two batches of different widths.
+    bridging = compute_bridging_branches(network_data).bridging_branch_mask
+    candidates = np.flatnonzero(network_data.outaged_branch_mask & ~bridging)
+    group = np.zeros((1, network_data.multi_outage_branch_mask.shape[1]), dtype=bool)
+    group[0, candidates[[0, 5, 10]]] = True
+    network_data = replace(
+        network_data,
+        multi_outage_branch_mask=np.concatenate([network_data.multi_outage_branch_mask, group], axis=0),
+        multi_outage_ids=[*network_data.multi_outage_ids, "SYNTH_TRIPLE"],
+        multi_outage_names=[*network_data.multi_outage_names, "three lines"],
+        multi_outage_types=[*network_data.multi_outage_types, "CONTINGENCY"],
+    )
+
+    # `import ...preprocess.preprocess as m` would bind the re-exported function, not the module.
+    preprocess_module = importlib.import_module("toop_engine_dc_solver.preprocess.preprocess")
+    with patch.object(preprocess_module, "extract_network_data_from_interface", lambda _: network_data):
+        result = preprocess_module.preprocess(backend, parameters=PreprocessParameters(preprocess_bb_outages=False))
+
+    assert [batch.shape[1] for batch in result.split_multi_outage_branches] == [2, 3]
+    assert "SYNTH_TRIPLE" in list(result.multi_outage_ids)
+    # The action set must survive a second group size, which is what the BSDF/LODF filter sees.
+    assert any(actions.shape[0] > 1 for actions in result.branch_action_set)
 
 
 def test_convert_multi_outages_no_outages(network_data_filled: NetworkData) -> None:

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
@@ -1159,7 +1159,7 @@ def test_multi_outage_batches_of_different_widths_reach_the_solver(_data_folder:
         multi_outage_types=[*network_data.multi_outage_types, "CONTINGENCY"],
     )
 
-    # `import ...preprocess.preprocess as m` would bind the re-exported function, not the module.
+    # Patch function preprocess with a version of extract_network_data_from_interface that returns our modified network_data.
     preprocess_module = importlib.import_module("toop_engine_dc_solver.preprocess.preprocess")
     with patch.object(preprocess_module, "extract_network_data_from_interface", lambda _: network_data):
         result = preprocess_module.preprocess(backend, parameters=PreprocessParameters(preprocess_bb_outages=False))

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
@@ -27,6 +27,7 @@ from toop_engine_dc_solver.jax.inputs import (
 )
 from toop_engine_dc_solver.preprocess.convert_to_jax import convert_to_jax, extract_dynamic_information_stats
 from toop_engine_dc_solver.preprocess.helpers.find_bridges import (
+    find_islanding_branch_groups,
     find_n_minus_2_safe_branches,
 )
 from toop_engine_dc_solver.preprocess.helpers.injection_topology import (
@@ -1078,6 +1079,54 @@ def test_exclude_bridges_keeps_a_synthesised_group_by_sparing_a_branch(
     # Exactly one leg is spared, and it is one of the group's own branches.
     assert np.all(np.sum(spared, axis=1) == 1)
     assert not np.any(spared & ~network_data.multi_outage_branch_mask)
+
+
+def test_trafo3w_multi_outage_keeps_one_leg_connected_to_the_star_node(
+    network_data_filled: NetworkData,
+) -> None:
+    """A three-winding transformer is computed as a two-leg outage, not dropped and not weakened.
+
+    Its three legs are the only branches touching the star node, so outaging the group as declared
+    always islands that node and the MODF denominator is singular for every topology. Sparing one
+    leg is what makes the other two computable, and which leg follows from the graph.
+    """
+    network_data = exclude_bridges_from_outage_masks(network_data_filled)
+
+    trafo3w_groups = [index for index, type_ in enumerate(network_data.multi_outage_types) if type_ == "trafo3w"]
+    assert trafo3w_groups, "fixture no longer contains a trafo3w multi-outage"
+
+    for group_index in trafo3w_groups:
+        declared = network_data.multi_outage_branch_mask[group_index]
+        spared = network_data.multi_outage_spared_branch_mask[group_index]
+        legs = np.flatnonzero(declared)
+        assert legs.size == 3
+
+        # The star node is the one node all three legs have in common.
+        star_nodes = set.intersection(
+            *({int(network_data.from_nodes[leg]), int(network_data.to_nodes[leg])} for leg in legs)
+        )
+        assert len(star_nodes) == 1
+        star_node = star_nodes.pop()
+        touching_star_node = np.flatnonzero((network_data.from_nodes == star_node) | (network_data.to_nodes == star_node))
+        assert np.array_equal(touching_star_node, legs)
+
+        # Exactly one leg is spared, so the star node keeps exactly one path to the rest of the grid.
+        assert np.sum(spared) == 1
+        assert np.all(spared <= declared)
+
+        computed = declared & ~spared
+        assert not find_islanding_branch_groups(
+            network_data.from_nodes,
+            network_data.to_nodes,
+            len(network_data.node_ids),
+            computed[np.newaxis, :],
+        )[0]
+
+    # The spared legs are the only difference between what was declared and what will be computed.
+    assert np.array_equal(
+        network_data.multi_outage_branch_mask,
+        network_data_filled.multi_outage_branch_mask,
+    )
 
 
 def test_convert_multi_outages(network_data_filled: NetworkData) -> None:

--- a/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
+++ b/packages/dc_solver_pkg/tests/preprocessing/test_preprocess.py
@@ -1039,26 +1039,64 @@ def test_exclude_bridges_from_outage_masks(
     )
 
 
+def test_exclude_bridges_drops_an_imported_group_containing_a_bridge(
+    network_data_filled: NetworkData,
+) -> None:
+    """An imported group is computed as declared or not at all - never silently weakened."""
+    bridge = int(np.flatnonzero(network_data_filled.bridging_branch_mask)[0])
+    non_bridge = int(np.flatnonzero(~network_data_filled.bridging_branch_mask)[0])
+    group = np.zeros((1, network_data_filled.multi_outage_branch_mask.shape[1]), dtype=bool)
+    group[0, [bridge, non_bridge]] = True
+    network_data_filled = replace(
+        network_data_filled,
+        multi_outage_branch_mask=np.concatenate([network_data_filled.multi_outage_branch_mask, group], axis=0),
+        multi_outage_ids=[*network_data_filled.multi_outage_ids, "IMPORTED_WITH_BRIDGE"],
+        multi_outage_names=[*network_data_filled.multi_outage_names, "imported group"],
+        multi_outage_types=[*network_data_filled.multi_outage_types, "CONTINGENCY"],
+    )
+
+    network_data = exclude_bridges_from_outage_masks(network_data_filled)
+
+    assert "IMPORTED_WITH_BRIDGE" not in list(network_data.multi_outage_ids)
+    # The synthesised trafo3w groups are kept and repaired instead of dropped.
+    assert list(network_data.multi_outage_ids) == list(network_data_filled.multi_outage_ids[:-1])
+
+
+def test_exclude_bridges_keeps_a_synthesised_group_by_sparing_a_branch(
+    network_data_filled: NetworkData,
+) -> None:
+    """A trafo3w group isolates its own star node, so it is repaired rather than dropped."""
+    network_data = exclude_bridges_from_outage_masks(network_data_filled)
+
+    assert list(network_data.multi_outage_ids) == list(network_data_filled.multi_outage_ids)
+    spared = network_data.multi_outage_spared_branch_mask
+    assert spared is not None
+    # Exactly one leg is spared, and it is one of the group's own branches.
+    assert np.all(np.sum(spared, axis=1) == 1)
+    assert not np.any(spared & ~network_data.multi_outage_branch_mask)
+
+
 def test_convert_multi_outages(network_data_filled: NetworkData) -> None:
-    network_data = convert_multi_outages(network_data_filled)
-    assert network_data.multi_outage_branch_mask.shape == network_data_filled.multi_outage_branch_mask.shape
-    assert network_data.multi_outage_node_mask.shape == network_data_filled.multi_outage_node_mask.shape
-    assert np.sum(network_data.multi_outage_branch_mask) == np.sum(network_data_filled.multi_outage_branch_mask)
-    assert np.sum(network_data.multi_outage_node_mask) == np.sum(network_data_filled.multi_outage_node_mask)
+    # Which branches have to stay in service is decided in exclude_bridges_from_outage_masks, on the
+    # unreduced network; convert_multi_outages only applies that decision.
+    network_data_excluded = exclude_bridges_from_outage_masks(network_data_filled)
+    network_data = convert_multi_outages(network_data_excluded)
+    assert network_data.multi_outage_branch_mask.shape == network_data_excluded.multi_outage_branch_mask.shape
+    assert np.sum(network_data.multi_outage_branch_mask) == np.sum(network_data_excluded.multi_outage_branch_mask)
+
+    # The oberrhein fixture only has trafo3w groups, which island their star node and therefore each
+    # need exactly one leg spared.
+    assert np.all(np.sum(network_data.multi_outage_spared_branch_mask, axis=1) == 1)
 
     index = 0
     for branch_indices in network_data.split_multi_outage_branches:
         assert not np.any(branch_indices == -1)
         for outage in branch_indices:
             assert np.all(network_data.multi_outage_branch_mask[index, outage])
-            assert np.sum(network_data.multi_outage_branch_mask[index]) == outage.shape[0] + 1
-            index += 1
-
-    index = 0
-    for node_indices in network_data.split_multi_outage_nodes:
-        for outage in node_indices:
-            assert np.all(network_data.multi_outage_node_mask[index, outage[outage != -1]])
-            assert np.sum(network_data.multi_outage_node_mask[index]) == np.sum(outage != -1)
+            # The group is still declared in full; only the spared branches are left uncomputed.
+            assert np.sum(network_data.multi_outage_branch_mask[index]) == outage.shape[0] + np.sum(
+                network_data.multi_outage_spared_branch_mask[index]
+            )
             index += 1
 
 
@@ -1075,54 +1113,31 @@ def test_filter_inactive_injections(network_data_filled: NetworkData) -> None:
 
 
 def test_convert_multi_outages_no_outages(network_data_filled: NetworkData) -> None:
+    # An all-false mask and a mask with no rows at all both mean "nothing to compute".
     network_data = replace(
         network_data_filled,
         multi_outage_branch_mask=np.zeros_like(network_data_filled.multi_outage_branch_mask),
-        multi_outage_node_mask=np.zeros_like(network_data_filled.multi_outage_node_mask),
     )
-
     assert network_data.split_multi_outage_branches is None
-    assert network_data.split_multi_outage_nodes is None
 
     network_data = convert_multi_outages(network_data)
     assert network_data.split_multi_outage_branches == []
-    assert network_data.split_multi_outage_nodes == []
 
-    # Should be the same as with size zero
     network_data = replace(
         network_data_filled,
         multi_outage_branch_mask=np.zeros((0, network_data_filled.multi_outage_branch_mask.shape[1]), dtype=bool),
-        multi_outage_node_mask=np.zeros((0, network_data_filled.multi_outage_node_mask.shape[1]), dtype=bool),
+        multi_outage_ids=[],
+        multi_outage_names=[],
+        multi_outage_types=[],
     )
-
     assert network_data.split_multi_outage_branches is None
-    assert network_data.split_multi_outage_nodes is None
 
     network_data = convert_multi_outages(network_data)
     assert network_data.split_multi_outage_branches == []
-    assert network_data.split_multi_outage_nodes == []
 
-    # When we leave the nodes in place, we should get one empty branch outage
-    network_data = replace(
-        network_data_filled,
-        multi_outage_branch_mask=np.zeros_like(network_data_filled.multi_outage_branch_mask),
-    )
-
-    network_data = convert_multi_outages(network_data)
+    # A populated mask yields one batch per distinct number of outaged branches.
+    network_data = convert_multi_outages(network_data_filled)
     assert len(network_data.split_multi_outage_branches) == 1
-    assert network_data.split_multi_outage_branches[0].size == 0
-    assert network_data.split_multi_outage_branches[0].shape[0] == network_data.split_multi_outage_nodes[0].shape[0]
-    assert network_data.split_multi_outage_nodes[0].size > 0
-
-    # When we leave the branches in place, we should get one empty node outage
-    network_data = replace(
-        network_data_filled,
-        multi_outage_node_mask=np.zeros_like(network_data_filled.multi_outage_node_mask),
-    )
-    network_data = convert_multi_outages(network_data)
-    assert len(network_data.split_multi_outage_nodes) == len(network_data.split_multi_outage_branches)
-    assert network_data.split_multi_outage_nodes[0].size == 0
-    assert network_data.split_multi_outage_nodes[0].shape[0] == network_data.split_multi_outage_branches[0].shape[0]
     assert network_data.split_multi_outage_branches[0].size > 0
 
 
@@ -1336,7 +1351,6 @@ def test_reduce_node_dimension(network_data_filled):
     # Check for consistent shapes
     assert network_data_reduced.ptdf.shape[1] == network_data_reduced.relevant_node_mask.shape[0]
     assert network_data_reduced.ptdf.shape[1] == network_data_reduced.nodal_injection.shape[1]
-    assert network_data_reduced.ptdf.shape[1] == network_data_reduced.multi_outage_node_mask.shape[1]
     assert network_data_reduced.ptdf.shape[1] == len(network_data_reduced.node_ids)
     assert network_data_reduced.ptdf.shape[1] == len(network_data_reduced.node_names)
     assert network_data_reduced.ptdf.shape[1] == len(network_data_reduced.node_types)
@@ -1376,7 +1390,6 @@ def test_reduce_node_dimension(network_data_filled):
     assert network_data_reduced.node_types[-1] == "REDUCED_NODE"
     assert new_rel_nodes[-1] == False
     assert network_data_reduced.nodal_injection[0, -1] == 1.0
-    assert network_data_reduced.multi_outage_node_mask[:, -1].sum() == 0
     reduced_node_ids = np.array(network_data_reduced.node_ids)
     old_node_ids = np.array(network_data_filled.node_ids)
     matching_ids = reduced_node_ids[network_data_reduced.from_nodes] == old_node_ids[network_data_filled.from_nodes]
@@ -1425,7 +1438,6 @@ def test_reduce_node_dimension_preserves_busbar_outage_station_nodes(network_dat
         monitored_branch_mask=np.array([True, False]),
         outaged_branch_mask=np.array([False, False]),
         multi_outage_branch_mask=np.zeros((0, 2), dtype=bool),
-        multi_outage_node_mask=np.zeros((0, 4), dtype=bool),
         controllable_phase_shift_mask=np.array([False, False]),
         asset_topology=RuntimeAssetTopology(bus_groups=[drop_station]),
         busbar_outage_map={"drop": ["drop_bb"]},
@@ -1443,7 +1455,6 @@ def test_reduce_node_dimension_preserves_busbar_outage_station_nodes(network_dat
     )
     significant_nodes = get_significant_nodes(
         network_data.relevant_node_mask,
-        network_data.multi_outage_node_mask,
         relevant_branches,
         network_data.from_nodes,
         network_data.to_nodes,

--- a/packages/interfaces_pkg/src/toop_engine_interfaces/backend.py
+++ b/packages/interfaces_pkg/src/toop_engine_interfaces/backend.py
@@ -443,30 +443,13 @@ class BackendInterface(ABC):
 
         True means a branch is outaged, False means it is not outaged.
 
-        get_multi_outage_branches, get_multi_outage_nodes and get_multi_outage_names have to return
-        the same first dimension, i.e. the same number of multi-outages.
+        get_multi_outage_branches and get_multi_outage_names have to return the same first
+        dimension, i.e. the same number of multi-outages.
 
         Returns
         -------
         Bool[np.ndarray, " n_multi_outages n_branch"]
             The mask of outaged branches for every multi-outage
-        """
-
-    @abstractmethod
-    def get_multi_outage_nodes(
-        self,
-    ) -> Bool[np.ndarray, " n_multi_outages n_node"]:
-        """Get the mask of outaged nodes for potential multi-outages
-
-        True means a node is outaged, False means it is not outaged.
-
-        get_multi_outage_branches, get_multi_outage_nodes and get_multi_outage_names have to return
-        the same first dimension, i.e. the same number of multi-outages.
-
-        Returns
-        -------
-        Bool[np.ndarray, " n_multi_outages n_node"]
-            The mask of outaged nodes for every multi-outage
         """
 
     @abstractmethod

--- a/packages/interfaces_pkg/tests/test_backend.py
+++ b/packages/interfaces_pkg/tests/test_backend.py
@@ -67,9 +67,6 @@ class TestBackend(BackendInterface):
     ) -> Bool[np.ndarray, " n_multi_outages n_branch"]:
         return np.array([[False, True], [True, False]])
 
-    def get_multi_outage_nodes(self) -> Bool[np.ndarray, " n_multi_outages n_node"]:
-        return np.array([[True, False, True], [False, True, False]])
-
     def get_injection_nodes(self) -> Int[np.ndarray, " n_injection"]:
         return np.array([0, 1])
 
@@ -170,7 +167,6 @@ def test_backend():
     assert backend.get_outaged_branch_mask().shape == (n_branch,)
     assert backend.get_outaged_injection_mask().shape == (2,)
     assert backend.get_multi_outage_branches().shape == (2, n_branch)
-    assert backend.get_multi_outage_nodes().shape == (2, n_bus)
     assert backend.get_injection_nodes().shape == (2,)
     assert backend.get_mw_injections().shape == (2, 2)
     assert backend.get_base_mva() == 100.0


### PR DESCRIPTION
Fixes a multi-outage bug: 
If a multi-outage islands the unsplit grid made the BSDF/LODF action filter reject every split of every substation, because modf_success is joined over all multi-outages and the MODF denominator is singular for any group that islands the base grid. 

1. `exclude_bridges_from_outage_masks` now runs an islanding test over whole multi-outage groups not just single branches: `find_islanding_branch_groups`, 
2. an *imported* group that contains a bridge or is a cut set is dropped whole and reported at warning level, i.e. a contingency is computed as declared or not at all); 
3. a *synthesised* group (trafo3w, bus - one physical element that islands its own star node/busbar) is repaired instead by sparing the minimal set of branches that resolves the islanding: `find_branches_to_spare_from_groups` (TBD). This replaces the previous unconditional "blank the first branch" hack. The gap between a declared and a computed synthesised group is now recorded explicitly in NetworkData.multi_outage_spared_branch_mask.

## Checklist

Please check if the PR fulfills these requirements:

- [x] PR Title follows conventional commit messages
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] All commits in this PR are DCO signed-off (see CONTRIBUTING.md)

## Does this PR already have an issue describing the problem?

Fixes #

## What is the new behavior (if this is a feature change)?

<!-- Describe the new behavior and the motivation/context for the change. -->

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
